### PR TITLE
refactor: deduplicate resolveSecretKey into shared helper

### DIFF
--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -1201,7 +1201,7 @@ func (r *ConfigReconciler) renderAutosignPolicyConfig(ctx context.Context, names
 				value := attr.Value
 				if attr.ValueFrom != nil {
 					var err error
-					value, err = r.resolveSecretKey(ctx, namespace,
+					value, err = resolveSecretKey(ctx, r.Client, namespace,
 						attr.ValueFrom.SecretKeyRef.Name, attr.ValueFrom.SecretKeyRef.Key)
 					if err != nil {
 						r.updateSigningPolicyStatus(ctx, &p, err)
@@ -1217,18 +1217,6 @@ func (r *ConfigReconciler) renderAutosignPolicyConfig(ctx context.Context, names
 	return sb.String(), nil
 }
 
-// resolveSecretKey reads a specific key from a Secret.
-func (r *ConfigReconciler) resolveSecretKey(ctx context.Context, namespace, secretName, key string) (string, error) {
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-		return "", fmt.Errorf("getting Secret %s: %w", secretName, err)
-	}
-	val, ok := secret.Data[key]
-	if !ok {
-		return "", fmt.Errorf("key %q not found in Secret %s", key, secretName)
-	}
-	return string(val), nil
-}
 
 // updateSigningPolicyStatus sets the phase and condition on a SigningPolicy.
 func (r *ConfigReconciler) updateSigningPolicyStatus(ctx context.Context, sp *openvoxv1alpha1.SigningPolicy, err error) {
@@ -1408,7 +1396,7 @@ func (r *ConfigReconciler) renderENCConfig(ctx context.Context, cfg *openvoxv1al
 		case nc.Spec.Auth.Token != nil:
 			auth.Type = "token"
 			auth.Header = nc.Spec.Auth.Token.Header
-			token, err := r.resolveSecretKey(ctx, cfg.Namespace,
+			token, err := resolveSecretKey(ctx, r.Client, cfg.Namespace,
 				nc.Spec.Auth.Token.SecretKeyRef.Name, nc.Spec.Auth.Token.SecretKeyRef.Key)
 			if err != nil {
 				return "", fmt.Errorf("resolving token secret: %w", err)
@@ -1416,7 +1404,7 @@ func (r *ConfigReconciler) renderENCConfig(ctx context.Context, cfg *openvoxv1al
 			auth.Token = token
 		case nc.Spec.Auth.Bearer != nil:
 			auth.Type = "bearer"
-			token, err := r.resolveSecretKey(ctx, cfg.Namespace,
+			token, err := resolveSecretKey(ctx, r.Client, cfg.Namespace,
 				nc.Spec.Auth.Bearer.SecretKeyRef.Name, nc.Spec.Auth.Bearer.SecretKeyRef.Key)
 			if err != nil {
 				return "", fmt.Errorf("resolving bearer secret: %w", err)
@@ -1424,12 +1412,12 @@ func (r *ConfigReconciler) renderENCConfig(ctx context.Context, cfg *openvoxv1al
 			auth.Token = token
 		case nc.Spec.Auth.Basic != nil:
 			auth.Type = "basic"
-			username, err := r.resolveSecretKey(ctx, cfg.Namespace,
+			username, err := resolveSecretKey(ctx, r.Client, cfg.Namespace,
 				nc.Spec.Auth.Basic.SecretRef.Name, nc.Spec.Auth.Basic.SecretRef.UsernameKey)
 			if err != nil {
 				return "", fmt.Errorf("resolving basic auth username: %w", err)
 			}
-			password, err := r.resolveSecretKey(ctx, cfg.Namespace,
+			password, err := resolveSecretKey(ctx, r.Client, cfg.Namespace,
 				nc.Spec.Auth.Basic.SecretRef.Name, nc.Spec.Auth.Basic.SecretRef.PasswordKey)
 			if err != nil {
 				return "", fmt.Errorf("resolving basic auth password: %w", err)

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -12,6 +12,19 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+// resolveSecretKey reads a specific key from a Secret.
+func resolveSecretKey(ctx context.Context, reader client.Reader, namespace, secretName, key string) (string, error) {
+	secret := &corev1.Secret{}
+	if err := reader.Get(ctx, client.ObjectKey{Name: secretName, Namespace: namespace}, secret); err != nil {
+		return "", fmt.Errorf("getting Secret %s: %w", secretName, err)
+	}
+	val, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in Secret %s", key, secretName)
+	}
+	return string(val), nil
+}
+
 // configMapVolume creates a Volume from a ConfigMap key where key name == path.
 func configMapVolume(volumeName, cmName, key string) corev1.Volume {
 	return corev1.Volume{

--- a/internal/controller/reportprocessor_controller.go
+++ b/internal/controller/reportprocessor_controller.go
@@ -230,7 +230,7 @@ func (r *ReportProcessorReconciler) renderReportWebhookConfig(ctx context.Contex
 			case rp.Spec.Auth.Token != nil:
 				auth.Type = "token"
 				auth.Header = rp.Spec.Auth.Token.Header
-				token, err := r.resolveSecretKey(ctx, namespace,
+				token, err := resolveSecretKey(ctx, r.Client, namespace,
 					rp.Spec.Auth.Token.SecretKeyRef.Name, rp.Spec.Auth.Token.SecretKeyRef.Key)
 				if err != nil {
 					return "", fmt.Errorf("resolving token secret for %s: %w", rp.Name, err)
@@ -238,7 +238,7 @@ func (r *ReportProcessorReconciler) renderReportWebhookConfig(ctx context.Contex
 				auth.Token = token
 			case rp.Spec.Auth.Bearer != nil:
 				auth.Type = "bearer"
-				token, err := r.resolveSecretKey(ctx, namespace,
+				token, err := resolveSecretKey(ctx, r.Client, namespace,
 					rp.Spec.Auth.Bearer.SecretKeyRef.Name, rp.Spec.Auth.Bearer.SecretKeyRef.Key)
 				if err != nil {
 					return "", fmt.Errorf("resolving bearer secret for %s: %w", rp.Name, err)
@@ -246,12 +246,12 @@ func (r *ReportProcessorReconciler) renderReportWebhookConfig(ctx context.Contex
 				auth.Token = token
 			case rp.Spec.Auth.Basic != nil:
 				auth.Type = "basic"
-				username, err := r.resolveSecretKey(ctx, namespace,
+				username, err := resolveSecretKey(ctx, r.Client, namespace,
 					rp.Spec.Auth.Basic.SecretRef.Name, rp.Spec.Auth.Basic.SecretRef.UsernameKey)
 				if err != nil {
 					return "", fmt.Errorf("resolving basic auth username for %s: %w", rp.Name, err)
 				}
-				password, err := r.resolveSecretKey(ctx, namespace,
+				password, err := resolveSecretKey(ctx, r.Client, namespace,
 					rp.Spec.Auth.Basic.SecretRef.Name, rp.Spec.Auth.Basic.SecretRef.PasswordKey)
 				if err != nil {
 					return "", fmt.Errorf("resolving basic auth password for %s: %w", rp.Name, err)
@@ -268,7 +268,7 @@ func (r *ReportProcessorReconciler) renderReportWebhookConfig(ctx context.Contex
 			if h.ValueFrom != nil {
 				var err error
 				if h.ValueFrom.SecretKeyRef != nil {
-					value, err = r.resolveSecretKey(ctx, namespace,
+					value, err = resolveSecretKey(ctx, r.Client, namespace,
 						h.ValueFrom.SecretKeyRef.Name, h.ValueFrom.SecretKeyRef.Key)
 					if err != nil {
 						return "", fmt.Errorf("resolving header secret for %s: %w", rp.Name, err)
@@ -294,18 +294,6 @@ func (r *ReportProcessorReconciler) renderReportWebhookConfig(ctx context.Contex
 	return string(out), nil
 }
 
-// resolveSecretKey reads a specific key from a Secret.
-func (r *ReportProcessorReconciler) resolveSecretKey(ctx context.Context, namespace, secretName, key string) (string, error) {
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-		return "", fmt.Errorf("getting Secret %s: %w", secretName, err)
-	}
-	val, ok := secret.Data[key]
-	if !ok {
-		return "", fmt.Errorf("key %q not found in Secret %s", key, secretName)
-	}
-	return string(val), nil
-}
 
 // resolveConfigMapKey reads a specific key from a ConfigMap.
 func (r *ReportProcessorReconciler) resolveConfigMapKey(ctx context.Context, namespace, cmName, key string) (string, error) {


### PR DESCRIPTION
## Summary

Closes #84.

- Extracted identical `resolveSecretKey` method from `ConfigReconciler` and `ReportProcessorReconciler` into a package-level function in `helpers.go`
- New signature takes `client.Reader` instead of a receiver, keeping it reusable for any controller

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes