### PR TITLE
fix: collection of bugfixes and HPA implementation (#75 #76 #77 #79 #81 #82 #83)

### DIFF
--- a/cmd/enc/classifier.go
+++ b/cmd/enc/classifier.go
@@ -150,7 +150,7 @@ func classify(cfg *ENCConfig, certname string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return "", fmt.Errorf("reading response: %w", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,8 +59,9 @@ func main() {
 	}
 
 	if err = (&controller.ConfigReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorder("config-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Config")
 		os.Exit(1)

--- a/cmd/report/processor.go
+++ b/cmd/report/processor.go
@@ -125,7 +125,7 @@ func forward(endpoint EndpointConfig, reportJSON []byte) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return fmt.Errorf("reading response: %w", err)
 	}

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -126,7 +126,7 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if resp.StatusCode == http.StatusOK {
 		logger.Info("CSR submitted successfully", "certname", certname)
 	} else if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "already has a requested certificate") {
@@ -161,7 +161,7 @@ func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openv
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 
 	if resp.StatusCode == http.StatusOK && len(body) > 0 {
 		block, _ := pem.Decode(body)

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -240,7 +240,7 @@ func (r *CertificateAuthorityReconciler) fetchCRL(ctx context.Context, caService
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("reading CRL response: %w", err)
 	}

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -27,7 +28,8 @@ import (
 // ConfigReconciler reconciles a Config object.
 type ConfigReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder events.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=configs,verbs=get;list;watch;create;update;patch;delete
@@ -252,8 +254,13 @@ func (r *ConfigReconciler) renderPuppetConf(ctx context.Context, cfg *openvoxv1a
 		fmt.Fprintf(&sb, "external_nodes = %s\n", encBinaryPath)
 	}
 
-	for k, v := range cfg.Spec.Puppet.ExtraConfig {
-		fmt.Fprintf(&sb, "%s = %s\n", k, v)
+	extraKeys := make([]string, 0, len(cfg.Spec.Puppet.ExtraConfig))
+	for k := range cfg.Spec.Puppet.ExtraConfig {
+		extraKeys = append(extraKeys, k)
+	}
+	sort.Strings(extraKeys)
+	for _, k := range extraKeys {
+		fmt.Fprintf(&sb, "%s = %s\n", k, cfg.Spec.Puppet.ExtraConfig[k])
 	}
 
 	return sb.String(), nil
@@ -333,7 +340,7 @@ func (r *ConfigReconciler) renderPuppetserverConf(cfg *openvoxv1alpha1.Config) s
 	sb.WriteString("    master-var-dir: /opt/puppetlabs/server/data/puppetserver\n")
 	sb.WriteString("    master-run-dir: /var/run/puppetlabs/puppetserver\n")
 	sb.WriteString("    master-log-dir: /var/log/puppetlabs/puppetserver\n")
-	sb.WriteString("    max-active-instances: 1\n")
+	sb.WriteString("    max-active-instances: 2\n")
 	fmt.Fprintf(&sb, "    max-requests-per-instance: %d\n", maxRequests)
 	fmt.Fprintf(&sb, "    borrow-timeout: %d\n", borrowTimeout)
 	fmt.Fprintf(&sb, "    compile-mode: %s\n", compileMode)

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +37,9 @@ const (
 	EventReasonPDBCreated       = "PDBCreated"
 	EventReasonPDBUpdated       = "PDBUpdated"
 	EventReasonPDBDeleted       = "PDBDeleted"
+	EventReasonHPACreated       = "HPACreated"
+	EventReasonHPAUpdated       = "HPAUpdated"
+	EventReasonHPADeleted       = "HPADeleted"
 	EventReasonDeploymentSynced = "DeploymentSynced"
 )
 
@@ -118,6 +122,11 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Reconcile PodDisruptionBudget
 	if err := r.reconcilePDB(ctx, server); err != nil {
 		return ctrl.Result{}, fmt.Errorf("reconciling PDB: %w", err)
+	}
+
+	// Reconcile HorizontalPodAutoscaler
+	if err := r.reconcileHPA(ctx, server); err != nil {
+		return ctrl.Result{}, fmt.Errorf("reconciling HPA: %w", err)
 	}
 
 	// Update status
@@ -213,11 +222,104 @@ func (r *ServerReconciler) buildPDB(server *openvoxv1alpha1.Server) (*policyv1.P
 	return pdb, nil
 }
 
+func (r *ServerReconciler) reconcileHPA(ctx context.Context, server *openvoxv1alpha1.Server) error {
+	logger := log.FromContext(ctx)
+	hpaName := server.Name
+	existing := &autoscalingv2.HorizontalPodAutoscaler{}
+	err := r.Get(ctx, types.NamespacedName{Name: hpaName, Namespace: server.Namespace}, existing)
+
+	// If HPA is disabled, delete if exists
+	if !server.Spec.Autoscaling.Enabled {
+		if err == nil {
+			logger.Info("deleting HPA (disabled)", "name", hpaName)
+			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonHPADeleted, "Reconcile", "HorizontalPodAutoscaler %s deleted", hpaName)
+		}
+		return nil
+	}
+
+	desired, buildErr := r.buildHPA(server)
+	if buildErr != nil {
+		return buildErr
+	}
+	if errors.IsNotFound(err) {
+		logger.Info("creating HPA", "name", hpaName)
+		if err := r.Create(ctx, desired); err != nil {
+			return err
+		}
+		r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonHPACreated, "Reconcile", "HorizontalPodAutoscaler %s created", hpaName)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// Update existing
+	existing.Spec = desired.Spec
+	if err := r.Update(ctx, existing); err != nil {
+		return err
+	}
+	r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonHPAUpdated, "Reconcile", "HorizontalPodAutoscaler %s updated", hpaName)
+	return nil
+}
+
+func (r *ServerReconciler) buildHPA(server *openvoxv1alpha1.Server) (*autoscalingv2.HorizontalPodAutoscaler, error) {
+	as := server.Spec.Autoscaling
+	targetCPU := as.TargetCPU
+	if targetCPU == 0 {
+		targetCPU = 75
+	}
+	maxReplicas := as.MaxReplicas
+	if maxReplicas == 0 {
+		maxReplicas = 5
+	}
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      server.Name,
+			Namespace: server.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "openvox-operator",
+				LabelServer:                   server.Name,
+			},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       server.Name,
+			},
+			MinReplicas: as.MinReplicas,
+			MaxReplicas: maxReplicas,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &targetCPU,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(server, hpa, r.Scheme); err != nil {
+		return nil, fmt.Errorf("setting controller reference on HPA: %w", err)
+	}
+	return hpa, nil
+}
+
 func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openvoxv1alpha1.Server{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Watches(&corev1.Secret{}, enqueueServersForSecret(mgr.GetClient())).
 		Complete(r)
 }

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -75,7 +75,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.ConfigRef, Namespace: server.Namespace}, cfg); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("waiting for Config", "configRef", server.Spec.ConfigRef)
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -85,7 +85,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.CertificateRef, Namespace: server.Namespace}, cert); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("waiting for Certificate", "certificateRef", server.Spec.CertificateRef)
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -104,7 +104,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: server.Namespace}, ca); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("waiting for CertificateAuthority", "authorityRef", cert.Spec.AuthorityRef)
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -155,7 +155,10 @@ func (r *ServerReconciler) reconcilePDB(ctx context.Context, server *openvoxv1al
 		return nil
 	}
 
-	desired := r.buildPDB(server)
+	desired, buildErr := r.buildPDB(server)
+	if buildErr != nil {
+		return buildErr
+	}
 	if errors.IsNotFound(err) {
 		logger.Info("creating PDB", "name", pdbName)
 		if err := r.Create(ctx, desired); err != nil {
@@ -177,7 +180,7 @@ func (r *ServerReconciler) reconcilePDB(ctx context.Context, server *openvoxv1al
 	return nil
 }
 
-func (r *ServerReconciler) buildPDB(server *openvoxv1alpha1.Server) *policyv1.PodDisruptionBudget {
+func (r *ServerReconciler) buildPDB(server *openvoxv1alpha1.Server) (*policyv1.PodDisruptionBudget, error) {
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      server.Name,
@@ -204,8 +207,10 @@ func (r *ServerReconciler) buildPDB(server *openvoxv1alpha1.Server) *policyv1.Po
 		minAvailable := intstrInt(1)
 		pdb.Spec.MinAvailable = &minAvailable
 	}
-	_ = controllerutil.SetControllerReference(server, pdb, r.Scheme)
-	return pdb
+	if err := controllerutil.SetControllerReference(server, pdb, r.Scheme); err != nil {
+		return nil, fmt.Errorf("setting controller reference on PDB: %w", err)
+	}
+	return pdb, nil
 }
 
 func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -112,7 +112,6 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 				Labels:    labels,
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: &replicas,
 				Strategy: strategy,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -129,6 +128,9 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 			},
 		}
 
+		if !server.Spec.Autoscaling.Enabled {
+			deploy.Spec.Replicas = &replicas
+		}
 		if err := controllerutil.SetControllerReference(server, deploy, r.Scheme); err != nil {
 			return err
 		}
@@ -138,7 +140,10 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 	}
 
 	// Update existing Deployment
-	deploy.Spec.Replicas = &replicas
+	// Only set replicas when HPA is not managing scaling
+	if !server.Spec.Autoscaling.Enabled {
+		deploy.Spec.Replicas = &replicas
+	}
 	deploy.Spec.Strategy = strategy
 	deploy.Spec.Template.Labels = labels
 	deploy.Spec.Template.Annotations = annotations


### PR DESCRIPTION
## Summary

Closes #75, #76, #77, #79, #81, #82, #83.

### Bugfixes
- **#77** Sort `ExtraConfig` map keys before rendering `puppet.conf` to prevent non-deterministic ConfigMap content causing unnecessary rolling restarts
- **#76** Fix `max-active-instances` HOCON default from `1` to `2` to match the kubebuilder default (actual value is overridden per-Server via JVM `-D` flag)
- **#75** Return `RequeueAfter: 5s` in Server reconciler when Config, Certificate, or CA is not yet available (was returning no-requeue)
- **#82** Handle `SetControllerReference` error on PDB instead of silently discarding it with `_ =`
- **#83** Add 10MB `io.LimitReader` to all HTTP response body reads (ENC, report processor, certificate signing, CA CRL fetch)
- **#81** Add `EventRecorder` to `ConfigReconciler` and wire it in `main.go`

### Features
- **#79** Implement `reconcileHPA()` for Server following the existing `reconcilePDB()` pattern. When `autoscaling.enabled: true`, creates/updates a `HorizontalPodAutoscaler` with CPU target. The Deployment no longer sets `spec.replicas` when HPA is active to avoid scaling conflicts.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/... ./cmd/...` passes
- [ ] Verify no unnecessary rolling restarts with ExtraConfig
- [ ] Verify Server reconciles after dependencies become available
- [ ] Verify HPA creates/updates/deletes correctly when toggling `autoscaling.enabled`