### PR TITLE
fix: address logic bugs in Server, Pool, and Deployment controllers

### DIFF
--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -82,7 +82,7 @@ type ServerSpec struct {
 	JavaArgs string `json:"javaArgs,omitempty"`
 
 	// MaxActiveInstances is the number of JRuby instances per Pod.
-	// +kubebuilder:default=2
+	// +kubebuilder:default=1
 	// +optional
 	MaxActiveInstances int32 `json:"maxActiveInstances,omitempty"`
 

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -1077,7 +1077,7 @@ spec:
                 description: JavaArgs defines the JVM arguments.
                 type: string
               maxActiveInstances:
-                default: 2
+                default: 1
                 description: MaxActiveInstances is the number of JRuby instances per
                   Pod.
                 format: int32

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -1077,7 +1077,7 @@ spec:
                 description: JavaArgs defines the JVM arguments.
                 type: string
               maxActiveInstances:
-                default: 2
+                default: 1
                 description: MaxActiveInstances is the number of JRuby instances per
                   Pod.
                 format: int32

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -340,7 +340,7 @@ func (r *ConfigReconciler) renderPuppetserverConf(cfg *openvoxv1alpha1.Config) s
 	sb.WriteString("    master-var-dir: /opt/puppetlabs/server/data/puppetserver\n")
 	sb.WriteString("    master-run-dir: /var/run/puppetlabs/puppetserver\n")
 	sb.WriteString("    master-log-dir: /var/log/puppetlabs/puppetserver\n")
-	sb.WriteString("    max-active-instances: 2\n")
+	sb.WriteString("    max-active-instances: 1\n")
 	fmt.Fprintf(&sb, "    max-requests-per-instance: %d\n", maxRequests)
 	fmt.Fprintf(&sb, "    borrow-timeout: %d\n", borrowTimeout)
 	fmt.Fprintf(&sb, "    compile-mode: %s\n", compileMode)

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -64,15 +64,22 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			if err := r.List(ctx, allPools, client.InNamespace(pool.Namespace)); err != nil {
 				return ctrl.Result{}, fmt.Errorf("listing Pools for hostname conflict check: %w", err)
 			}
+			hasConflict := false
 			for i := range allPools.Items {
 				other := &allPools.Items[i]
 				if other.Name == pool.Name {
 					continue
 				}
 				if other.Spec.Route != nil && other.Spec.Route.Enabled && other.Spec.Route.Hostname == pool.Spec.Route.Hostname {
-					logger.Info("hostname conflict: another Pool uses the same hostname",
-						"conflictingPool", other.Name, "hostname", pool.Spec.Route.Hostname)
+					logger.Error(fmt.Errorf("hostname %q already used by Pool %q", pool.Spec.Route.Hostname, other.Name),
+						"hostname conflict detected, skipping TLSRoute reconciliation")
+					hasConflict = true
+					break
 				}
+			}
+
+			if hasConflict {
+				return ctrl.Result{}, fmt.Errorf("hostname conflict: %q is already used by another Pool", pool.Spec.Route.Hostname)
 			}
 
 			if err := r.reconcileTLSRoute(ctx, pool); err != nil {
@@ -371,6 +378,16 @@ func (r *PoolReconciler) injectDNSAltNames(ctx context.Context, pool *openvoxv1a
 		cert.Spec.DNSAltNames = append(cert.Spec.DNSAltNames, hostname)
 		if err := r.Update(ctx, cert); err != nil {
 			return fmt.Errorf("updating Certificate %s: %w", cert.Name, err)
+		}
+
+		// Reset certificate phase to trigger re-signing with the new alt name
+		if cert.Status.Phase == openvoxv1alpha1.CertificatePhaseSigned {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhasePending
+			if err := r.Status().Update(ctx, cert); err != nil {
+				return fmt.Errorf("resetting Certificate %s phase: %w", cert.Name, err)
+			}
+			logger.Info("reset Certificate phase to Pending for re-signing",
+				"certificate", cert.Name)
 		}
 	}
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -134,15 +134,23 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if server.Spec.Replicas != nil {
 		replicas = *server.Spec.Replicas
 	}
+	ready := r.getReadyReplicas(ctx, server)
 	server.Status.Desired = replicas
-	server.Status.Ready = r.getReadyReplicas(ctx, server)
-	server.Status.Phase = openvoxv1alpha1.ServerPhaseRunning
+	server.Status.Ready = ready
+
+	if ready > 0 {
+		server.Status.Phase = openvoxv1alpha1.ServerPhaseRunning
+	} else {
+		server.Status.Phase = openvoxv1alpha1.ServerPhasePending
+	}
 
 	if err := r.Status().Update(ctx, server); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonServerRunning, "Reconcile", "Server reconciled successfully")
+	if ready > 0 {
+		r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonServerRunning, "Reconcile", "Server reconciled successfully")
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -28,10 +28,14 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 
 	javaArgs := resolveJavaArgs(server)
 	// Override max-active-instances via JVM system property.
-	// The ConfigMap sets max-active-instances: 1 as a safe default,
+	// The ConfigMap sets max-active-instances: 2 as a safe default,
 	// but each Server can specify its own value. HOCON's Typesafe Config
 	// library resolves -D system properties as overrides.
-	javaArgs = fmt.Sprintf("%s -Djruby-puppet.max-active-instances=%d", javaArgs, server.Spec.MaxActiveInstances)
+	maxActive := server.Spec.MaxActiveInstances
+	if maxActive <= 0 {
+		maxActive = 2
+	}
+	javaArgs = fmt.Sprintf("%s -Djruby-puppet.max-active-instances=%d", javaArgs, maxActive)
 
 	role := RoleServer
 	if server.Spec.CA && !server.Spec.Server {

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -33,7 +33,7 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 	// library resolves -D system properties as overrides.
 	maxActive := server.Spec.MaxActiveInstances
 	if maxActive <= 0 {
-		maxActive = 2
+		maxActive = 1
 	}
 	javaArgs = fmt.Sprintf("%s -Djruby-puppet.max-active-instances=%d", javaArgs, maxActive)
 


### PR DESCRIPTION
## Summary

Fixes four logic bugs found during codebase analysis, plus a default value change.

### Server Phase not reflecting actual state
`server_controller.go` unconditionally set `ServerPhaseRunning` after reconciliation, even when zero pods were ready. Now sets `Pending` when `readyReplicas == 0` and `Running` only when at least one pod is ready.

### Pool hostname conflicts silently ignored
`pool_controller.go` detected hostname conflicts between Pools but only logged them as info and proceeded to create the TLSRoute anyway. Now returns an error, preventing conflicting TLSRoutes from being created.

### injectDNSAltNames does not trigger certificate re-signing
When `pool_controller.go` injected a DNS alt name into a Certificate that was already in `Signed` phase, the new alt name was never included in the actual certificate. Now resets the Certificate phase to `Pending` to trigger re-signing.

### MaxActiveInstances=0 causes broken JRuby config
`server_deployment.go` passed `MaxActiveInstances` directly to JVM args. If the kubebuilder default was bypassed (e.g. explicit `0`), JRuby would start with zero instances. Now defaults to `1` when the value is `<= 0`.

### MaxActiveInstances default changed from 2 to 1
In Kubernetes, horizontal scaling (more pods) is preferred over vertical scaling (more JRuby threads per pod). A single JRuby instance per pod gives predictable memory usage and better HPA behavior. Users can still set `maxActiveInstances` in the Server spec if needed.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes
- [ ] Verify Server status transitions: Pending → WaitingForCert → Running
- [ ] Verify hostname conflict prevents TLSRoute creation
- [ ] Verify DNS alt name injection triggers certificate re-sign