### PR TITLE
docs: add missing ENC and NodeClassifier pages to mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Code Deployment: concepts/code-deployment.md
       - Traffic Flow: concepts/traffic-flow.md
       - Gateway API: concepts/gateway-api.md
+      - External Node Classification: concepts/external-node-classification.md
   - Getting Started:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
@@ -70,3 +71,4 @@ nav:
       - Certificate: reference/certificate.md
       - Server: reference/server.md
       - Pool: reference/pool.md
+      - NodeClassifier: reference/nodeclassifier.md


### PR DESCRIPTION
## Summary
- Add `concepts/external-node-classification.md` to the Concepts navigation section
- Add `reference/nodeclassifier.md` to the Reference navigation section

Both pages existed in `docs/` but were not linked in the mkdocs navigation.