### PR TITLE
feat: configurable E2E image tags, RBAC and logging fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,10 @@ ci: lint vet test check-manifests vulncheck helm-lint ## Run all CI checks local
 IMAGE_REGISTRY ?= ghcr.io/slauger
 IMAGE_TAG ?= $(LOCAL_TAG)
 
-.PHONY: e2e
-e2e: ## Run E2E tests against the current cluster (images must exist in registry).
+E2E_CHAINSAW = IMAGE_TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) $(CHAINSAW) test --config tests/e2e/chainsaw-config.yaml
+
+.PHONY: e2e-operator
+e2e-operator: ## Deploy operator for E2E tests.
 	helm upgrade --install openvox-operator charts/openvox-operator \
 		--namespace $(NAMESPACE) --create-namespace \
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
@@ -168,7 +170,22 @@ e2e: ## Run E2E tests against the current cluster (images must exist in registry
 		--set image.pullPolicy=Always
 	kubectl wait --for=condition=Available deployment/openvox-operator \
 		-n $(NAMESPACE) --timeout=2m
-	IMAGE_TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) $(CHAINSAW) test tests/e2e/
+
+.PHONY: e2e
+e2e: e2e-operator ## Run all E2E tests.
+	$(E2E_CHAINSAW) tests/e2e/
+
+.PHONY: e2e-stack
+e2e-stack: e2e-operator ## Run stack deployment tests (single-node, multi-server).
+	$(E2E_CHAINSAW) tests/e2e/single-node tests/e2e/multi-server
+
+.PHONY: e2e-agent
+e2e-agent: e2e-operator ## Run agent tests (basic, broken, idempotent, concurrent).
+	$(E2E_CHAINSAW) tests/e2e/agent-basic tests/e2e/agent-broken tests/e2e/agent-idempotent tests/e2e/agent-concurrent
+
+.PHONY: e2e-integration
+e2e-integration: e2e-operator ## Run integration tests (enc, report, full).
+	$(E2E_CHAINSAW) tests/e2e/agent-enc tests/e2e/agent-report tests/e2e/agent-full
 
 ##@ Help
 

--- a/Makefile
+++ b/Makefile
@@ -156,18 +156,19 @@ ci: lint vet test check-manifests vulncheck helm-lint ## Run all CI checks local
 
 ##@ E2E
 
-E2E_REGISTRY ?= ghcr.io/slauger
+IMAGE_REGISTRY ?= ghcr.io/slauger
+IMAGE_TAG ?= $(LOCAL_TAG)
 
 .PHONY: e2e
 e2e: ## Run E2E tests against the current cluster (images must exist in registry).
 	helm upgrade --install openvox-operator charts/openvox-operator \
 		--namespace $(NAMESPACE) --create-namespace \
-		--set image.repository=$(E2E_REGISTRY)/openvox-operator \
-		--set image.tag=$(LOCAL_TAG) \
+		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
+		--set image.tag=$(IMAGE_TAG) \
 		--set image.pullPolicy=Always
 	kubectl wait --for=condition=Available deployment/openvox-operator \
 		-n $(NAMESPACE) --timeout=2m
-	$(CHAINSAW) test tests/e2e/
+	IMAGE_TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) $(CHAINSAW) test tests/e2e/
 
 ##@ Help
 

--- a/charts/openvox-operator/templates/clusterrole.yaml
+++ b/charts/openvox-operator/templates/clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["tlsroutes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
+  - apiGroups: ["", "events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: ["coordination.k8s.io"]

--- a/charts/openvox-stack/templates/nodeclassifier.yaml
+++ b/charts/openvox-stack/templates/nodeclassifier.yaml
@@ -17,6 +17,7 @@ spec:
   timeoutSeconds: {{ . }}
   {{- end }}
   {{- with .Values.nodeClassifier.auth }}
+  {{- if or .mtls .token .bearer .basic }}
   auth:
     {{- if .mtls }}
     mtls: true
@@ -45,6 +46,7 @@ spec:
         passwordKey: {{ . }}
         {{- end }}
     {{- end }}
+  {{- end }}
   {{- end }}
   {{- if .Values.nodeClassifier.cache.enabled }}
   cache:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,7 +42,7 @@ rules:
     resources: ["tlsroutes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Events
-  - apiGroups: [""]
+  - apiGroups: ["", "events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]
   # Leader election

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -64,7 +64,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: cert.Namespace}, ca); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Error(err, "referenced CertificateAuthority not found", "authorityRef", cert.Spec.AuthorityRef)
+			logger.Info("waiting for CertificateAuthority", "authorityRef", cert.Spec.AuthorityRef)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -135,7 +135,7 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 
 	result, err := r.signCertificate(ctx, cert, ca, caServiceName, cert.Namespace)
 	if err != nil {
-		logger.Error(err, "certificate signing failed")
+		logger.Info("certificate signing failed, will retry", "error", err)
 		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseError
 		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
 			Type:               openvoxv1alpha1.ConditionCertSigned,

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -129,7 +129,7 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 	// Periodic CRL refresh: fetch CRL from CA service and update the CRL secret
 	crlResult, err := r.reconcileCRLRefresh(ctx, ca)
 	if err != nil {
-		logger.Error(err, "CRL refresh failed, will retry")
+		logger.Info("CRL refresh failed, will retry", "error", err)
 		r.Recorder.Eventf(ca, nil, corev1.EventTypeWarning, EventReasonCRLRefreshFailed, "Reconcile", "CRL refresh failed: %v", err)
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -74,7 +74,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	cfg := &openvoxv1alpha1.Config{}
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.ConfigRef, Namespace: server.Namespace}, cfg); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Error(err, "referenced Config not found", "configRef", server.Spec.ConfigRef)
+			logger.Info("waiting for Config", "configRef", server.Spec.ConfigRef)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -84,7 +84,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	cert := &openvoxv1alpha1.Certificate{}
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.CertificateRef, Namespace: server.Namespace}, cert); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Error(err, "referenced Certificate not found", "certificateRef", server.Spec.CertificateRef)
+			logger.Info("waiting for Certificate", "certificateRef", server.Spec.CertificateRef)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -103,7 +103,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: server.Namespace}, ca); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Error(err, "referenced CertificateAuthority not found", "authorityRef", cert.Spec.AuthorityRef)
+			logger.Info("waiting for CertificateAuthority", "authorityRef", cert.Spec.AuthorityRef)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err

--- a/tests/e2e/agent-basic/chainsaw-test.yaml
+++ b/tests/e2e/agent-basic/chainsaw-test.yaml
@@ -4,6 +4,11 @@ metadata:
   name: agent-basic
 spec:
   namespace: e2e-agent-basic
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
   steps:
     - name: Install openvox-stack
       try:
@@ -11,13 +16,15 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install e2e-agent-basic "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-basic --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-code:${IMAGE_TAG}
       catch:
         - events: {}
 
@@ -61,7 +68,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-broken/chainsaw-test.yaml
+++ b/tests/e2e/agent-broken/chainsaw-test.yaml
@@ -4,6 +4,11 @@ metadata:
   name: agent-broken
 spec:
   namespace: e2e-agent-broken
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
   steps:
     - name: Install openvox-stack
       try:
@@ -11,13 +16,15 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install e2e-agent-broken "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-broken --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-code:${IMAGE_TAG}
       catch:
         - events: {}
 
@@ -50,7 +57,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-concurrent/chainsaw-test.yaml
+++ b/tests/e2e/agent-concurrent/chainsaw-test.yaml
@@ -4,6 +4,11 @@ metadata:
   name: agent-concurrent
 spec:
   namespace: e2e-agent-concurrent
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
   steps:
     - name: Install openvox-stack
       try:
@@ -11,13 +16,15 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install e2e-agent-concurrent "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-concurrent --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-code:${IMAGE_TAG}
       catch:
         - events: {}
 
@@ -50,7 +57,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:
@@ -77,7 +84,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:
@@ -104,7 +111,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-enc/chainsaw-test.yaml
+++ b/tests/e2e/agent-enc/chainsaw-test.yaml
@@ -4,6 +4,11 @@ metadata:
   name: agent-enc
 spec:
   namespace: e2e-agent-enc
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
   steps:
     - name: Deploy mock server
       try:
@@ -26,7 +31,7 @@ spec:
                   spec:
                     containers:
                       - name: mock
-                        image: ghcr.io/slauger/openvox-mock:latest
+                        image: (join('', [$registry, '/openvox-mock:', $imageTag]))
                         imagePullPolicy: Always
                         ports:
                           - containerPort: 8080
@@ -63,13 +68,15 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install e2e-agent-enc "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-enc --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-enc-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-code:${IMAGE_TAG}
       catch:
         - events: {}
 
@@ -102,7 +109,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-full/chainsaw-test.yaml
+++ b/tests/e2e/agent-full/chainsaw-test.yaml
@@ -4,6 +4,11 @@ metadata:
   name: agent-full
 spec:
   namespace: e2e-agent-full
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
   steps:
     - name: Deploy mock server
       try:
@@ -26,7 +31,7 @@ spec:
                   spec:
                     containers:
                       - name: mock
-                        image: ghcr.io/slauger/openvox-mock:latest
+                        image: (join('', [$registry, '/openvox-mock:', $imageTag]))
                         imagePullPolicy: Always
                         ports:
                           - containerPort: 8080
@@ -63,13 +68,15 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install e2e-agent-full "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-full --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-full-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-code:${IMAGE_TAG}
       catch:
         - events: {}
 
@@ -102,7 +109,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-idempotent/chainsaw-test.yaml
+++ b/tests/e2e/agent-idempotent/chainsaw-test.yaml
@@ -4,6 +4,11 @@ metadata:
   name: agent-idempotent
 spec:
   namespace: e2e-agent-idempotent
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
   steps:
     - name: Install openvox-stack
       try:
@@ -11,13 +16,15 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install e2e-agent-idempotent "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-idempotent --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-code:${IMAGE_TAG}
       catch:
         - events: {}
 
@@ -50,7 +57,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:
@@ -92,7 +99,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-report/chainsaw-test.yaml
+++ b/tests/e2e/agent-report/chainsaw-test.yaml
@@ -4,6 +4,11 @@ metadata:
   name: agent-report
 spec:
   namespace: e2e-agent-report
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
   steps:
     - name: Deploy mock server
       try:
@@ -26,7 +31,7 @@ spec:
                   spec:
                     containers:
                       - name: mock
-                        image: ghcr.io/slauger/openvox-mock:latest
+                        image: (join('', [$registry, '/openvox-mock:', $imageTag]))
                         imagePullPolicy: Always
                         ports:
                           - containerPort: 8080
@@ -60,13 +65,15 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install e2e-agent-report "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-report --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-report-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-code:${IMAGE_TAG}
       catch:
         - events: {}
 
@@ -99,7 +106,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: ghcr.io/slauger/openvox-agent:latest
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/multi-server/chainsaw-test.yaml
+++ b/tests/e2e/multi-server/chainsaw-test.yaml
@@ -11,12 +11,13 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install openvox-stack-multi "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-multi-server --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/multi-server-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always
       catch:
         - events: {}

--- a/tests/e2e/single-node/chainsaw-test.yaml
+++ b/tests/e2e/single-node/chainsaw-test.yaml
@@ -11,12 +11,13 @@ spec:
             timeout: 2m
             content: |
               REPO_ROOT=$(git rev-parse --show-toplevel)
-              LOCAL_TAG=$(git describe --always)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
               helm upgrade --install openvox-stack-single "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-single-node --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/single-node-values.yaml" \
-                --set config.image.repository=ghcr.io/slauger/openvox-server \
-                --set config.image.tag="${LOCAL_TAG}" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always
       catch:
         - events: {}


### PR DESCRIPTION
## Summary

- Make E2E image tag and registry configurable via `IMAGE_TAG` and `IMAGE_REGISTRY` env vars, allowing `make e2e IMAGE_TAG=latest` to control all images (operator, server, code, agent, mock)
- Split E2E into separate Makefile targets: `e2e-stack`, `e2e-agent`, `e2e-integration`
- Fix chainsaw config not being loaded (missing `--config` flag)
- Add `events.k8s.io` API group to ClusterRole RBAC so the operator can record events in all namespaces
- Fix NodeClassifier Helm template rendering `auth: null` when no auth method is configured
- Reduce transient startup log messages (dependency not found, CRL refresh, cert signing) from error to info level

## Test plan

- [ ] `make e2e-stack IMAGE_TAG=latest` passes (single-node, multi-server)
- [ ] `make e2e-agent IMAGE_TAG=latest` passes (basic, broken, idempotent, concurrent)
- [ ] `make e2e-integration IMAGE_TAG=latest` passes (enc, report, full)
- [ ] Operator logs show no error-level entries during normal stack lifecycle
- [ ] `make ci` passes