### PR TITLE
chore: rename test images workflow to CI (Test Images)

### DIFF
--- a/.github/workflows/ci-test-images.yaml
+++ b/.github/workflows/ci-test-images.yaml
@@ -1,4 +1,4 @@
-name: Container Build (Test Images)
+name: CI (Test Images)
 
 on:
   push:


### PR DESCRIPTION
## Summary

- Rename workflow from "Container Build (Test Images)" to "CI (Test Images)" for consistency