### PR TITLE
feat: support namespace-scoped operator mode

### DIFF
--- a/charts/openvox-operator/templates/clusterrole.yaml
+++ b/charts/openvox-operator/templates/clusterrole.yaml
@@ -1,7 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if eq .Values.scope.mode "namespace" }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ include "openvox-operator.fullname" . }}
+  {{- if eq .Values.scope.mode "namespace" }}
+  namespace: {{ .Values.scope.watchNamespace | default .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "openvox-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/openvox-operator/templates/clusterrolebinding.yaml
+++ b/charts/openvox-operator/templates/clusterrolebinding.yaml
@@ -1,12 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if eq .Values.scope.mode "namespace" }}
+kind: RoleBinding
+{{- else }}
 kind: ClusterRoleBinding
+{{- end }}
 metadata:
   name: {{ include "openvox-operator.fullname" . }}
+  {{- if eq .Values.scope.mode "namespace" }}
+  namespace: {{ .Values.scope.watchNamespace | default .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "openvox-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if eq .Values.scope.mode "namespace" }}
+  kind: Role
+  {{- else }}
   kind: ClusterRole
+  {{- end }}
   name: {{ include "openvox-operator.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/charts/openvox-operator/templates/deployment.yaml
+++ b/charts/openvox-operator/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             {{- if .Values.leaderElect }}
             - --leader-elect
             {{- end }}
+            {{- if eq .Values.scope.mode "namespace" }}
+            - --watch-namespace={{ .Values.scope.watchNamespace | default .Release.Namespace }}
+            {{- end }}
           ports:
             - name: health
               containerPort: 8081

--- a/charts/openvox-operator/values.yaml
+++ b/charts/openvox-operator/values.yaml
@@ -15,6 +15,14 @@ serviceAccount:
 
 leaderElect: true
 
+# Operator scope configuration
+# mode: "cluster" (default) watches all namespaces with ClusterRole/ClusterRoleBinding
+# mode: "namespace" restricts the operator to a single namespace with Role/RoleBinding
+scope:
+  mode: cluster
+  # watchNamespace: defaults to .Release.Namespace when mode is "namespace"
+  watchNamespace: ""
+
 resources:
   limits:
     cpu: 500m

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -33,12 +34,15 @@ func main() {
 	var metricsAddr string
 	var probeAddr string
 	var enableLeaderElection bool
+	var watchNamespace string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&watchNamespace, "watch-namespace", "",
+		"Namespace to restrict the operator to. If empty, the operator watches all namespaces (cluster-wide).")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -46,13 +50,27 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "openvox-operator.voxpupuli.org",
-	})
+	}
+
+	if watchNamespace != "" {
+		setupLog.Info("watching single namespace", "namespace", watchNamespace)
+		mgrOptions.Cache = cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				watchNamespace: {},
+			},
+		}
+		mgrOptions.LeaderElectionNamespace = watchNamespace
+	} else {
+		setupLog.Info("watching all namespaces (cluster-wide)")
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -42,7 +42,7 @@ type authConfig struct {
 	authType     string
 	authToken    string
 	authHeader   string
-	authUsername  string
+	authUsername string
 	authPassword string
 }
 
@@ -81,7 +81,7 @@ func main() {
 			authType:     os.Getenv("AUTH_TYPE"),
 			authToken:    os.Getenv("AUTH_TOKEN"),
 			authHeader:   os.Getenv("AUTH_HEADER"),
-			authUsername:  os.Getenv("AUTH_USERNAME"),
+			authUsername: os.Getenv("AUTH_USERNAME"),
 			authPassword: os.Getenv("AUTH_PASSWORD"),
 		},
 	}

--- a/cmd/report/puppetdb_test.go
+++ b/cmd/report/puppetdb_test.go
@@ -8,23 +8,23 @@ import (
 // sampleReport returns a to_data_hash report for testing.
 func sampleReport() map[string]any {
 	return map[string]any{
-		"host":                   "testnode.example.com",
-		"time":                   "2024-01-15T10:30:00.000000000Z",
-		"configuration_version":  "1705312200",
-		"transaction_uuid":       "abc-123",
-		"report_format":          float64(10),
-		"puppet_version":         "8.4.0",
-		"status":                 "changed",
-		"transaction_completed":  true,
-		"noop":                   false,
-		"noop_pending":           false,
-		"environment":            "production",
-		"corrective_change":      false,
-		"catalog_uuid":           "cat-456",
-		"code_id":                "code-789",
-		"job_id":                 "job-012",
-		"cached_catalog_status":  "not_used",
-		"server_used":            "puppet.example.com",
+		"host":                  "testnode.example.com",
+		"time":                  "2024-01-15T10:30:00.000000000Z",
+		"configuration_version": "1705312200",
+		"transaction_uuid":      "abc-123",
+		"report_format":         float64(10),
+		"puppet_version":        "8.4.0",
+		"status":                "changed",
+		"transaction_completed": true,
+		"noop":                  false,
+		"noop_pending":          false,
+		"environment":           "production",
+		"corrective_change":     false,
+		"catalog_uuid":          "cat-456",
+		"code_id":               "code-789",
+		"job_id":                "job-012",
+		"cached_catalog_status": "not_used",
+		"server_used":           "puppet.example.com",
 		"resource_statuses": map[string]any{
 			"Notify[hello]": map[string]any{
 				"title":             "hello",
@@ -52,16 +52,16 @@ func sampleReport() map[string]any {
 		},
 		"metrics": map[string]any{
 			"time": map[string]any{
-				"name":   "time",
-				"label":  "Time",
+				"name":  "time",
+				"label": "Time",
 				"values": []any{
 					[]any{"total", "Total", float64(5.5)},
 					[]any{"notify", "Notify", float64(0.001)},
 				},
 			},
 			"resources": map[string]any{
-				"name":   "resources",
-				"label":  "Resources",
+				"name":  "resources",
+				"label": "Resources",
 				"values": []any{
 					[]any{"total", "Total", float64(1)},
 					[]any{"changed", "Changed", float64(1)},

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -38,8 +38,8 @@ type CertificateAuthorityReconciler struct {
 
 // Event reasons for CertificateAuthority.
 const (
-	EventReasonCAInitialized  = "CAInitialized"
-	EventReasonCRLRefreshed   = "CRLRefreshed"
+	EventReasonCAInitialized    = "CAInitialized"
+	EventReasonCRLRefreshed     = "CRLRefreshed"
 	EventReasonCRLRefreshFailed = "CRLRefreshFailed"
 )
 

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -1224,7 +1224,6 @@ func (r *ConfigReconciler) renderAutosignPolicyConfig(ctx context.Context, names
 	return sb.String(), nil
 }
 
-
 // updateSigningPolicyStatus sets the phase and condition on a SigningPolicy.
 func (r *ConfigReconciler) updateSigningPolicyStatus(ctx context.Context, sp *openvoxv1alpha1.SigningPolicy, err error) {
 	if err != nil {

--- a/internal/controller/reportprocessor_controller.go
+++ b/internal/controller/reportprocessor_controller.go
@@ -294,7 +294,6 @@ func (r *ReportProcessorReconciler) renderReportWebhookConfig(ctx context.Contex
 	return string(out), nil
 }
 
-
 // resolveConfigMapKey reads a specific key from a ConfigMap.
 func (r *ReportProcessorReconciler) resolveConfigMapKey(ctx context.Context, namespace, cmName, key string) (string, error) {
 	cm := &corev1.ConfigMap{}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -282,7 +282,7 @@ func (r *ServerReconciler) buildHPA(server *openvoxv1alpha1.Server) (*autoscalin
 			Namespace: server.Namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": "openvox-operator",
-				LabelServer:                   server.Name,
+				LabelServer:                    server.Name,
 			},
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{


### PR DESCRIPTION
## Summary

- Add `--watch-namespace` CLI flag to restrict the operator to a single namespace
- When set, the controller-runtime cache only watches the specified namespace and leader election is scoped accordingly
- Helm chart conditionally renders `Role`/`RoleBinding` instead of `ClusterRole`/`ClusterRoleBinding` based on `scope.mode`
- Default remains `cluster` (backward-compatible), namespace mode is opt-in

## Security motivation

The operator currently runs with a ClusterRole granting full CRUD on Secrets, Deployments, RBAC objects etc. across all namespaces. While the controller code already operates within namespace boundaries (`client.InNamespace()`), the RBAC permissions are cluster-wide. A compromised operator pod could access all Secrets in every namespace.

Namespace-scoped mode reduces the blast radius to only the managed namespace.

## Helm usage

```yaml
# Cluster-wide (default, no change needed)
scope:
  mode: cluster

# Namespace-scoped
scope:
  mode: namespace
  watchNamespace: "my-namespace"  # defaults to .Release.Namespace
```

## Changes

| File | Change |
|------|--------|
| `cmd/main.go` | `--watch-namespace` flag, `Cache.DefaultNamespaces`, `LeaderElectionNamespace` |
| `charts/.../values.yaml` | `scope.mode` + `scope.watchNamespace` |
| `charts/.../templates/clusterrole.yaml` | Conditional ClusterRole vs Role |
| `charts/.../templates/clusterrolebinding.yaml` | Conditional ClusterRoleBinding vs RoleBinding |
| `charts/.../templates/deployment.yaml` | Conditional `--watch-namespace` arg |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `helm template` with `scope.mode=cluster` renders ClusterRole/ClusterRoleBinding (no `--watch-namespace`)
- [x] `helm template` with `scope.mode=namespace` renders Role/RoleBinding with correct namespace + `--watch-namespace` arg
- [x] `helm template` with custom `scope.watchNamespace` correctly overrides the target namespace
- [ ] Deploy in cluster-wide mode (regression test)
- [ ] Deploy in namespace-scoped mode