### PR TITLE
fix: enforce TLS 1.2 minimum and log silent watcher errors

### DIFF
--- a/cmd/enc/classifier.go
+++ b/cmd/enc/classifier.go
@@ -235,7 +235,7 @@ func normalizeResponse(body []byte, format string) (string, error) {
 
 // buildHTTPClient creates an http.Client with TLS and timeout configuration.
 func buildHTTPClient(cfg *ENCConfig) (*http.Client, error) {
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	// Load CA certificate for server verification
 	if cfg.SSL.CAFile != "" {

--- a/cmd/report/processor.go
+++ b/cmd/report/processor.go
@@ -139,7 +139,7 @@ func forward(endpoint EndpointConfig, reportJSON []byte) error {
 
 // buildHTTPClient creates an http.Client with TLS and timeout configuration.
 func buildHTTPClient(endpoint EndpointConfig) (*http.Client, error) {
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	// Load CA certificate for server verification
 	if endpoint.SSL.CAFile != "" {

--- a/internal/controller/certificate_watchers.go
+++ b/internal/controller/certificate_watchers.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -36,6 +37,7 @@ func enqueueCertificatesForSecret(c client.Client) handler.EventHandler {
 
 		certList := &openvoxv1alpha1.CertificateList{}
 		if err := c.List(ctx, certList, client.InNamespace(obj.GetNamespace())); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list Certificates in watcher")
 			return nil
 		}
 

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -1267,12 +1267,14 @@ func (r *ConfigReconciler) enqueueConfigsForSigningPolicy(c client.Reader) handl
 		// Find the CA referenced by this SigningPolicy
 		ca := &openvoxv1alpha1.CertificateAuthority{}
 		if err := c.Get(ctx, types.NamespacedName{Name: sp.Spec.CertificateAuthorityRef, Namespace: sp.Namespace}, ca); err != nil {
+			log.FromContext(ctx).Error(err, "failed to get CertificateAuthority in watcher", "name", sp.Spec.CertificateAuthorityRef)
 			return nil
 		}
 
 		// Enqueue all Configs whose authorityRef points to this CA
 		cfgList := &openvoxv1alpha1.ConfigList{}
 		if err := c.List(ctx, cfgList, client.InNamespace(ca.Namespace)); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list Configs in watcher")
 			return nil
 		}
 
@@ -1490,6 +1492,7 @@ func (r *ConfigReconciler) enqueueConfigsForNodeClassifier(c client.Reader) hand
 
 		cfgList := &openvoxv1alpha1.ConfigList{}
 		if err := c.List(ctx, cfgList, client.InNamespace(nc.Namespace)); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list Configs in watcher")
 			return nil
 		}
 

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -128,6 +128,7 @@ func enqueuePoolsForServer(c client.Client) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 		pools := &openvoxv1alpha1.PoolList{}
 		if err := c.List(ctx, pools, client.InNamespace(obj.GetNamespace())); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list Pools in watcher")
 			return nil
 		}
 		var requests []ctrl.Request

--- a/internal/controller/reportprocessor_controller.go
+++ b/internal/controller/reportprocessor_controller.go
@@ -84,6 +84,7 @@ func (r *ReportProcessorReconciler) enqueueReportProcessorsForConfig(c client.Re
 
 		rpList := &openvoxv1alpha1.ReportProcessorList{}
 		if err := c.List(ctx, rpList, client.InNamespace(cfg.Namespace)); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list ReportProcessors in watcher")
 			return nil
 		}
 

--- a/internal/controller/server_watchers.go
+++ b/internal/controller/server_watchers.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -32,6 +33,7 @@ func enqueueServersForSecret(c client.Client) handler.EventHandler {
 		if caName != "" {
 			cfgList := &openvoxv1alpha1.ConfigList{}
 			if err := c.List(ctx, cfgList, client.InNamespace(obj.GetNamespace())); err != nil {
+				log.FromContext(ctx).Error(err, "failed to list Configs in watcher")
 				return nil
 			}
 			var requests []ctrl.Request
@@ -50,6 +52,7 @@ func enqueueServersForSecret(c client.Client) handler.EventHandler {
 func enqueueServersForConfig(c client.Client, ctx context.Context, namespace, cfgName string) []ctrl.Request {
 	serverList := &openvoxv1alpha1.ServerList{}
 	if err := c.List(ctx, serverList, client.InNamespace(namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list Servers in watcher")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Closes #86.

- Set `MinVersion: tls.VersionTLS12` on HTTP clients in `openvox-enc` and `openvox-report` to prevent TLS downgrade attacks
- Add error logging to all controller watcher map functions (`EnqueueRequestsFromMapFunc`) that previously swallowed `List`/`Get` errors silently

## Changed files

- `cmd/enc/classifier.go` — TLS MinVersion
- `cmd/report/processor.go` — TLS MinVersion
- `internal/controller/certificate_watchers.go` — log List error
- `internal/controller/server_watchers.go` — log List errors (2 calls)
- `internal/controller/pool_controller.go` — log List error
- `internal/controller/config_controller.go` — log Get/List errors (3 calls)
- `internal/controller/reportprocessor_controller.go` — log List error

## Test plan

- [ ] `go build ./...` passes
- [ ] Existing unit tests pass
- [ ] Verify TLS 1.2 enforcement in ENC/report HTTP clients
- [ ] Verify watcher errors now appear in operator logs