### PR TITLE
docs: add missing configRef edges to README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ graph TD
     Cert_Stable --> Stable["⚙️ Server: stable<br/>v8.12.1"]
     Cert_Canary --> Canary["⚙️ Server: canary<br/>v8.13.0"]
 
+    Cfg -->|configRef| CA
+    Cfg -->|configRef| Stable
+    Cfg -->|configRef| Canary
+
     CA --> CA_D["Deployment"]
     Stable --> ST_D["Deployment"]
     Canary --> CN_D["Deployment"]


### PR DESCRIPTION
The architecture diagram in the README showed no relationship between Config and Servers. This adds the configRef arrows to reflect that each Server references its Config.

Minimal change - only 3 lines added to the existing diagram.