### PR TITLE
feat: add printer columns for image tag and CA role

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -9,6 +9,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=cfg
 // +kubebuilder:printcolumn:name="CA",type=string,JSONPath=`.spec.authorityRef`
+// +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image.tag`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -9,6 +9,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Config",type=string,JSONPath=`.spec.configRef`
+// +kubebuilder:printcolumn:name="CA",type=boolean,JSONPath=`.spec.ca`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.ready`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.authorityRef
       name: CA
       type: string
+    - jsonPath: .spec.image.tag
+      name: Image
+      type: string
     - jsonPath: .status.phase
       name: Phase
       type: string

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .spec.configRef
       name: Config
       type: string
+    - jsonPath: .spec.ca
+      name: CA
+      type: boolean
     - jsonPath: .spec.replicas
       name: Replicas
       type: integer

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.authorityRef
       name: CA
       type: string
+    - jsonPath: .spec.image.tag
+      name: Image
+      type: string
     - jsonPath: .status.phase
       name: Phase
       type: string

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .spec.configRef
       name: Config
       type: string
+    - jsonPath: .spec.ca
+      name: CA
+      type: boolean
     - jsonPath: .spec.replicas
       name: Replicas
       type: integer


### PR DESCRIPTION
## Summary

- Add Image column to Config (shows server image tag)
- Add CA column to Server (distinguishes CA vs compiler servers)

## Example output

```
kubectl get config
NAME        CA     IMAGE   PHASE   AGE
my-config   my-ca  8.25.0  Ready   5m

kubectl get server
NAME     CONFIG     CA      REPLICAS   READY   PHASE     AGE
my-ca    my-config  true    1          1       Running   5m
my-srv   my-config  false   3          3       Running   4m
```

Closes #62