### PR TITLE
fix: add puppet to PATH in agent image and resolve status conflict

### DIFF
--- a/images/openvox-agent/Containerfile
+++ b/images/openvox-agent/Containerfile
@@ -17,4 +17,6 @@ RUN rpm -Uvh https://yum.voxpupuli.org/openvox8-release-el-9.noarch.rpm \
     && dnf install -y --setopt=install_weak_deps=False openvox-agent-${OPENVOX_AGENT_VERSION} \
     && dnf clean all
 
+ENV PATH="/opt/puppetlabs/bin:${PATH}"
+
 ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -129,6 +129,11 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("reconciling HPA: %w", err)
 	}
 
+	// Re-fetch server to avoid conflict errors from concurrent reconciliations
+	if err := r.Get(ctx, req.NamespacedName, server); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Update status
 	replicas := int32(1)
 	if server.Spec.Replicas != nil {


### PR DESCRIPTION
## Summary

- Add /opt/puppetlabs/bin to PATH in agent Containerfile so E2E tests can call puppet without full path
- Re-fetch Server object before final status update to prevent optimistic concurrency conflicts

## Test plan

- [ ] E2E agent tests no longer fail with 'puppet: command not found'
- [ ] Server controller logs no longer show 'object has been modified' errors