### PR TITLE
fix: pin r10k version via Gemfile

### DIFF
--- a/images/openvox-code/Containerfile
+++ b/images/openvox-code/Containerfile
@@ -12,8 +12,10 @@ FROM registry.access.redhat.com/ubi9/ubi:9.7-1773204657 AS builder
 
 RUN dnf module enable ruby:3.3 -y \
     && dnf install -y --setopt=install_weak_deps=False ruby ruby-devel rubygem-bundler git gcc make redhat-rpm-config \
-    && dnf clean all \
-    && gem install r10k --no-document
+    && dnf clean all
+
+COPY images/openvox-code/Gemfile /tmp/Gemfile
+RUN cd /tmp && bundle install --jobs=4
 
 WORKDIR /code/environments
 COPY images/openvox-code/environments/production/Puppetfile /code/environments/production/Puppetfile

--- a/images/openvox-code/Gemfile
+++ b/images/openvox-code/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'r10k', '~> 5.0'


### PR DESCRIPTION
## Summary

- Replace `gem install r10k` with a Gemfile + `bundle install` to pin r10k to `~> 5.0`
- Fixes hadolint DL3028 (pin versions in gem install)

## Test plan

- [ ] CI hadolint check passes for `images/openvox-code/Containerfile`
- [ ] `docker build -f images/openvox-code/Containerfile .` succeeds