### PR TITLE
feat(helm): convert signingPolicy to signingPolicies array

### DIFF
--- a/charts/openvox-stack/ci/multi-server-values.yaml
+++ b/charts/openvox-stack/ci/multi-server-values.yaml
@@ -1,3 +1,7 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
 servers:
   - name: ca
     ca: true

--- a/charts/openvox-stack/ci/single-node-values.yaml
+++ b/charts/openvox-stack/ci/single-node-values.yaml
@@ -1,3 +1,7 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
 servers:
   - name: ca
     ca: true

--- a/charts/openvox-stack/templates/NOTES.txt
+++ b/charts/openvox-stack/templates/NOTES.txt
@@ -10,8 +10,15 @@ Resources created:
 
   Config:               {{ include "openvox-stack.configName" . }}
   CertificateAuthority: {{ include "openvox-stack.caName" . }}
-{{- if .Values.signingPolicy.enabled }}
-  SigningPolicy:        {{ include "openvox-stack.signingPolicyName" . }}
+{{- if .Values.signingPolicies }}
+  SigningPolicies:
+{{- range .Values.signingPolicies }}
+    - {{ .name }}
+{{- end }}
+{{- else }}
+
+  WARNING: No signing policies configured. CSR signing is disabled.
+           To enable, add signingPolicies to your values.yaml.
 {{- end }}
 {{- if .Values.nodeClassifier.enabled }}
   NodeClassifier:       {{ include "openvox-stack.nodeClassifierName" . }}

--- a/charts/openvox-stack/templates/_helpers.tpl
+++ b/charts/openvox-stack/templates/_helpers.tpl
@@ -25,13 +25,14 @@ CertificateAuthority name.
 {{- end }}
 
 {{/*
-SigningPolicy name.
+SigningPolicy name for array entries.
+Usage: include "openvox-stack.signingPolicyName" (dict "root" $ "entry" $entry "index" $i)
 */}}
 {{- define "openvox-stack.signingPolicyName" -}}
-{{- if .Values.signingPolicy.name -}}
-{{- .Values.signingPolicy.name }}
+{{- if .entry.name -}}
+{{- .entry.name }}
 {{- else -}}
-{{- include "openvox-stack.fullname" . }}-autosign
+{{- printf "%s-signing-policy-%d" (include "openvox-stack.fullname" .root) .index | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 

--- a/charts/openvox-stack/templates/signingpolicy.yaml
+++ b/charts/openvox-stack/templates/signingpolicy.yaml
@@ -1,9 +1,41 @@
-{{- if .Values.signingPolicy.enabled }}
+{{- range $i, $entry := .Values.signingPolicies }}
+---
 apiVersion: openvox.voxpupuli.org/v1alpha1
 kind: SigningPolicy
 metadata:
-  name: {{ include "openvox-stack.signingPolicyName" . }}
+  name: {{ include "openvox-stack.signingPolicyName" (dict "root" $ "entry" $entry "index" $i) }}
 spec:
-  certificateAuthorityRef: {{ include "openvox-stack.caName" . }}
-  any: {{ .Values.signingPolicy.any }}
+  certificateAuthorityRef: {{ include "openvox-stack.caName" $ }}
+  {{- if $entry.any }}
+  any: true
+  {{- end }}
+  {{- with $entry.pattern }}
+  pattern:
+    allow:
+      {{- range .allow }}
+      - {{ . | quote }}
+      {{- end }}
+  {{- end }}
+  {{- with $entry.dnsAltNames }}
+  dnsAltNames:
+    allow:
+      {{- range .allow }}
+      - {{ . | quote }}
+      {{- end }}
+  {{- end }}
+  {{- with $entry.csrAttributes }}
+  csrAttributes:
+    {{- range . }}
+    - name: {{ .name }}
+      {{- if .value }}
+      value: {{ .value | quote }}
+      {{- end }}
+      {{- if .valueFrom }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .valueFrom.secretKeyRef.name }}
+          key: {{ .valueFrom.secretKeyRef.key }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -26,10 +26,14 @@ ca:
     size: 1Gi
     storageClass: ""
 
-signingPolicy:
-  enabled: true
-  name: ""             # default: {fullname}-autosign
-  any: true
+signingPolicies: []
+# signingPolicies:
+#   - name: autosign-any
+#     any: true
+#   - name: preshared-key
+#     csrAttributes:
+#       - name: pp_preshared_key
+#         value: "my-secret-token"
 
 nodeClassifier:
   enabled: false

--- a/cmd/autosign/policy_test.go
+++ b/cmd/autosign/policy_test.go
@@ -203,7 +203,7 @@ func TestEvaluatePolicy_CSRAttributes(t *testing.T) {
 	csr := generateCSR(t, "node1", nil, []pkix.Extension{ext})
 
 	policy := Policy{
-		Name: "env-check",
+		Name:    "env-check",
 		Pattern: &PatternConf{Allow: []string{"*"}},
 		CSRAttributes: []CSRAttributeConf{
 			{Name: "pp_environment", Value: "production"},
@@ -224,7 +224,7 @@ func TestEvaluatePolicy_CSRAttributeNotPresent(t *testing.T) {
 	csr := generateCSR(t, "node1", nil, nil)
 
 	policy := Policy{
-		Name: "env-check",
+		Name:    "env-check",
 		Pattern: &PatternConf{Allow: []string{"*"}},
 		CSRAttributes: []CSRAttributeConf{
 			{Name: "pp_environment", Value: "production"},


### PR DESCRIPTION
## Summary

- Replace singular `signingPolicy` object with `signingPolicies` array to support multiple signing policies per CA
- Default is now an empty list — no autosign out of the box (previously `any: true` signed all CSRs unconditionally)
- Template now renders all CRD-supported fields: `any`, `pattern`, `dnsAltNames`, and `csrAttributes` (with `valueFrom`/`secretKeyRef` support)
- NOTES.txt shows configured policies or a warning when none are set
- CI values updated with explicit `signingPolicies` entry

## Test plan

- [ ] `helm lint charts/openvox-stack` — default values (empty list)
- [ ] `helm template test charts/openvox-stack` — no SigningPolicy rendered
- [ ] `helm template test charts/openvox-stack --set 'signingPolicies[0].any=true'` — any-mode works
- [ ] `helm template test charts/openvox-stack -f charts/openvox-stack/ci/single-node-values.yaml` — CI values
- [ ] `helm lint charts/openvox-stack -f charts/openvox-stack/ci/multi-server-values.yaml` — multi-server