### PR TITLE
fix: add error logging to helper functions that silently return nil

### DIFF
--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -135,7 +135,7 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 
 	result, err := r.signCertificate(ctx, cert, ca, caServiceName, cert.Namespace)
 	if err != nil {
-		logger.Info("certificate signing failed, will retry", "error", err)
+		logger.Error(err, "certificate signing failed, will retry")
 		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseError
 		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
 			Type:               openvoxv1alpha1.ConditionCertSigned,
@@ -211,8 +211,11 @@ func (r *CertificateReconciler) adoptTLSSecret(ctx context.Context, cert *openvo
 func (r *CertificateReconciler) extractNotAfter(ctx context.Context, secretName, namespace string) *metav1.Time {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+		if !errors.IsNotFound(err) {
+			log.FromContext(ctx).Error(err, "failed to get TLS Secret", "name", secretName, "namespace", namespace)
+		}
 		return nil
 	}
-	return parseCertNotAfter(secret.Data["cert.pem"])
+	return parseCertNotAfter(ctx, secret.Data["cert.pem"])
 }
 

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -125,7 +125,10 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
+	if err != nil {
+		logger.Error(err, "failed to read CSR response body")
+	}
 	if resp.StatusCode == http.StatusOK {
 		logger.Info("CSR submitted successfully", "certname", certname)
 	} else if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "already has a requested certificate") {
@@ -160,7 +163,10 @@ func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openv
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to read certificate response body")
+	}
 
 	if resp.StatusCode == http.StatusOK && len(body) > 0 {
 		block, _ := pem.Decode(body)

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -133,6 +133,7 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 func (r *CertificateAuthorityReconciler) findConfigForCA(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority) *openvoxv1alpha1.Config {
 	cfgList := &openvoxv1alpha1.ConfigList{}
 	if err := r.List(ctx, cfgList, client.InNamespace(ca.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list Configs", "namespace", ca.Namespace)
 		return nil
 	}
 	for i := range cfgList.Items {
@@ -178,7 +179,10 @@ func (r *CertificateAuthorityReconciler) SetupWithManager(mgr ctrl.Manager) erro
 func (r *CertificateAuthorityReconciler) extractCANotAfter(ctx context.Context, secretName, namespace string) *metav1.Time {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+		if !errors.IsNotFound(err) {
+			log.FromContext(ctx).Error(err, "failed to get CA Secret", "name", secretName, "namespace", namespace)
+		}
 		return nil
 	}
-	return parseCertNotAfter(secret.Data["ca_crt.pem"])
+	return parseCertNotAfter(ctx, secret.Data["ca_crt.pem"])
 }

--- a/internal/controller/certificateauthority_job.go
+++ b/internal/controller/certificateauthority_job.go
@@ -39,9 +39,12 @@ func (r *CertificateAuthorityReconciler) findCertificatesForCA(ctx context.Conte
 // findCAServerCert finds the Certificate belonging to the Server with ca:true.
 // This is the cert that should be signed during CA setup.
 func (r *CertificateAuthorityReconciler) findCAServerCert(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, certs []openvoxv1alpha1.Certificate) *openvoxv1alpha1.Certificate {
+	logger := log.FromContext(ctx)
+
 	// Build set of Config names referencing this CA
 	cfgList := &openvoxv1alpha1.ConfigList{}
 	if err := r.List(ctx, cfgList, client.InNamespace(ca.Namespace)); err != nil {
+		logger.Error(err, "failed to list Configs for CA server cert discovery", "namespace", ca.Namespace)
 		return nil
 	}
 	configNames := map[string]bool{}
@@ -53,6 +56,7 @@ func (r *CertificateAuthorityReconciler) findCAServerCert(ctx context.Context, c
 
 	serverList := &openvoxv1alpha1.ServerList{}
 	if err := r.List(ctx, serverList, client.InNamespace(ca.Namespace)); err != nil {
+		logger.Error(err, "failed to list Servers for CA server cert discovery", "namespace", ca.Namespace)
 		return nil
 	}
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -81,9 +82,12 @@ func hashStringMap(data map[string]string) string {
 // 3. Finding a Pool referenced by the CA server's poolRefs
 // 4. Returning the first matching Pool name as service name
 func findCAServiceName(ctx context.Context, reader client.Reader, ca *openvoxv1alpha1.CertificateAuthority, namespace string) string {
+	logger := log.FromContext(ctx)
+
 	// Build set of Config names referencing this CA
 	cfgList := &openvoxv1alpha1.ConfigList{}
 	if err := reader.List(ctx, cfgList, client.InNamespace(namespace)); err != nil {
+		logger.Error(err, "failed to list Configs for CA service discovery", "namespace", namespace)
 		return ""
 	}
 	configNames := map[string]bool{}
@@ -95,6 +99,7 @@ func findCAServiceName(ctx context.Context, reader client.Reader, ca *openvoxv1a
 
 	serverList := &openvoxv1alpha1.ServerList{}
 	if err := reader.List(ctx, serverList, client.InNamespace(namespace)); err != nil {
+		logger.Error(err, "failed to list Servers for CA service discovery", "namespace", namespace)
 		return ""
 	}
 
@@ -114,13 +119,17 @@ func findCAServiceName(ctx context.Context, reader client.Reader, ca *openvoxv1a
 }
 
 // parseCertNotAfter extracts the NotAfter time from a PEM-encoded certificate.
-func parseCertNotAfter(certPEM []byte) *metav1.Time {
+func parseCertNotAfter(ctx context.Context, certPEM []byte) *metav1.Time {
+	logger := log.FromContext(ctx)
+
 	block, _ := pem.Decode(certPEM)
 	if block == nil || block.Type != "CERTIFICATE" {
+		logger.Error(fmt.Errorf("expected PEM block type CERTIFICATE"), "failed to decode certificate PEM")
 		return nil
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
+		logger.Error(err, "failed to parse X.509 certificate")
 		return nil
 	}
 	t := metav1.NewTime(cert.NotAfter.UTC().Truncate(time.Second))
@@ -131,6 +140,9 @@ func parseCertNotAfter(certPEM []byte) *metav1.Time {
 func isSecretReady(ctx context.Context, reader client.Reader, name, namespace, requiredKey string) bool {
 	secret := &corev1.Secret{}
 	if err := reader.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		if !errors.IsNotFound(err) {
+			log.FromContext(ctx).Error(err, "failed to get Secret", "name", name, "namespace", namespace)
+		}
 		return false
 	}
 	if requiredKey != "" {


### PR DESCRIPTION
## Summary
- Add structured error logging to helper functions that previously discarded errors silently, making debugging nearly impossible
- API errors are logged at Error level; expected conditions (NotFound) remain silent
- Upgrade `logger.Info` to `logger.Error` for certificate signing failures

## Changes
- **helpers.go**: Log errors in `findCAServiceName()` List calls, `parseCertNotAfter()` parse failures (added `ctx` param), and non-existent import for `log`
- **certificateauthority_controller.go**: Log errors in `findConfigForCA()`, `findCAServerCert()`, and `extractCANotAfter()` (NotFound excluded)
- **certificate_controller.go**: Log errors in `extractNotAfter()` (NotFound excluded), fix signing error log level
- **certificate_signing.go**: Check and log `io.ReadAll` errors in `submitCSR()` and `fetchSignedCert()`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/controller/...` passes

Closes #115