### PR TITLE
feat: extend CertificateAuthority CRD with additional CA settings

### DIFF
--- a/api/v1alpha1/certificateauthority_types.go
+++ b/api/v1alpha1/certificateauthority_types.go
@@ -44,6 +44,28 @@ type CertificateAuthoritySpec struct {
 	// +optional
 	AllowSubjectAltNames bool `json:"allowSubjectAltNames,omitempty"`
 
+	// AllowAuthorizationExtensions controls whether authorization extensions
+	// (pp_role, pp_environment, etc.) are allowed in CSRs.
+	// +kubebuilder:default=true
+	// +optional
+	AllowAuthorizationExtensions bool `json:"allowAuthorizationExtensions,omitempty"`
+
+	// EnableInfraCRL enables infrastructure CRL for compile server revocation.
+	// +kubebuilder:default=true
+	// +optional
+	EnableInfraCRL bool `json:"enableInfraCRL,omitempty"`
+
+	// AllowAutoRenewal allows agents to automatically renew certificates before expiry.
+	// +kubebuilder:default=true
+	// +optional
+	AllowAutoRenewal bool `json:"allowAutoRenewal,omitempty"`
+
+	// AutoRenewalCertTTL is the TTL threshold for automatic certificate renewal.
+	// Uses duration format: "90d", "30d", "2160h".
+	// +kubebuilder:default="90d"
+	// +optional
+	AutoRenewalCertTTL string `json:"autoRenewalCertTTL,omitempty"`
+
 	// Storage defines the PVC settings for CA data.
 	// +optional
 	Storage StorageSpec `json:"storage,omitempty"`

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: certificateauthorities.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org
@@ -50,11 +50,28 @@ spec:
           spec:
             description: CertificateAuthoritySpec defines the desired state of CertificateAuthority.
             properties:
+              allowAuthorizationExtensions:
+                default: true
+                description: |-
+                  AllowAuthorizationExtensions controls whether authorization extensions
+                  (pp_role, pp_environment, etc.) are allowed in CSRs.
+                type: boolean
+              allowAutoRenewal:
+                default: true
+                description: AllowAutoRenewal allows agents to automatically renew
+                  certificates before expiry.
+                type: boolean
               allowSubjectAltNames:
                 default: true
                 description: AllowSubjectAltNames controls whether SANs are allowed
                   in CSRs.
                 type: boolean
+              autoRenewalCertTTL:
+                default: 90d
+                description: |-
+                  AutoRenewalCertTTL is the TTL threshold for automatic certificate renewal.
+                  Uses duration format: "90d", "30d", "2160h".
+                type: string
               crlRefreshInterval:
                 default: 5m
                 description: |-
@@ -62,6 +79,11 @@ spec:
                   and updates the CRL Secret. Only applies to non-CA servers.
                   Uses Go duration format: "5m", "1h", "30s".
                 type: string
+              enableInfraCRL:
+                default: true
+                description: EnableInfraCRL enables infrastructure CRL for compile
+                  server revocation.
+                type: boolean
               intermediateCA:
                 description: IntermediateCA configures an intermediate CA setup.
                 properties:

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: certificates.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: configs.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_nodeclassifiers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_nodeclassifiers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: nodeclassifiers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_pools.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_pools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: pools.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: servers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_signingpolicies.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_signingpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: signingpolicies.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: certificateauthorities.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org
@@ -50,11 +50,28 @@ spec:
           spec:
             description: CertificateAuthoritySpec defines the desired state of CertificateAuthority.
             properties:
+              allowAuthorizationExtensions:
+                default: true
+                description: |-
+                  AllowAuthorizationExtensions controls whether authorization extensions
+                  (pp_role, pp_environment, etc.) are allowed in CSRs.
+                type: boolean
+              allowAutoRenewal:
+                default: true
+                description: AllowAutoRenewal allows agents to automatically renew
+                  certificates before expiry.
+                type: boolean
               allowSubjectAltNames:
                 default: true
                 description: AllowSubjectAltNames controls whether SANs are allowed
                   in CSRs.
                 type: boolean
+              autoRenewalCertTTL:
+                default: 90d
+                description: |-
+                  AutoRenewalCertTTL is the TTL threshold for automatic certificate renewal.
+                  Uses duration format: "90d", "30d", "2160h".
+                type: string
               crlRefreshInterval:
                 default: 5m
                 description: |-
@@ -62,6 +79,11 @@ spec:
                   and updates the CRL Secret. Only applies to non-CA servers.
                   Uses Go duration format: "5m", "1h", "30s".
                 type: string
+              enableInfraCRL:
+                default: true
+                description: EnableInfraCRL enables infrastructure CRL for compile
+                  server revocation.
+                type: boolean
               intermediateCA:
                 description: IntermediateCA configures an intermediate CA setup.
                 properties:

--- a/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: certificates.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: configs.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_nodeclassifiers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_nodeclassifiers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: nodeclassifiers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_pools.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_pools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: pools.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: servers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_signingpolicies.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_signingpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: signingpolicies.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/samples/certificateauthority.yaml
+++ b/config/samples/certificateauthority.yaml
@@ -4,5 +4,10 @@ metadata:
   name: production-ca
 spec:
   ttl: 5y
+  allowSubjectAltNames: true
+  allowAuthorizationExtensions: true
+  enableInfraCRL: true
+  allowAutoRenewal: true
+  autoRenewalCertTTL: 90d
   storage:
     size: 1Gi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slauger/openvox-operator
 
-go 1.26
+go 1.25.0
 
 require (
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -1030,10 +1030,30 @@ func (r *ConfigReconciler) renderMetricsConf(cfg *openvoxv1alpha1.Config) string
 
 func (r *ConfigReconciler) renderCAConf(ca *openvoxv1alpha1.CertificateAuthority) string {
 	allowSANs := true
+	allowAuthzExt := true
+	enableInfraCRL := true
+	allowAutoRenewal := true
+	autoRenewalCertTTL := "90d"
+
 	if ca != nil {
 		allowSANs = ca.Spec.AllowSubjectAltNames
+		allowAuthzExt = ca.Spec.AllowAuthorizationExtensions
+		enableInfraCRL = ca.Spec.EnableInfraCRL
+		allowAutoRenewal = ca.Spec.AllowAutoRenewal
+		if ca.Spec.AutoRenewalCertTTL != "" {
+			autoRenewalCertTTL = ca.Spec.AutoRenewalCertTTL
+		}
 	}
-	return fmt.Sprintf("certificate-authority: {\n    allow-subject-alt-names: %t\n}\n", allowSANs)
+
+	var sb strings.Builder
+	sb.WriteString("certificate-authority: {\n")
+	fmt.Fprintf(&sb, "    allow-subject-alt-names: %t\n", allowSANs)
+	fmt.Fprintf(&sb, "    allow-authorization-extensions: %t\n", allowAuthzExt)
+	fmt.Fprintf(&sb, "    enable-infra-crl: %t\n", enableInfraCRL)
+	fmt.Fprintf(&sb, "    allow-auto-renewal: %t\n", allowAutoRenewal)
+	fmt.Fprintf(&sb, "    auto-renewal-cert-ttl: %s\n", autoRenewalCertTTL)
+	sb.WriteString("}\n")
+	return sb.String()
 }
 
 // --- Autosign Policy ---


### PR DESCRIPTION
## Summary

Extends the `CertificateAuthority` CRD with additional certificate-authority settings that map to the OpenVox Server `ca.conf` configuration.

Fixes #12

## Changes

### New fields in `CertificateAuthoritySpec`

| Field | Type | Default | ca.conf equivalent | Description |
|---|---|---|---|---|
| `allowAuthorizationExtensions` | bool | `true` | `allow-authorization-extensions` | Allow authorization extensions in CSRs (pp_role, pp_environment, etc.) |
| `enableInfraCRL` | bool | `true` | `enable-infra-crl` | Enable infrastructure CRL for compile server revocation |
| `allowAutoRenewal` | bool | `true` | `allow-auto-renewal` | Allow agents to automatically renew certificates before expiry |
| `autoRenewalCertTTL` | string | `90d` | `auto-renewal-cert-ttl` | TTL threshold for automatic certificate renewal |

### Updated `renderCAConf()`

All four new fields are rendered into `ca.conf` alongside the existing `allow-subject-alt-names`.

### CRD Manifests

Regenerated via `make manifests` (controller-gen v0.20.1, Go 1.25.7).

## Example

```yaml
apiVersion: openvox.voxpupuli.org/v1alpha1
kind: CertificateAuthority
metadata:
  name: production-ca
spec:
  ttl: 5y
  allowSubjectAltNames: true
  allowAuthorizationExtensions: true
  enableInfraCRL: true
  allowAutoRenewal: true
  autoRenewalCertTTL: 90d
  storage:
    size: 1Gi
```