### PR TITLE
feat: enable readOnlyRootFilesystem with emptyDir volumes (fixes #48)

### DIFF
--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -605,9 +605,12 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 								{Name: "ca-data", MountPath: "/etc/puppetlabs/puppetserver/ca"},
 								{Name: "ssl", MountPath: "/etc/puppetlabs/puppet/ssl"},
 								{Name: "puppet-conf", MountPath: "/etc/puppetlabs/puppet/puppet.conf", SubPath: "puppet.conf", ReadOnly: true},
+								{Name: "tmp", MountPath: "/tmp"},
+								{Name: "puppetserver-data", MountPath: "/opt/puppetlabs/server/data/puppetserver"},
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: boolPtr(false),
+								ReadOnlyRootFilesystem:   boolPtr(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -624,6 +627,8 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 							},
 						},
 						{Name: "ssl", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "puppetserver-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 						{
 							Name: "puppet-conf",
 							VolumeSource: corev1.VolumeSource{

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -154,6 +154,10 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 		{Name: "ca-cfg", MountPath: "/etc/puppetlabs/puppetserver/services.d/ca.cfg", SubPath: "ca.cfg", ReadOnly: true},
 		{Name: "logback-xml", MountPath: "/etc/puppetlabs/puppetserver/logback.xml", SubPath: "logback.xml", ReadOnly: true},
 		{Name: "metrics-conf", MountPath: "/etc/puppetlabs/puppetserver/conf.d/metrics.conf", SubPath: "metrics.conf", ReadOnly: true},
+		{Name: "puppetserver-data", MountPath: "/opt/puppetlabs/server/data/puppetserver"},
+		{Name: "tmp", MountPath: "/tmp"},
+		{Name: "var-log", MountPath: "/var/log/puppetlabs"},
+		{Name: "var-run", MountPath: "/var/run"},
 	}
 
 	// SSL: emptyDir populated by init container from secret volumes.
@@ -163,6 +167,10 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 
 	volumes := []corev1.Volume{
 		{Name: "ssl", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "puppetserver-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "var-log", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "var-run", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{
 			Name: "ssl-cert",
 			VolumeSource: corev1.VolumeSource{
@@ -392,7 +400,7 @@ chmod 640 /ssl/private_keys/puppet.pem`
 		},
 	}
 
-	readOnlyRootFilesystem := false
+	readOnlyRootFilesystem := true
 	containerSecurityContext := &corev1.SecurityContext{
 		AllowPrivilegeEscalation: boolPtr(false),
 		ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,


### PR DESCRIPTION
## Summary

Sets `readOnlyRootFilesystem: true` für Server Pods und CA Setup Job, mit emptyDir Volumes für alle benötigten schreibbaren Pfade.

## Changes

### `internal/controller/server_deployment.go`
- `ReadOnlyRootFilesystem: true` für main container und init container
- emptyDir Volumes + Mounts:
  - `/opt/puppetlabs/server/data/puppetserver` — Runtime-Daten, Catalog Cache
  - `/tmp` — JVM Temp-Dateien
  - `/var/log/puppetlabs` — Log-Dateien
  - `/var/run` — PID-Dateien

### `internal/controller/certificateauthority_controller.go`
- `ReadOnlyRootFilesystem: true` für CA Setup Job Container
- emptyDir Volumes + Mounts:
  - `/tmp` — Setup-Script schreibt nach `/tmp/api-response`
  - `/opt/puppetlabs/server/data/puppetserver` — benötigt für `puppetserver ca setup`

## Testing

```
go build ./...  ✅
go test ./...   ✅
```

⚠️ **Needs runtime testing** mit echtem OpenVox Server — falls weitere schreibbare Pfade fehlen, können weitere emptyDir Volumes ergänzt werden.

Fixes #48
Refs #35