### PR TITLE
fix: add libffi-devel for fiddle gem in openvox-code image

### DIFF
--- a/images/openvox-code/Containerfile
+++ b/images/openvox-code/Containerfile
@@ -11,7 +11,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1773204657 AS builder
 
 RUN dnf module enable ruby:3.3 -y \
-    && dnf install -y --setopt=install_weak_deps=False ruby ruby-devel rubygem-bundler git gcc make redhat-rpm-config \
+    && dnf install -y --setopt=install_weak_deps=False ruby ruby-devel rubygem-bundler git gcc make redhat-rpm-config libffi-devel \
     && dnf clean all
 
 COPY images/openvox-code/Gemfile /tmp/Gemfile


### PR DESCRIPTION
## Summary

- Add `libffi-devel` to openvox-code builder stage -- required by the `fiddle` gem (transitive dependency of r10k via gettext/locale)

## Test plan

- [ ] CI container build for openvox-code succeeds