### PR TITLE
feat: security hardening for operator and managed workloads

### DIFF
--- a/charts/openvox-operator/templates/deployment.yaml
+++ b/charts/openvox-operator/templates/deployment.yaml
@@ -26,6 +26,8 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           {{- if .Values.image.digest }}

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -574,6 +574,9 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 						RunAsUser:    int64Ptr(1001),
 						RunAsGroup:   int64Ptr(0),
 						RunAsNonRoot: boolPtr(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -586,6 +589,12 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 								{Name: "ca-data", MountPath: "/etc/puppetlabs/puppetserver/ca"},
 								{Name: "ssl", MountPath: "/etc/puppetlabs/puppet/ssl"},
 								{Name: "puppet-conf", MountPath: "/etc/puppetlabs/puppet/puppet.conf", SubPath: "puppet.conf", ReadOnly: true},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: boolPtr(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
 							},
 						},
 					},

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -392,12 +392,28 @@ chmod 640 /ssl/private_keys/puppet.pem`
 		},
 	}
 
+	readOnlyRootFilesystem := false
+	containerSecurityContext := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: boolPtr(false),
+		ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+	container.SecurityContext = containerSecurityContext
+	initContainer.SecurityContext = containerSecurityContext
+
+	automountServiceAccountToken := false
 	podSpec := corev1.PodSpec{
-		ServiceAccountName: fmt.Sprintf("%s-server", server.Spec.ConfigRef),
+		ServiceAccountName:           fmt.Sprintf("%s-server", server.Spec.ConfigRef),
+		AutomountServiceAccountToken: &automountServiceAccountToken,
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsUser:    int64Ptr(1001),
 			RunAsGroup:   int64Ptr(0),
 			RunAsNonRoot: boolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		},
 		InitContainers: []corev1.Container{initContainer},
 		Containers:     []corev1.Container{container},


### PR DESCRIPTION
## Summary

Implements the high-impact, low-effort security hardening from #35.

## Changes

### Operator Pod (Helm Chart)
- Added `seccompProfile: RuntimeDefault` to pod security context

### Server Pods (ServerReconciler)
- Added `seccompProfile: RuntimeDefault` to pod security context
- Added container security context:
  - `allowPrivilegeEscalation: false`
  - `capabilities.drop: [ALL]`
  - `readOnlyRootFilesystem: false` (placeholder — emptyDir volumes needed first)
- Added `automountServiceAccountToken: false` (server pods don't need K8s API access)

### CA Setup Job (CertificateAuthorityReconciler)  
- Added `seccompProfile: RuntimeDefault` to pod security context
- Added container security context:
  - `allowPrivilegeEscalation: false`
  - `capabilities.drop: [ALL]`
- Note: `automountServiceAccountToken` kept enabled (Job needs it for Secret creation)

## Out of Scope (separate issues)
- `readOnlyRootFilesystem: true` — requires emptyDir volume analysis first
- Image signing: #45
- RBAC audit: #46

## Testing
All existing tests pass locally with Go 1.26.