### PR TITLE
refactor: extract hardcoded timeouts and defaults into constants

### DIFF
--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -77,7 +76,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if statusErr := r.Status().Update(ctx, cert); statusErr != nil {
 			logger.Error(statusErr, "failed to update Certificate status", "name", cert.Name)
 		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
 	}
 
 	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
@@ -126,7 +125,7 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 	caServiceName := findCAServiceName(ctx, r.Client, ca, cert.Namespace)
 	if caServiceName == "" {
 		logger.Info("waiting for CA server to become available")
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
 	}
 
 	cert.Status.Phase = openvoxv1alpha1.CertificatePhaseRequesting
@@ -151,7 +150,7 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 		if result.RequeueAfter > 0 {
 			return result, nil
 		}
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
 	}
 
 	if result.RequeueAfter > 0 {

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +28,7 @@ import (
 // caHTTPClient returns an HTTP client for talking to the Puppet CA (internal, self-signed).
 func caHTTPClient() *http.Client {
 	return &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: HTTPClientTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // internal CA
 		},
@@ -59,7 +58,7 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 
 	if len(keyPEM) == 0 {
 		// Generate new RSA 4096-bit key
-		privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+		privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("generating RSA key: %w", err)
 		}
@@ -122,17 +121,17 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, fmt.Errorf("submitting CSR: %w", err)
+		return ctrl.Result{RequeueAfter: RequeueIntervalLong}, fmt.Errorf("submitting CSR: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
 	if resp.StatusCode == http.StatusOK {
 		logger.Info("CSR submitted successfully", "certname", certname)
 	} else if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "already has a requested certificate") {
 		logger.Info("CSR already pending", "certname", certname)
 	} else {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, fmt.Errorf("CA rejected CSR (HTTP %d): %s", resp.StatusCode, string(body))
+		return ctrl.Result{RequeueAfter: RequeueIntervalCRL}, fmt.Errorf("CA rejected CSR (HTTP %d): %s", resp.StatusCode, string(body))
 	}
 
 	return ctrl.Result{}, nil
@@ -161,7 +160,7 @@ func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openv
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
 
 	if resp.StatusCode == http.StatusOK && len(body) > 0 {
 		block, _ := pem.Decode(body)
@@ -188,12 +187,12 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 	signedCertPEM, err := r.fetchSignedCert(ctx, cert, caServiceName, namespace)
 	if err != nil {
 		logger.Info("failed to fetch signed cert, will retry", "error", err)
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
 	}
 
 	if signedCertPEM == nil {
 		logger.Info("certificate not yet signed, will retry", "certname", cert.Spec.Certname)
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
 
 	// Step 3: Cert is signed -- read key from pending Secret and create TLS Secret

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -77,7 +77,7 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 	cfg := r.findConfigForCA(ctx, ca)
 	if cfg == nil {
 		logger.Info("waiting for a Config with authorityRef pointing to this CA", "ca", ca.Name)
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
 
 	// Step 1: Ensure CA data PVC exists
@@ -132,7 +132,7 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 	if err != nil {
 		logger.Info("CRL refresh failed, will retry", "error", err)
 		r.Recorder.Eventf(ca, nil, corev1.EventTypeWarning, EventReasonCRLRefreshFailed, "Reconcile", "CRL refresh failed: %v", err)
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalCRL}, nil
 	}
 	return crlResult, nil
 }
@@ -189,7 +189,7 @@ func (r *CertificateAuthorityReconciler) SetupWithManager(mgr ctrl.Manager) erro
 func (r *CertificateAuthorityReconciler) reconcileCRLRefresh(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	interval := 5 * time.Minute
+	interval := DefaultCRLRefreshInterval
 	if ca.Spec.CRLRefreshInterval != "" {
 		parsed, err := time.ParseDuration(ca.Spec.CRLRefreshInterval)
 		if err != nil {
@@ -222,7 +222,7 @@ func (r *CertificateAuthorityReconciler) reconcileCRLRefresh(ctx context.Context
 // fetchCRL retrieves the CRL from the CA HTTP API.
 func (r *CertificateAuthorityReconciler) fetchCRL(ctx context.Context, caServiceName, namespace string) ([]byte, error) {
 	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: HTTPClientTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // internal CA
 		},
@@ -241,7 +241,7 @@ func (r *CertificateAuthorityReconciler) fetchCRL(ctx context.Context, caService
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
 	if err != nil {
 		return nil, fmt.Errorf("reading CRL response: %w", err)
 	}
@@ -290,7 +290,7 @@ func (r *CertificateAuthorityReconciler) reconcileCAPVC(ctx context.Context, ca 
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: ca.Namespace}, pvc)
 	if errors.IsNotFound(err) {
-		storageSize := "1Gi"
+		storageSize := DefaultCAStorageGi
 		if ca.Spec.Storage.Size != "" {
 			storageSize = ca.Spec.Storage.Size
 		}
@@ -538,7 +538,7 @@ func (r *CertificateAuthorityReconciler) reconcileCASetupJob(ctx context.Context
 
 func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, cfg *openvoxv1alpha1.Config, jobName string, certs []openvoxv1alpha1.Certificate) *batchv1.Job {
 	image := fmt.Sprintf("%s:%s", cfg.Spec.Image.Repository, cfg.Spec.Image.Tag)
-	backoffLimit := int32(3)
+	backoffLimit := CAJobBackoffLimit
 	saName := fmt.Sprintf("%s-ca-setup", ca.Name)
 	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
 	labels := caLabels(ca.Name)
@@ -590,8 +590,8 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 					ServiceAccountName: saName,
 					RestartPolicy:      corev1.RestartPolicyNever,
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsUser:    int64Ptr(1001),
-						RunAsGroup:   int64Ptr(0),
+						RunAsUser:    int64Ptr(CASetupRunAsUser),
+						RunAsGroup:   int64Ptr(CASetupRunAsGroup),
 						RunAsNonRoot: boolPtr(true),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -812,7 +812,7 @@ func (r *CertificateAuthorityReconciler) reconcileJob(ctx context.Context, ca *o
 		if err := r.Create(ctx, desiredJob); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
 	} else if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -843,7 +843,7 @@ func (r *CertificateAuthorityReconciler) reconcileJob(ctx context.Context, ca *o
 		}
 	}
 
-	return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
 }
 
 func (r *CertificateAuthorityReconciler) deleteAndRequeueJob(ctx context.Context, job *batchv1.Job, reason string) (ctrl.Result, error) {
@@ -852,7 +852,7 @@ func (r *CertificateAuthorityReconciler) deleteAndRequeueJob(ctx context.Context
 	if err := r.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagation}); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
 }
 
 // extractCANotAfter reads the ca_crt.pem from the CA Secret and returns its NotAfter time.

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -1,0 +1,40 @@
+package controller
+
+import "time"
+
+// Requeue intervals for controller reconciliation loops.
+const (
+	RequeueIntervalShort  = 5 * time.Second
+	RequeueIntervalMedium = 10 * time.Second
+	RequeueIntervalLong   = 15 * time.Second
+	RequeueIntervalCRL    = 30 * time.Second
+)
+
+// HTTP client configuration.
+const (
+	HTTPClientTimeout = 30 * time.Second
+	HTTPBodyLimit     = 10 * 1024 * 1024 // 10 MB
+)
+
+// Default CRL refresh interval when not configured on the CertificateAuthority.
+const DefaultCRLRefreshInterval = 5 * time.Minute
+
+// RSA key size for certificate signing requests.
+const RSAKeySize = 4096
+
+// CA setup Job defaults.
+const (
+	CAJobBackoffLimit   = int32(3)
+	DefaultCAStorageGi  = "1Gi"
+	CASetupRunAsUser    = int64(1001)
+	CASetupRunAsGroup   = int64(0)
+	ServerRunAsUser     = int64(1001)
+	ServerRunAsGroup    = int64(0)
+)
+
+// HPA and PDB defaults for Server resources.
+const (
+	DefaultHPAMaxReplicas = int32(5)
+	DefaultHPATargetCPU   = int32(75)
+	DefaultPDBMinAvailable = 1
+)

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -79,7 +78,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.ConfigRef, Namespace: server.Namespace}, cfg); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("waiting for Config", "configRef", server.Spec.ConfigRef)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -89,7 +88,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.CertificateRef, Namespace: server.Namespace}, cert); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("waiting for Certificate", "certificateRef", server.Spec.CertificateRef)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -100,7 +99,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if statusErr := r.Status().Update(ctx, server); statusErr != nil {
 			logger.Error(statusErr, "failed to update Server status", "name", server.Name)
 		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
 	}
 
 	// Resolve CertificateAuthority (needed for CA PVC name when ca: true)
@@ -108,7 +107,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: server.Namespace}, ca); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("waiting for CertificateAuthority", "authorityRef", cert.Spec.AuthorityRef)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -226,7 +225,7 @@ func (r *ServerReconciler) buildPDB(server *openvoxv1alpha1.Server) (*policyv1.P
 		pdb.Spec.MaxUnavailable = server.Spec.PDB.MaxUnavailable
 	} else {
 		// Default: minAvailable: 1
-		minAvailable := intstrInt(1)
+		minAvailable := intstrInt(DefaultPDBMinAvailable)
 		pdb.Spec.MinAvailable = &minAvailable
 	}
 	if err := controllerutil.SetControllerReference(server, pdb, r.Scheme); err != nil {
@@ -282,11 +281,11 @@ func (r *ServerReconciler) buildHPA(server *openvoxv1alpha1.Server) (*autoscalin
 	as := server.Spec.Autoscaling
 	targetCPU := as.TargetCPU
 	if targetCPU == 0 {
-		targetCPU = 75
+		targetCPU = DefaultHPATargetCPU
 	}
 	maxReplicas := as.MaxReplicas
 	if maxReplicas == 0 {
-		maxReplicas = 5
+		maxReplicas = DefaultHPAMaxReplicas
 	}
 
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -456,8 +456,8 @@ chmod 640 /ssl/private_keys/puppet.pem`
 		ServiceAccountName:           fmt.Sprintf("%s-server", server.Spec.ConfigRef),
 		AutomountServiceAccountToken: &automountServiceAccountToken,
 		SecurityContext: &corev1.PodSecurityContext{
-			RunAsUser:    int64Ptr(1001),
-			RunAsGroup:   int64Ptr(0),
+			RunAsUser:    int64Ptr(ServerRunAsUser),
+			RunAsGroup:   int64Ptr(ServerRunAsGroup),
 			RunAsNonRoot: boolPtr(true),
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,


### PR DESCRIPTION
## Summary

- Add `internal/controller/constants.go` with named constants for all hardcoded values across controllers
- Replace 20+ magic numbers with named constants: requeue intervals (`5s`/`10s`/`15s`/`30s`), HTTP client timeout (`30s`), HTTP body limit (`10MB`), RSA key size (`4096`), CA Job backoff limit (`3`), default CA storage (`1Gi`), HPA defaults (max replicas `5`, target CPU `75`), PDB default (min available `1`), and RunAsUser/RunAsGroup (`1001`/`0`)
- Remove unused `time` imports from `certificate_controller.go`, `certificate_signing.go`, and `server_controller.go`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes
- [ ] CI pipeline passes

Closes #119