### PR TITLE
fix: wire metrics endpoint and disable development logging (fixes #73, fixes #78)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
@@ -39,7 +40,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 
-	opts := zap.Options{Development: true}
+	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -47,6 +48,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "openvox-operator.voxpupuli.org",


### PR DESCRIPTION
## Changes

Two quick fixes from the code audit:

### Fix #73: Metrics endpoint was never served
`ctrl.Options` was missing `Metrics` config despite the `--metrics-bind-address` flag being parsed. Prometheus scraping was silently broken.

### Fix #78: Development logging disabled in production
`zap.Options{Development: true}` was hardcoded. Switched to `false` (production mode).

Fixes #73
Fixes #78