### PR TITLE
test: add controller reconciler unit tests

### DIFF
--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -1,0 +1,560 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestConfigReconcile_NotFound(t *testing.T) {
+	c := setupTestClient()
+	r := newConfigReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("nonexistent"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Error("expected no requeue for missing Config")
+	}
+}
+
+func TestConfigReconcile_BasicCreation(t *testing.T) {
+	cfg := newConfig("production")
+	c := setupTestClient(cfg)
+	r := newConfigReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("production"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Requeue {
+		t.Error("expected no requeue")
+	}
+
+	// Verify ConfigMap
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not created: %v", err)
+	}
+
+	expectedKeys := []string{
+		"puppet.conf", "puppetdb.conf", "webserver.conf", "webserver-ca.conf",
+		"puppetserver.conf", "auth.conf", "ca.conf", "product.conf",
+		"logback.xml", "metrics.conf", "ca-enabled.cfg", "ca-disabled.cfg",
+	}
+	for _, key := range expectedKeys {
+		if _, ok := cm.Data[key]; !ok {
+			t.Errorf("ConfigMap missing key %q", key)
+		}
+	}
+	if len(cm.Data) != len(expectedKeys) {
+		t.Errorf("ConfigMap has %d keys, expected %d", len(cm.Data), len(expectedKeys))
+	}
+
+	// Verify ServiceAccount
+	sa := &corev1.ServiceAccount{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-server", Namespace: testNamespace}, sa); err != nil {
+		t.Fatalf("ServiceAccount not created: %v", err)
+	}
+
+	// Verify status phase
+	updatedCfg := &openvoxv1alpha1.Config{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production", Namespace: testNamespace}, updatedCfg); err != nil {
+		t.Fatalf("failed to get Config: %v", err)
+	}
+	if updatedCfg.Status.Phase != openvoxv1alpha1.ConfigPhaseRunning {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.ConfigPhaseRunning, updatedCfg.Status.Phase)
+	}
+}
+
+func TestConfigReconcile_PuppetConfRendering(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     []configOption
+		contains []string
+		excludes []string
+	}{
+		{
+			name: "storeconfigs enabled",
+			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				Storeconfigs: true,
+				StoreBackend: "puppetdb",
+				Reports:      "puppetdb",
+			})},
+			contains: []string{"storeconfigs = true", "storeconfigs_backend = puppetdb"},
+		},
+		{
+			name: "storeconfigs disabled",
+			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				Storeconfigs: false,
+				Reports:      "puppetdb",
+			})},
+			excludes: []string{"storeconfigs = true"},
+		},
+		{
+			name: "custom environmentPath",
+			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				EnvironmentPath: "/custom/code/environments",
+				Reports:         "puppetdb",
+			})},
+			contains: []string{"environmentpath = /custom/code/environments"},
+		},
+		{
+			name: "custom hieraConfig",
+			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				HieraConfig: "/etc/puppetlabs/custom/hiera.yaml",
+				Reports:     "puppetdb",
+			})},
+			contains: []string{"hiera_config = /etc/puppetlabs/custom/hiera.yaml"},
+		},
+		{
+			name: "extraConfig sorted",
+			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				Reports: "puppetdb",
+				ExtraConfig: map[string]string{
+					"zz_setting": "zvalue",
+					"aa_setting": "avalue",
+				},
+			})},
+			contains: []string{"aa_setting = avalue", "zz_setting = zvalue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newConfig("test-cfg", tt.opts...)
+			c := setupTestClient(cfg)
+			r := newConfigReconciler(c)
+
+			if _, err := r.Reconcile(testCtx(), testRequest("test-cfg")); err != nil {
+				t.Fatalf("reconcile error: %v", err)
+			}
+
+			cm := &corev1.ConfigMap{}
+			if err := c.Get(testCtx(), types.NamespacedName{Name: "test-cfg-config", Namespace: testNamespace}, cm); err != nil {
+				t.Fatalf("ConfigMap not found: %v", err)
+			}
+
+			puppetConf := cm.Data["puppet.conf"]
+			for _, s := range tt.contains {
+				if !strings.Contains(puppetConf, s) {
+					t.Errorf("puppet.conf missing %q\n---\n%s", s, puppetConf)
+				}
+			}
+			for _, s := range tt.excludes {
+				if strings.Contains(puppetConf, s) {
+					t.Errorf("puppet.conf should not contain %q\n---\n%s", s, puppetConf)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigReconcile_PuppetConfWithCA(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	ca := newCertificateAuthority("production-ca")
+	c := setupTestClient(cfg, ca)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	puppetConf := cm.Data["puppet.conf"]
+	if !strings.Contains(puppetConf, "ca_ttl =") {
+		t.Errorf("puppet.conf missing ca_ttl\n---\n%s", puppetConf)
+	}
+	if !strings.Contains(puppetConf, "autosign = ") {
+		t.Errorf("puppet.conf missing autosign\n---\n%s", puppetConf)
+	}
+}
+
+func TestConfigReconcile_PuppetConfWithENC(t *testing.T) {
+	nc := newNodeClassifier("my-enc", "https://enc.example.com")
+	cfg := newConfig("production", withNodeClassifierRef("my-enc"))
+	c := setupTestClient(cfg, nc)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	puppetConf := cm.Data["puppet.conf"]
+	if !strings.Contains(puppetConf, "node_terminus = exec") {
+		t.Errorf("puppet.conf missing node_terminus\n---\n%s", puppetConf)
+	}
+	if !strings.Contains(puppetConf, "external_nodes = ") {
+		t.Errorf("puppet.conf missing external_nodes\n---\n%s", puppetConf)
+	}
+}
+
+func TestConfigReconcile_PuppetConfWithReports(t *testing.T) {
+	cfg := newConfig("production")
+	rp := newReportProcessor("webhook-rp", "production", "https://reports.example.com")
+	c := setupTestClient(cfg, rp)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	puppetConf := cm.Data["puppet.conf"]
+	if !strings.Contains(puppetConf, "reports = puppetdb,webhook") {
+		t.Errorf("puppet.conf missing reports with webhook\n---\n%s", puppetConf)
+	}
+}
+
+func TestConfigReconcile_PuppetserverConf(t *testing.T) {
+	tests := []struct {
+		name     string
+		ps       openvoxv1alpha1.PuppetServerSpec
+		contains []string
+	}{
+		{
+			name: "default server-var-dir",
+			ps:   openvoxv1alpha1.PuppetServerSpec{},
+			contains: []string{
+				"server-var-dir: /run/puppetserver",
+			},
+		},
+		{
+			name: "custom compile-mode",
+			ps: openvoxv1alpha1.PuppetServerSpec{
+				CompileMode: "jit",
+			},
+			contains: []string{"compile-mode: jit"},
+		},
+		{
+			name: "custom borrow-timeout",
+			ps: openvoxv1alpha1.PuppetServerSpec{
+				BorrowTimeout: 600000,
+			},
+			contains: []string{"borrow-timeout: 600000"},
+		},
+		{
+			name: "http-client settings",
+			ps: openvoxv1alpha1.PuppetServerSpec{
+				HTTPClient: &openvoxv1alpha1.HTTPClientSpec{
+					ConnectTimeoutMs: int32Ptr(5000),
+					IdleTimeoutMs:    int32Ptr(30000),
+				},
+			},
+			contains: []string{
+				"connect-timeout-milliseconds: 5000",
+				"idle-timeout-milliseconds: 30000",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newConfig("test-cfg", withPuppetServerSpec(tt.ps))
+			c := setupTestClient(cfg)
+			r := newConfigReconciler(c)
+
+			if _, err := r.Reconcile(testCtx(), testRequest("test-cfg")); err != nil {
+				t.Fatalf("reconcile error: %v", err)
+			}
+
+			cm := &corev1.ConfigMap{}
+			if err := c.Get(testCtx(), types.NamespacedName{Name: "test-cfg-config", Namespace: testNamespace}, cm); err != nil {
+				t.Fatalf("ConfigMap not found: %v", err)
+			}
+
+			psConf := cm.Data["puppetserver.conf"]
+			for _, s := range tt.contains {
+				if !strings.Contains(psConf, s) {
+					t.Errorf("puppetserver.conf missing %q\n---\n%s", s, psConf)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigReconcile_AuthConf(t *testing.T) {
+	cfg := newConfig("production")
+	c := setupTestClient(cfg)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	authConf := cm.Data["auth.conf"]
+	// Must contain default rules
+	if !strings.Contains(authConf, "puppetlabs v3 catalog from agents") {
+		t.Errorf("auth.conf missing default catalog rule")
+	}
+	if !strings.Contains(authConf, "puppetlabs status service - simple") {
+		t.Errorf("auth.conf missing default status rule")
+	}
+	// Must end with deny-all
+	if !strings.Contains(authConf, `deny: "*"`) {
+		t.Errorf("auth.conf missing deny-all rule")
+	}
+	if !strings.Contains(authConf, `name: "puppetlabs deny all"`) {
+		t.Errorf("auth.conf missing deny-all rule name")
+	}
+}
+
+func TestConfigReconcile_AuthConfCustomRules(t *testing.T) {
+	rules := []openvoxv1alpha1.AuthorizationRule{
+		{
+			Name: "custom api access",
+			MatchRequest: openvoxv1alpha1.AuthorizationMatchRequest{
+				Path:   "/custom/api",
+				Type:   "path",
+				Method: []string{"get"},
+			},
+			Allow:     "*",
+			SortOrder: 100,
+		},
+	}
+
+	cfg := newConfig("production", withAuthorizationRules(rules))
+	c := setupTestClient(cfg)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	authConf := cm.Data["auth.conf"]
+	// Custom rule must appear
+	if !strings.Contains(authConf, `"custom api access"`) {
+		t.Errorf("auth.conf missing custom rule\n---\n%s", authConf)
+	}
+	// Custom rule must appear before deny-all
+	customIdx := strings.Index(authConf, "custom api access")
+	denyIdx := strings.Index(authConf, "puppetlabs deny all")
+	if customIdx >= denyIdx {
+		t.Errorf("custom rule should appear before deny-all (custom=%d, deny=%d)", customIdx, denyIdx)
+	}
+}
+
+func TestConfigReconcile_LogbackXML(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     []configOption
+		contains []string
+	}{
+		{
+			name: "default INFO level",
+			opts: nil,
+			contains: []string{
+				`<root level="INFO">`,
+			},
+		},
+		{
+			name: "custom root level",
+			opts: []configOption{withLogging("DEBUG", nil)},
+			contains: []string{
+				`<root level="DEBUG">`,
+			},
+		},
+		{
+			name: "per-logger overrides",
+			opts: []configOption{withLogging("INFO", map[string]string{
+				"puppetlabs.puppetserver": "DEBUG",
+			})},
+			contains: []string{
+				`<logger name="puppetlabs.puppetserver" level="DEBUG" />`,
+				`<root level="INFO">`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newConfig("test-cfg", tt.opts...)
+			c := setupTestClient(cfg)
+			r := newConfigReconciler(c)
+
+			if _, err := r.Reconcile(testCtx(), testRequest("test-cfg")); err != nil {
+				t.Fatalf("reconcile error: %v", err)
+			}
+
+			cm := &corev1.ConfigMap{}
+			if err := c.Get(testCtx(), types.NamespacedName{Name: "test-cfg-config", Namespace: testNamespace}, cm); err != nil {
+				t.Fatalf("ConfigMap not found: %v", err)
+			}
+
+			logbackXML := cm.Data["logback.xml"]
+			for _, s := range tt.contains {
+				if !strings.Contains(logbackXML, s) {
+					t.Errorf("logback.xml missing %q\n---\n%s", s, logbackXML)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigReconcile_AutosignPolicy(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	ca := newCertificateAuthority("production-ca")
+	sp := newSigningPolicy("allow-all", "production-ca", true)
+
+	c := setupTestClient(cfg, ca, sp)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	// Verify autosign-policy Secret
+	secret := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-ca-autosign-policy", Namespace: testNamespace}, secret); err != nil {
+		t.Fatalf("autosign Secret not created: %v", err)
+	}
+
+	policyYAML := string(secret.Data["autosign-policy.yaml"])
+	if !strings.Contains(policyYAML, "any: true") {
+		t.Errorf("autosign policy missing any:true\n---\n%s", policyYAML)
+	}
+	if !strings.Contains(policyYAML, "name: allow-all") {
+		t.Errorf("autosign policy missing policy name\n---\n%s", policyYAML)
+	}
+}
+
+func TestConfigReconcile_ENCSecret(t *testing.T) {
+	tests := []struct {
+		name     string
+		nc       *openvoxv1alpha1.NodeClassifier
+		contains []string
+	}{
+		{
+			name: "basic enc config",
+			nc:   newNodeClassifier("my-enc", "https://enc.example.com"),
+			contains: []string{
+				"url: https://enc.example.com",
+				"method: GET",
+				"path: /node/{certname}",
+				"responseFormat: yaml",
+			},
+		},
+		{
+			name: "mtls auth",
+			nc: func() *openvoxv1alpha1.NodeClassifier {
+				nc := newNodeClassifier("my-enc", "https://enc.example.com")
+				nc.Spec.Auth = &openvoxv1alpha1.NodeClassifierAuth{MTLS: true}
+				return nc
+			}(),
+			contains: []string{
+				"type: mtls",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newConfig("production", withNodeClassifierRef("my-enc"))
+			c := setupTestClient(cfg, tt.nc)
+			r := newConfigReconciler(c)
+
+			if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+				t.Fatalf("reconcile error: %v", err)
+			}
+
+			secret := &corev1.Secret{}
+			if err := c.Get(testCtx(), types.NamespacedName{Name: "production-enc", Namespace: testNamespace}, secret); err != nil {
+				t.Fatalf("ENC Secret not created: %v", err)
+			}
+
+			encYAML := string(secret.Data["enc.yaml"])
+			for _, s := range tt.contains {
+				if !strings.Contains(encYAML, s) {
+					t.Errorf("enc.yaml missing %q\n---\n%s", s, encYAML)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigReconcile_ReportWebhookSecret(t *testing.T) {
+	cfg := newConfig("production")
+	rp1 := newReportProcessor("beta-webhook", "production", "https://beta.example.com/reports")
+	rp2 := newReportProcessor("alpha-webhook", "production", "https://alpha.example.com/reports")
+
+	c := setupTestClient(cfg, rp1, rp2)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-report-webhook", Namespace: testNamespace}, secret); err != nil {
+		t.Fatalf("report-webhook Secret not created: %v", err)
+	}
+
+	webhookYAML := string(secret.Data["report-webhook.yaml"])
+	// Processors should be sorted by name
+	alphaIdx := strings.Index(webhookYAML, "alpha-webhook")
+	betaIdx := strings.Index(webhookYAML, "beta-webhook")
+	if alphaIdx < 0 || betaIdx < 0 {
+		t.Fatalf("report-webhook.yaml missing processor entries\n---\n%s", webhookYAML)
+	}
+	if alphaIdx > betaIdx {
+		t.Errorf("processors should be sorted by name (alpha=%d, beta=%d)", alphaIdx, betaIdx)
+	}
+}
+
+func TestConfigReconcile_UpdateExistingConfigMap(t *testing.T) {
+	cfg := newConfig("production")
+	existingCM := newConfigMap("production-config", map[string]string{
+		"puppet.conf": "old content",
+	})
+
+	c := setupTestClient(cfg, existingCM)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	if cm.Data["puppet.conf"] == "old content" {
+		t.Error("ConfigMap was not updated")
+	}
+	if !strings.Contains(cm.Data["puppet.conf"], "[main]") {
+		t.Error("ConfigMap puppet.conf missing expected content")
+	}
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
+}

--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -18,7 +18,7 @@ func TestConfigReconcile_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Requeue || res.RequeueAfter != 0 {
+	if res.RequeueAfter != 0 {
 		t.Error("expected no requeue for missing Config")
 	}
 }
@@ -32,7 +32,7 @@ func TestConfigReconcile_BasicCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Requeue {
+	if res.RequeueAfter != 0 {
 		t.Error("expected no requeue")
 	}
 

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -18,7 +18,7 @@ func TestPoolReconcile_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Requeue || res.RequeueAfter != 0 {
+	if res.RequeueAfter != 0 {
 		t.Error("expected no requeue for missing Pool")
 	}
 }

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -1,0 +1,235 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestPoolReconcile_NotFound(t *testing.T) {
+	c := setupTestClient()
+	r := newPoolReconciler(c, false)
+
+	res, err := r.Reconcile(testCtx(), testRequest("nonexistent"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Error("expected no requeue for missing Pool")
+	}
+}
+
+func TestPoolReconcile_ServiceCreation(t *testing.T) {
+	pool := newPool("puppet")
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, false)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	svc := &corev1.Service{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, svc); err != nil {
+		t.Fatalf("Service not created: %v", err)
+	}
+
+	// Default port
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 8140 {
+		t.Errorf("expected port 8140, got %v", svc.Spec.Ports)
+	}
+
+	// Default type
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Errorf("expected type ClusterIP, got %v", svc.Spec.Type)
+	}
+
+	// Selector should use pool label
+	expectedSelector := poolServiceSelector(pool)
+	for k, v := range expectedSelector {
+		if svc.Spec.Selector[k] != v {
+			t.Errorf("selector[%q] = %q, want %q", k, svc.Spec.Selector[k], v)
+		}
+	}
+
+	// Status should be updated
+	updated := &openvoxv1alpha1.Pool{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Pool: %v", err)
+	}
+	if updated.Status.ServiceName != "puppet" {
+		t.Errorf("expected status.serviceName %q, got %q", "puppet", updated.Status.ServiceName)
+	}
+}
+
+func TestPoolReconcile_ServiceCustomPort(t *testing.T) {
+	pool := newPool("puppet", withServicePort(9140))
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, false)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	svc := &corev1.Service{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, svc); err != nil {
+		t.Fatalf("Service not found: %v", err)
+	}
+
+	if svc.Spec.Ports[0].Port != 9140 {
+		t.Errorf("expected port 9140, got %d", svc.Spec.Ports[0].Port)
+	}
+}
+
+func TestPoolReconcile_ServiceLoadBalancer(t *testing.T) {
+	pool := newPool("puppet", withServiceType(corev1.ServiceTypeLoadBalancer))
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, false)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	svc := &corev1.Service{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, svc); err != nil {
+		t.Fatalf("Service not found: %v", err)
+	}
+
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Errorf("expected type LoadBalancer, got %v", svc.Spec.Type)
+	}
+}
+
+func TestPoolReconcile_ServiceAnnotations(t *testing.T) {
+	annotations := map[string]string{
+		"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
+	}
+	pool := newPool("puppet", withServiceAnnotations(annotations))
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, false)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	svc := &corev1.Service{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, svc); err != nil {
+		t.Fatalf("Service not found: %v", err)
+	}
+
+	for k, v := range annotations {
+		if svc.Annotations[k] != v {
+			t.Errorf("annotation %q = %q, want %q", k, svc.Annotations[k], v)
+		}
+	}
+}
+
+func TestPoolReconcile_EndpointCount(t *testing.T) {
+	pool := newPool("puppet")
+	eps := newEndpointSlice("puppet-abc", "puppet", 3)
+	c := setupTestClient(pool, eps)
+	r := newPoolReconciler(c, false)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	updated := &openvoxv1alpha1.Pool{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Pool: %v", err)
+	}
+
+	if updated.Status.Endpoints != 3 {
+		t.Errorf("expected 3 endpoints, got %d", updated.Status.Endpoints)
+	}
+}
+
+func TestPoolReconcile_TLSRouteCreation(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"))
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, true)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	route := &gwapiv1.TLSRoute{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, route); err != nil {
+		t.Fatalf("TLSRoute not created: %v", err)
+	}
+
+	if len(route.Spec.Hostnames) != 1 || string(route.Spec.Hostnames[0]) != "puppet.example.com" {
+		t.Errorf("unexpected hostnames: %v", route.Spec.Hostnames)
+	}
+	if len(route.Spec.ParentRefs) != 1 || string(route.Spec.ParentRefs[0].Name) != "my-gateway" {
+		t.Errorf("unexpected parentRefs: %v", route.Spec.ParentRefs)
+	}
+}
+
+func TestPoolReconcile_TLSRouteDisabled(t *testing.T) {
+	pool := newPool("puppet") // no route spec
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, true)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	route := &gwapiv1.TLSRoute{}
+	err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, route)
+	if err == nil {
+		t.Error("TLSRoute should not be created when route is disabled")
+	}
+}
+
+func TestPoolReconcile_TLSRouteHostnameConflict(t *testing.T) {
+	// Create pool-a first and reconcile it
+	pool1 := newPool("puppet-a", withRoute(true, "puppet.example.com", "gw"))
+	c := setupTestClient(pool1)
+	r := newPoolReconciler(c, true)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet-a")); err != nil {
+		t.Fatalf("reconcile pool-a error: %v", err)
+	}
+
+	// Now add pool-b with the same hostname
+	pool2 := newPool("puppet-b", withRoute(true, "puppet.example.com", "gw"))
+	if err := c.Create(testCtx(), pool2); err != nil {
+		t.Fatalf("failed to create pool-b: %v", err)
+	}
+
+	// Reconcile pool-b should fail with hostname conflict
+	_, err := r.Reconcile(testCtx(), testRequest("puppet-b"))
+	if err == nil {
+		t.Fatal("expected hostname conflict error")
+	}
+}
+
+func TestPoolReconcile_UpdateExistingService(t *testing.T) {
+	pool := newPool("puppet", withServicePort(9140))
+	existingSvc := &corev1.Service{}
+	existingSvc.Name = "puppet"
+	existingSvc.Namespace = testNamespace
+	existingSvc.Spec.Ports = []corev1.ServicePort{
+		{Name: "https", Port: 8140},
+	}
+
+	c := setupTestClient(pool, existingSvc)
+	r := newPoolReconciler(c, false)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	svc := &corev1.Service{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, svc); err != nil {
+		t.Fatalf("Service not found: %v", err)
+	}
+
+	if svc.Spec.Ports[0].Port != 9140 {
+		t.Errorf("Service was not updated: port = %d, want 9140", svc.Spec.Ports[0].Port)
+	}
+}

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -1,0 +1,344 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// serverPrereqs returns standard prerequisite objects for Server reconcile tests.
+func serverPrereqs() []client.Object {
+	return []client.Object{
+		newConfig("production", withAuthorityRef("production-ca")),
+		newConfigMap("production-config", map[string]string{
+			"puppet.conf": "[main]\n", "puppetdb.conf": "", "webserver.conf": "",
+			"webserver-ca.conf": "", "puppetserver.conf": "", "auth.conf": "",
+			"ca.conf": "", "product.conf": "", "logback.xml": "", "metrics.conf": "",
+			"ca-enabled.cfg": "", "ca-disabled.cfg": "",
+		}),
+		newCertificate("production-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned),
+		newCertificateAuthority("production-ca"),
+		newSecret("production-cert-tls", map[string][]byte{
+			"cert.pem": []byte("cert"), "key.pem": []byte("key"),
+		}),
+		newSecret("production-ca-ca", map[string][]byte{
+			"ca_crt.pem": []byte("ca-cert"),
+		}),
+	}
+}
+
+func TestServerReconcile_NotFound(t *testing.T) {
+	c := setupTestClient()
+	r := newServerReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("nonexistent"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Error("expected no requeue for missing Server")
+	}
+}
+
+func TestServerReconcile_ConfigNotFound(t *testing.T) {
+	server := newServer("test-server")
+	c := setupTestClient(server)
+	r := newServerReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("test-server"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 5*time.Second {
+		t.Errorf("expected requeue after 5s, got %v", res.RequeueAfter)
+	}
+}
+
+func TestServerReconcile_CertificateNotSigned(t *testing.T) {
+	cfg := newConfig("production")
+	cert := newCertificate("production-cert", "production-ca", openvoxv1alpha1.CertificatePhasePending)
+	server := newServer("test-server")
+
+	c := setupTestClient(cfg, cert, server)
+	r := newServerReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("test-server"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 10*time.Second {
+		t.Errorf("expected requeue after 10s, got %v", res.RequeueAfter)
+	}
+
+	updated := &openvoxv1alpha1.Server{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Server: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.ServerPhaseWaitingForCert {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.ServerPhaseWaitingForCert, updated.Status.Phase)
+	}
+}
+
+func TestServerReconcile_BasicDeployment(t *testing.T) {
+	objs := append(serverPrereqs(), newServer("test-server", withReplicas(3)))
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("Deployment not created: %v", err)
+	}
+
+	if deploy.Spec.Replicas == nil || *deploy.Spec.Replicas != 3 {
+		t.Errorf("expected 3 replicas, got %v", deploy.Spec.Replicas)
+	}
+	if deploy.Spec.Selector == nil || deploy.Spec.Selector.MatchLabels[LabelServer] != "test-server" {
+		t.Error("deployment selector missing server label")
+	}
+	if deploy.Spec.Template.Labels[LabelServer] != "test-server" {
+		t.Error("pod template missing server label")
+	}
+	if deploy.Spec.Template.Labels[LabelConfig] != "production" {
+		t.Error("pod template missing config label")
+	}
+}
+
+func TestServerReconcile_DeploymentStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     []serverOption
+		strategy appsv1.DeploymentStrategyType
+	}{
+		{
+			name:     "server uses RollingUpdate",
+			opts:     []serverOption{withServerRole(true), withCA(false)},
+			strategy: appsv1.RollingUpdateDeploymentStrategyType,
+		},
+		{
+			name:     "CA uses Recreate",
+			opts:     []serverOption{withServerRole(false), withCA(true)},
+			strategy: appsv1.RecreateDeploymentStrategyType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := append(serverPrereqs(), newServer("test-server", tt.opts...))
+			c := setupTestClient(objs...)
+			r := newServerReconciler(c)
+
+			if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+				t.Fatalf("reconcile error: %v", err)
+			}
+
+			deploy := &appsv1.Deployment{}
+			if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+				t.Fatalf("Deployment not found: %v", err)
+			}
+			if deploy.Spec.Strategy.Type != tt.strategy {
+				t.Errorf("expected strategy %q, got %q", tt.strategy, deploy.Spec.Strategy.Type)
+			}
+		})
+	}
+}
+
+func TestServerReconcile_AnnotationHashes(t *testing.T) {
+	objs := append(serverPrereqs(), newServer("test-server"))
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	annotations := deploy.Spec.Template.Annotations
+	for _, key := range []string{
+		"openvox.voxpupuli.org/config-hash",
+		"openvox.voxpupuli.org/ssl-secret-hash",
+		"openvox.voxpupuli.org/ca-secret-hash",
+	} {
+		if v, ok := annotations[key]; !ok || v == "" {
+			t.Errorf("annotation %q missing or empty", key)
+		}
+	}
+}
+
+func TestServerReconcile_PDBCreation(t *testing.T) {
+	objs := append(serverPrereqs(), newServer("test-server", withPDBEnabled(true)))
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, pdb); err != nil {
+		t.Fatalf("PDB not created: %v", err)
+	}
+
+	if pdb.Spec.MinAvailable == nil {
+		t.Fatal("PDB minAvailable not set (expected default)")
+	}
+	if pdb.Spec.Selector == nil || pdb.Spec.Selector.MatchLabels[LabelServer] != "test-server" {
+		t.Error("PDB selector incorrect")
+	}
+}
+
+func TestServerReconcile_PDBDeletion(t *testing.T) {
+	existingPDB := &policyv1.PodDisruptionBudget{}
+	existingPDB.Name = "test-server"
+	existingPDB.Namespace = testNamespace
+
+	objs := append(serverPrereqs(), newServer("test-server"), existingPDB)
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, pdb)
+	if err == nil {
+		t.Error("PDB should have been deleted")
+	}
+}
+
+func TestServerReconcile_HPACreation(t *testing.T) {
+	objs := append(serverPrereqs(), newServer("test-server", withAutoscaling(true)))
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, hpa); err != nil {
+		t.Fatalf("HPA not created: %v", err)
+	}
+
+	if hpa.Spec.MaxReplicas != 5 {
+		t.Errorf("expected maxReplicas=5 (default), got %d", hpa.Spec.MaxReplicas)
+	}
+	if len(hpa.Spec.Metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(hpa.Spec.Metrics))
+	}
+	if hpa.Spec.Metrics[0].Resource == nil || hpa.Spec.Metrics[0].Resource.Target.AverageUtilization == nil {
+		t.Fatal("expected CPU utilization metric")
+	}
+	if *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization != 75 {
+		t.Errorf("expected targetCPU=75 (default), got %d", *hpa.Spec.Metrics[0].Resource.Target.AverageUtilization)
+	}
+}
+
+func TestServerReconcile_HPADeletion(t *testing.T) {
+	existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+	existingHPA.Name = "test-server"
+	existingHPA.Namespace = testNamespace
+
+	objs := append(serverPrereqs(), newServer("test-server"), existingHPA)
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, hpa)
+	if err == nil {
+		t.Error("HPA should have been deleted")
+	}
+}
+
+func TestServerReconcile_AutoscalingNoReplicas(t *testing.T) {
+	objs := append(serverPrereqs(), newServer("test-server", withAutoscaling(true), withReplicas(3)))
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	if deploy.Spec.Replicas != nil {
+		t.Errorf("when HPA is enabled, replicas should not be set, got %d", *deploy.Spec.Replicas)
+	}
+}
+
+func TestServerReconcile_StatusPhase(t *testing.T) {
+	tests := []struct {
+		name          string
+		readyReplicas int32
+		wantPhase     openvoxv1alpha1.ServerPhase
+	}{
+		{
+			name:          "running with ready replicas",
+			readyReplicas: 2,
+			wantPhase:     openvoxv1alpha1.ServerPhaseRunning,
+		},
+		{
+			name:          "pending with zero ready",
+			readyReplicas: 0,
+			wantPhase:     openvoxv1alpha1.ServerPhasePending,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := append(serverPrereqs(), newServer("test-server"))
+			c := setupTestClient(objs...)
+			r := newServerReconciler(c)
+
+			// First reconcile to create the Deployment
+			if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+				t.Fatalf("first reconcile error: %v", err)
+			}
+
+			// Update Deployment status with ready replicas
+			deploy := &appsv1.Deployment{}
+			if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+				t.Fatalf("Deployment not found: %v", err)
+			}
+			deploy.Status.ReadyReplicas = tt.readyReplicas
+			if err := c.Status().Update(testCtx(), deploy); err != nil {
+				t.Fatalf("failed to update Deployment status: %v", err)
+			}
+
+			// Reconcile again to pick up status
+			if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+				t.Fatalf("second reconcile error: %v", err)
+			}
+
+			updated := &openvoxv1alpha1.Server{}
+			if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, updated); err != nil {
+				t.Fatalf("failed to get Server: %v", err)
+			}
+			if updated.Status.Phase != tt.wantPhase {
+				t.Errorf("expected phase %q, got %q", tt.wantPhase, updated.Status.Phase)
+			}
+		})
+	}
+}

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -42,7 +42,7 @@ func TestServerReconcile_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Requeue || res.RequeueAfter != 0 {
+	if res.RequeueAfter != 0 {
 		t.Error("expected no requeue for missing Server")
 	}
 }

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -1,0 +1,400 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// testBuildPodSpec is a helper that constructs a PodSpec using buildPodSpec with reasonable defaults.
+func testBuildPodSpec(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) corev1.PodSpec {
+	cert := &openvoxv1alpha1.Certificate{
+		Spec: openvoxv1alpha1.CertificateSpec{
+			AuthorityRef: "production-ca",
+			Certname:     "puppet",
+		},
+	}
+	cert.Status.Phase = openvoxv1alpha1.CertificatePhaseSigned
+	cert.Status.SecretName = "production-cert-tls"
+
+	ca := newCertificateAuthority("production-ca")
+
+	image := resolveImage(server, cfg)
+	javaArgs := resolveJavaArgs(server)
+	maxActive := server.Spec.MaxActiveInstances
+	if maxActive <= 0 {
+		maxActive = 1
+	}
+	javaArgs = fmt.Sprintf("%s -Djruby-puppet.max-active-instances=%d", javaArgs, maxActive)
+	configMapName := fmt.Sprintf("%s-config", server.Spec.ConfigRef)
+
+	r := &ServerReconciler{Scheme: testScheme()}
+	return r.buildPodSpec(server, cfg, cert, ca, image, javaArgs, configMapName)
+}
+
+func TestBuildPodSpec_ServerRole(t *testing.T) {
+	cfg := newConfig("production", withCodeImage("ghcr.io/slauger/puppet-code:latest"))
+	server := newServer("test-server", withServerRole(true), withCA(false))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	// Server role should have code volume
+	found := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == "code" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("server pod should have code volume")
+	}
+
+	// Server role should NOT have CA PVC
+	for _, v := range podSpec.Volumes {
+		if v.Name == "ca-data" {
+			t.Error("server pod should not have CA data PVC")
+		}
+	}
+}
+
+func TestBuildPodSpec_CARole(t *testing.T) {
+	cfg := newConfig("production")
+	server := newServer("test-server", withCA(true), withServerRole(false))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	// CA should have ca-data PVC
+	found := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == "ca-data" {
+			found = true
+			if v.PersistentVolumeClaim == nil {
+				t.Error("ca-data should be a PVC")
+			} else if v.PersistentVolumeClaim.ClaimName != "production-ca-data" {
+				t.Errorf("expected PVC name %q, got %q", "production-ca-data", v.PersistentVolumeClaim.ClaimName)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("CA pod should have ca-data volume")
+	}
+
+	// CA should have autosign-policy mount
+	hasAutosign := false
+	for _, vm := range podSpec.Containers[0].VolumeMounts {
+		if vm.Name == "autosign-policy" {
+			hasAutosign = true
+			break
+		}
+	}
+	if !hasAutosign {
+		t.Error("CA pod should have autosign-policy volume mount")
+	}
+
+	// CA should use webserver-ca.conf (via ca.conf key mapping)
+	hasWebserverCA := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == "webserver-conf" && v.ConfigMap != nil {
+			for _, item := range v.ConfigMap.Items {
+				if item.Key == "webserver-ca.conf" {
+					hasWebserverCA = true
+				}
+			}
+		}
+	}
+	if !hasWebserverCA {
+		t.Error("CA pod should use webserver-ca.conf")
+	}
+
+	// CA should NOT have code volume (server=false)
+	for _, v := range podSpec.Volumes {
+		if v.Name == "code" {
+			t.Error("CA-only pod should not have code volume")
+		}
+	}
+}
+
+func TestBuildPodSpec_CodeVolumeImage(t *testing.T) {
+	cfg := newConfig("production", withCodeImage("ghcr.io/slauger/puppet-code:v1.0"))
+	server := newServer("test-server", withServerRole(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	for _, v := range podSpec.Volumes {
+		if v.Name == "code" {
+			if v.Image == nil {
+				t.Fatal("code volume should be an image volume")
+			}
+			if v.Image.Reference != "ghcr.io/slauger/puppet-code:v1.0" {
+				t.Errorf("expected code image %q, got %q", "ghcr.io/slauger/puppet-code:v1.0", v.Image.Reference)
+			}
+			return
+		}
+	}
+	t.Error("code volume not found")
+}
+
+func TestBuildPodSpec_CodeVolumePVC(t *testing.T) {
+	cfg := newConfig("production", withCodePVC("puppet-code-pvc"))
+	server := newServer("test-server", withServerRole(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	for _, v := range podSpec.Volumes {
+		if v.Name == "code" {
+			if v.PersistentVolumeClaim == nil {
+				t.Fatal("code volume should be a PVC")
+			}
+			if v.PersistentVolumeClaim.ClaimName != "puppet-code-pvc" {
+				t.Errorf("expected PVC name %q, got %q", "puppet-code-pvc", v.PersistentVolumeClaim.ClaimName)
+			}
+			if !v.PersistentVolumeClaim.ReadOnly {
+				t.Error("code PVC should be read-only")
+			}
+			return
+		}
+	}
+	t.Error("code volume not found")
+}
+
+func TestBuildPodSpec_NoCodeVolume(t *testing.T) {
+	cfg := newConfig("production") // no code spec
+	server := newServer("test-server", withServerRole(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	for _, v := range podSpec.Volumes {
+		if v.Name == "code" {
+			t.Error("pod should not have code volume when no code spec is set")
+		}
+	}
+}
+
+func TestBuildPodSpec_ReadOnlyRootFilesystem(t *testing.T) {
+	cfg := newConfig("production", withReadOnlyRootFS(true))
+	server := newServer("test-server")
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	sc := podSpec.Containers[0].SecurityContext
+	if sc == nil || sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		t.Error("readOnlyRootFilesystem should be true")
+	}
+}
+
+func TestBuildPodSpec_SecurityContext(t *testing.T) {
+	cfg := newConfig("production")
+	server := newServer("test-server")
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	// Pod-level security context
+	psc := podSpec.SecurityContext
+	if psc == nil {
+		t.Fatal("pod security context is nil")
+	}
+	if psc.RunAsUser == nil || *psc.RunAsUser != 1001 {
+		t.Errorf("expected RunAsUser=1001, got %v", psc.RunAsUser)
+	}
+	if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
+		t.Error("expected RunAsNonRoot=true")
+	}
+	if psc.SeccompProfile == nil || psc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("expected Seccomp RuntimeDefault")
+	}
+
+	// Container-level security context
+	csc := podSpec.Containers[0].SecurityContext
+	if csc == nil {
+		t.Fatal("container security context is nil")
+	}
+	if csc.Capabilities == nil || len(csc.Capabilities.Drop) == 0 {
+		t.Error("expected capabilities Drop ALL")
+	} else if csc.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("expected Drop ALL, got %v", csc.Capabilities.Drop)
+	}
+	if csc.AllowPrivilegeEscalation == nil || *csc.AllowPrivilegeEscalation {
+		t.Error("expected AllowPrivilegeEscalation=false")
+	}
+}
+
+func TestBuildPodSpec_ENCVolumes(t *testing.T) {
+	cfg := newConfig("production", withNodeClassifierRef("my-enc"))
+	server := newServer("test-server", withServerRole(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	hasENCConfig := false
+	hasENCCache := false
+	for _, v := range podSpec.Volumes {
+		switch v.Name {
+		case "enc-config":
+			hasENCConfig = true
+			if v.Secret == nil || v.Secret.SecretName != "production-enc" {
+				t.Errorf("enc-config volume should reference Secret %q", "production-enc")
+			}
+		case "enc-cache":
+			hasENCCache = true
+			if v.EmptyDir == nil {
+				t.Error("enc-cache should be emptyDir")
+			}
+		}
+	}
+	if !hasENCConfig {
+		t.Error("missing enc-config volume")
+	}
+	if !hasENCCache {
+		t.Error("missing enc-cache volume")
+	}
+}
+
+func TestBuildPodSpec_PoolLabels(t *testing.T) {
+	server := newServer("test-server", withPoolRefs("pool-a", "pool-b"))
+
+	// Pool labels are set at the deployment level via reconcileDeployment,
+	// so we test via a full reconcile.
+	objs := append(serverPrereqs(), server)
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	for _, poolName := range []string{"pool-a", "pool-b"} {
+		label := poolLabel(poolName)
+		if deploy.Spec.Template.Labels[label] != "true" {
+			t.Errorf("pod template missing pool label %q", label)
+		}
+	}
+}
+
+func TestBuildPodSpec_InitContainer(t *testing.T) {
+	cfg := newConfig("production")
+	server := newServer("test-server")
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	if len(podSpec.InitContainers) == 0 {
+		t.Fatal("expected at least one init container")
+	}
+
+	initC := podSpec.InitContainers[0]
+	if initC.Name != "tls-init" {
+		t.Errorf("expected init container name %q, got %q", "tls-init", initC.Name)
+	}
+
+	// Check that tls-init mounts ssl, ssl-cert, ssl-ca
+	mountNames := make(map[string]bool)
+	for _, vm := range initC.VolumeMounts {
+		mountNames[vm.Name] = true
+	}
+	for _, name := range []string{"ssl", "ssl-cert", "ssl-ca"} {
+		if !mountNames[name] {
+			t.Errorf("tls-init missing volume mount %q", name)
+		}
+	}
+}
+
+func TestBuildPodSpec_Probes(t *testing.T) {
+	cfg := newConfig("production")
+	server := newServer("test-server")
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	container := podSpec.Containers[0]
+	if container.StartupProbe == nil {
+		t.Fatal("startup probe is nil")
+	}
+	if container.StartupProbe.PeriodSeconds != 5 {
+		t.Errorf("startup probe period = %d, want 5", container.StartupProbe.PeriodSeconds)
+	}
+	if container.StartupProbe.FailureThreshold != 60 {
+		t.Errorf("startup probe failure threshold = %d, want 60", container.StartupProbe.FailureThreshold)
+	}
+
+	if container.ReadinessProbe == nil {
+		t.Fatal("readiness probe is nil")
+	}
+	if container.ReadinessProbe.PeriodSeconds != 10 {
+		t.Errorf("readiness probe period = %d, want 10", container.ReadinessProbe.PeriodSeconds)
+	}
+
+	if container.LivenessProbe == nil {
+		t.Fatal("liveness probe is nil")
+	}
+	if container.LivenessProbe.PeriodSeconds != 30 {
+		t.Errorf("liveness probe period = %d, want 30", container.LivenessProbe.PeriodSeconds)
+	}
+
+	// All probes should check /status/v1/simple via HTTPS
+	for name, probe := range map[string]*corev1.Probe{
+		"startup":   container.StartupProbe,
+		"readiness": container.ReadinessProbe,
+		"liveness":  container.LivenessProbe,
+	} {
+		if probe.HTTPGet == nil {
+			t.Errorf("%s probe missing HTTPGet", name)
+			continue
+		}
+		if probe.HTTPGet.Path != "/status/v1/simple" {
+			t.Errorf("%s probe path = %q, want /status/v1/simple", name, probe.HTTPGet.Path)
+		}
+		if probe.HTTPGet.Scheme != corev1.URISchemeHTTPS {
+			t.Errorf("%s probe scheme = %q, want HTTPS", name, probe.HTTPGet.Scheme)
+		}
+	}
+}
+
+func TestResolveJavaArgs_Default(t *testing.T) {
+	server := &openvoxv1alpha1.Server{
+		Spec: openvoxv1alpha1.ServerSpec{},
+	}
+	got := resolveJavaArgs(server)
+	if got != "-Xms512m -Xmx1024m" {
+		t.Errorf("resolveJavaArgs() = %q, want %q", got, "-Xms512m -Xmx1024m")
+	}
+}
+
+func TestResolveJavaArgs_Explicit(t *testing.T) {
+	server := &openvoxv1alpha1.Server{
+		Spec: openvoxv1alpha1.ServerSpec{
+			JavaArgs: "-Xms1g -Xmx2g",
+		},
+	}
+	got := resolveJavaArgs(server)
+	if got != "-Xms1g -Xmx2g" {
+		t.Errorf("resolveJavaArgs() = %q, want %q", got, "-Xms1g -Xmx2g")
+	}
+}
+
+func TestResolveJavaArgs_FromMemoryLimit(t *testing.T) {
+	server := &openvoxv1alpha1.Server{
+		Spec: openvoxv1alpha1.ServerSpec{
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+	}
+	got := resolveJavaArgs(server)
+	// 4Gi = 4294967296 bytes, 90% = 3865470566 bytes, /1024/1024 = 3686 MB
+	expected := fmt.Sprintf("-Xms%dm -Xmx%dm", 3686, 3686)
+	if got != expected {
+		t.Errorf("resolveJavaArgs() = %q, want %q", got, expected)
+	}
+}

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -461,7 +461,7 @@ func newDeployment(name string, readyReplicas int32) *appsv1.Deployment {
 	}
 }
 
-// Unused import guards – ensures the test scheme includes all necessary API groups.
+// Unused import guards -- ensures the test scheme includes all necessary API groups.
 var (
 	_ = &appsv1.Deployment{}
 	_ = &autoscalingv2.HorizontalPodAutoscaler{}

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -1,0 +1,471 @@
+package controller
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+const testNamespace = "default"
+
+// testScheme returns a runtime.Scheme with all types needed by the controllers.
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(openvoxv1alpha1.AddToScheme(s))
+	utilruntime.Must(gwapiv1.Install(s))
+	return s
+}
+
+// setupTestClient creates a fake client pre-loaded with the given objects.
+// StatusSubresource is enabled for all CRD types that use status updates.
+func setupTestClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(
+			&openvoxv1alpha1.Config{},
+			&openvoxv1alpha1.Server{},
+			&openvoxv1alpha1.Pool{},
+			&openvoxv1alpha1.Certificate{},
+			&openvoxv1alpha1.CertificateAuthority{},
+			&openvoxv1alpha1.SigningPolicy{},
+			&openvoxv1alpha1.NodeClassifier{},
+			&openvoxv1alpha1.ReportProcessor{},
+		).
+		Build()
+}
+
+// testRecorder returns a fake event recorder.
+func testRecorder() events.EventRecorder {
+	return events.NewFakeRecorder(100)
+}
+
+// testRequest returns a ctrl.Request for the given name in the test namespace.
+func testRequest(name string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: name, Namespace: testNamespace},
+	}
+}
+
+// testCtx returns a background context.
+func testCtx() context.Context {
+	return context.Background()
+}
+
+// --- Object builders ---
+
+type configOption func(*openvoxv1alpha1.Config)
+
+func newConfig(name string, opts ...configOption) *openvoxv1alpha1.Config {
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: openvoxv1alpha1.ConfigSpec{
+			Image: openvoxv1alpha1.ImageSpec{
+				Repository: "ghcr.io/slauger/openvox-server",
+				Tag:        "latest",
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			Puppet: openvoxv1alpha1.PuppetSpec{
+				EnvironmentTimeout: "unlimited",
+				EnvironmentPath:    "/etc/puppetlabs/code/environments",
+				HieraConfig:        "$confdir/hiera.yaml",
+				Storeconfigs:       true,
+				StoreBackend:       "puppetdb",
+				Reports:            "puppetdb",
+			},
+		},
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+	return cfg
+}
+
+func withAuthorityRef(ref string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.AuthorityRef = ref
+	}
+}
+
+func withNodeClassifierRef(ref string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.NodeClassifierRef = ref
+	}
+}
+
+func withReadOnlyRootFS(v bool) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.ReadOnlyRootFilesystem = v
+	}
+}
+
+func withCodeImage(image string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.Code = &openvoxv1alpha1.CodeSpec{Image: image}
+	}
+}
+
+func withCodePVC(claimName string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.Code = &openvoxv1alpha1.CodeSpec{ClaimName: claimName}
+	}
+}
+
+func withLogging(level string, loggers map[string]string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.Logging = &openvoxv1alpha1.LoggingSpec{
+			Level:   level,
+			Loggers: loggers,
+		}
+	}
+}
+
+func withAuthorizationRules(rules []openvoxv1alpha1.AuthorizationRule) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.PuppetServer.AuthorizationRules = rules
+	}
+}
+
+func withPuppetServerSpec(ps openvoxv1alpha1.PuppetServerSpec) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.PuppetServer = ps
+	}
+}
+
+func withPuppetSpec(p openvoxv1alpha1.PuppetSpec) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.Puppet = p
+	}
+}
+
+type serverOption func(*openvoxv1alpha1.Server)
+
+func newServer(name string, opts ...serverOption) *openvoxv1alpha1.Server {
+	replicas := int32(1)
+	s := &openvoxv1alpha1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: openvoxv1alpha1.ServerSpec{
+			ConfigRef:      "production",
+			CertificateRef: "production-cert",
+			Server:         true,
+			CA:             false,
+			Replicas:       &replicas,
+		},
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+func withConfigRef(ref string) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.ConfigRef = ref
+	}
+}
+
+func withCertificateRef(ref string) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.CertificateRef = ref
+	}
+}
+
+func withCA(ca bool) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.CA = ca
+		if ca && !s.Spec.Server {
+			s.Spec.Server = false
+		}
+	}
+}
+
+func withServerRole(server bool) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.Server = server
+	}
+}
+
+func withReplicas(r int32) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.Replicas = &r
+	}
+}
+
+func withPoolRefs(refs ...string) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.PoolRefs = refs
+	}
+}
+
+func withPDBEnabled(enabled bool) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.PDB = &openvoxv1alpha1.PDBSpec{Enabled: enabled}
+	}
+}
+
+func withAutoscaling(enabled bool) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.Autoscaling = openvoxv1alpha1.AutoscalingSpec{Enabled: enabled}
+	}
+}
+
+func withJavaArgs(args string) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.JavaArgs = args
+	}
+}
+
+func withResources(res corev1.ResourceRequirements) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.Resources = res
+	}
+}
+
+func withServerCodeImage(image string) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.Code = &openvoxv1alpha1.CodeSpec{Image: image}
+	}
+}
+
+type poolOption func(*openvoxv1alpha1.Pool)
+
+func newPool(name string, opts ...poolOption) *openvoxv1alpha1.Pool {
+	p := &openvoxv1alpha1.Pool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+func withServicePort(port int32) poolOption {
+	return func(p *openvoxv1alpha1.Pool) {
+		p.Spec.Service.Port = port
+	}
+}
+
+func withServiceType(t corev1.ServiceType) poolOption {
+	return func(p *openvoxv1alpha1.Pool) {
+		p.Spec.Service.Type = t
+	}
+}
+
+func withServiceAnnotations(a map[string]string) poolOption {
+	return func(p *openvoxv1alpha1.Pool) {
+		p.Spec.Service.Annotations = a
+	}
+}
+
+func withRoute(enabled bool, hostname, gwName string) poolOption {
+	return func(p *openvoxv1alpha1.Pool) {
+		p.Spec.Route = &openvoxv1alpha1.PoolRouteSpec{
+			Enabled:  enabled,
+			Hostname: hostname,
+			GatewayRef: openvoxv1alpha1.GatewayReference{
+				Name: gwName,
+			},
+		}
+	}
+}
+
+func newCertificate(name, authorityRef string, phase openvoxv1alpha1.CertificatePhase) *openvoxv1alpha1.Certificate {
+	cert := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: openvoxv1alpha1.CertificateSpec{
+			AuthorityRef: authorityRef,
+			Certname:     "puppet",
+		},
+	}
+	cert.Status.Phase = phase
+	if phase == openvoxv1alpha1.CertificatePhaseSigned {
+		cert.Status.SecretName = name + "-tls"
+	}
+	return cert
+}
+
+func newCertificateAuthority(name string) *openvoxv1alpha1.CertificateAuthority {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+			TTL:                          "5y",
+			AllowSubjectAltNames:         true,
+			AllowAuthorizationExtensions: true,
+			EnableInfraCRL:               true,
+			AllowAutoRenewal:             true,
+			AutoRenewalCertTTL:           "90d",
+		},
+	}
+	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseReady
+	ca.Status.CASecretName = name + "-ca"
+	return ca
+}
+
+func newSigningPolicy(name, caRef string, any bool) *openvoxv1alpha1.SigningPolicy {
+	return &openvoxv1alpha1.SigningPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: openvoxv1alpha1.SigningPolicySpec{
+			CertificateAuthorityRef: caRef,
+			Any:                     any,
+		},
+	}
+}
+
+func newNodeClassifier(name, url string) *openvoxv1alpha1.NodeClassifier {
+	return &openvoxv1alpha1.NodeClassifier{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: openvoxv1alpha1.NodeClassifierSpec{
+			URL: url,
+			Request: openvoxv1alpha1.NodeClassifierRequest{
+				Method: "GET",
+				Path:   "/node/{certname}",
+			},
+			Response: openvoxv1alpha1.NodeClassifierResponse{
+				Format: "yaml",
+			},
+			TimeoutSeconds: 10,
+		},
+	}
+}
+
+func newReportProcessor(name, configRef, url string) *openvoxv1alpha1.ReportProcessor {
+	return &openvoxv1alpha1.ReportProcessor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: openvoxv1alpha1.ReportProcessorSpec{
+			ConfigRef:      configRef,
+			URL:            url,
+			TimeoutSeconds: 30,
+		},
+	}
+}
+
+func newSecret(name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Data: data,
+	}
+}
+
+func newConfigMap(name string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Data: data,
+	}
+}
+
+func newEndpointSlice(name, serviceName string, readyCount int) *discoveryv1.EndpointSlice {
+	eps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				"kubernetes.io/service-name": serviceName,
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+	}
+	ready := true
+	for i := 0; i < readyCount; i++ {
+		eps.Endpoints = append(eps.Endpoints, discoveryv1.Endpoint{
+			Conditions: discoveryv1.EndpointConditions{
+				Ready: &ready,
+			},
+		})
+	}
+	return eps
+}
+
+// --- Convenience for reconcilers ---
+
+func newConfigReconciler(c client.Client) *ConfigReconciler {
+	return &ConfigReconciler{
+		Client:   c,
+		Scheme:   testScheme(),
+		Recorder: testRecorder(),
+	}
+}
+
+func newServerReconciler(c client.Client) *ServerReconciler {
+	return &ServerReconciler{
+		Client:   c,
+		Scheme:   testScheme(),
+		Recorder: testRecorder(),
+	}
+}
+
+func newPoolReconciler(c client.Client, gatewayAPI bool) *PoolReconciler {
+	return &PoolReconciler{
+		Client:              c,
+		Scheme:              testScheme(),
+		GatewayAPIAvailable: gatewayAPI,
+	}
+}
+
+// --- Fake deployment helper for status tests ---
+
+func newDeployment(name string, readyReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: readyReplicas,
+		},
+	}
+}
+
+// Unused import guards – ensures the test scheme includes all necessary API groups.
+var (
+	_ = &appsv1.Deployment{}
+	_ = &autoscalingv2.HorizontalPodAutoscaler{}
+	_ = &policyv1.PodDisruptionBudget{}
+	_ = &discoveryv1.EndpointSlice{}
+	_ = &gwapiv1.TLSRoute{}
+)

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -3,11 +3,8 @@ package controller
 import (
 	"context"
 
-	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -180,18 +177,6 @@ func newServer(name string, opts ...serverOption) *openvoxv1alpha1.Server {
 	return s
 }
 
-func withConfigRef(ref string) serverOption {
-	return func(s *openvoxv1alpha1.Server) {
-		s.Spec.ConfigRef = ref
-	}
-}
-
-func withCertificateRef(ref string) serverOption {
-	return func(s *openvoxv1alpha1.Server) {
-		s.Spec.CertificateRef = ref
-	}
-}
-
 func withCA(ca bool) serverOption {
 	return func(s *openvoxv1alpha1.Server) {
 		s.Spec.CA = ca
@@ -228,24 +213,6 @@ func withPDBEnabled(enabled bool) serverOption {
 func withAutoscaling(enabled bool) serverOption {
 	return func(s *openvoxv1alpha1.Server) {
 		s.Spec.Autoscaling = openvoxv1alpha1.AutoscalingSpec{Enabled: enabled}
-	}
-}
-
-func withJavaArgs(args string) serverOption {
-	return func(s *openvoxv1alpha1.Server) {
-		s.Spec.JavaArgs = args
-	}
-}
-
-func withResources(res corev1.ResourceRequirements) serverOption {
-	return func(s *openvoxv1alpha1.Server) {
-		s.Spec.Resources = res
-	}
-}
-
-func withServerCodeImage(image string) serverOption {
-	return func(s *openvoxv1alpha1.Server) {
-		s.Spec.Code = &openvoxv1alpha1.CodeSpec{Image: image}
 	}
 }
 
@@ -447,25 +414,3 @@ func newPoolReconciler(c client.Client, gatewayAPI bool) *PoolReconciler {
 	}
 }
 
-// --- Fake deployment helper for status tests ---
-
-func newDeployment(name string, readyReplicas int32) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
-		},
-		Status: appsv1.DeploymentStatus{
-			ReadyReplicas: readyReplicas,
-		},
-	}
-}
-
-// Unused import guards -- ensures the test scheme includes all necessary API groups.
-var (
-	_ = &appsv1.Deployment{}
-	_ = &autoscalingv2.HorizontalPodAutoscaler{}
-	_ = &policyv1.PodDisruptionBudget{}
-	_ = &discoveryv1.EndpointSlice{}
-	_ = &gwapiv1.TLSRoute{}
-)


### PR DESCRIPTION
## Summary

- Add happy-path unit tests for `ConfigReconciler`, `ServerReconciler`, and `PoolReconciler` using the fake client (no envtest/etcd required)
- Add direct unit tests for `buildPodSpec` and `resolveJavaArgs`
- Add shared test infrastructure (`testutil_test.go`) with scheme setup, fake client factory, and object builders

## Test coverage

| File | Tests | Coverage highlights |
|------|-------|-------------------|
| `config_controller_test.go` | 14 | ConfigMap creation, puppet.conf/puppetserver.conf/auth.conf/logback.xml rendering, autosign/ENC/report-webhook Secrets |
| `server_controller_test.go` | 12 | Deployment creation/strategy, PDB/HPA lifecycle, annotation hashes, status phase transitions |
| `server_deployment_test.go` | 14 | Server/CA roles, code volumes, security context, ENC volumes, pool labels, init container, probes, JVM args |
| `pool_controller_test.go` | 10 | Service creation/update, custom port/type/annotations, endpoint count, TLSRoute create/disable/conflict |

## Test plan

- [x] `go test ./internal/controller/ -v -count=1` — all 50 new tests pass
- [x] `go vet ./internal/controller/` — no issues
- [x] Coverage: `buildPodSpec` 97.9%, `resolveJavaArgs` 100%, `renderPuppetConf` 93.8%, `reconcileService` 83%

Closes #31