### PR TITLE
feat: add resource limits to CA setup Job

### DIFF
--- a/api/v1alpha1/certificateauthority_types.go
+++ b/api/v1alpha1/certificateauthority_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -70,6 +71,11 @@ type CertificateAuthoritySpec struct {
 	// Storage defines the PVC settings for CA data.
 	// +optional
 	Storage StorageSpec `json:"storage,omitempty"`
+
+	// Resources defines the compute resources for the CA setup Job.
+	// If not specified, defaults are applied (requests: 200m CPU, 768Mi memory; limits: 1 CPU, 1Gi memory).
+	// +optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// CRLRefreshInterval defines how often the operator fetches the CRL from the CA
 	// and updates the CRL Secret. Only applies to non-CA servers.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -150,7 +150,7 @@ func (in *CertificateAuthority) DeepCopyInto(out *CertificateAuthority) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 }
 
@@ -208,6 +208,7 @@ func (in *CertificateAuthorityList) DeepCopyObject() runtime.Object {
 func (in *CertificateAuthoritySpec) DeepCopyInto(out *CertificateAuthoritySpec) {
 	*out = *in
 	out.Storage = in.Storage
+	in.Resources.DeepCopyInto(&out.Resources)
 	out.IntermediateCA = in.IntermediateCA
 }
 

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -101,6 +101,67 @@ spec:
                 required:
                 - enabled
                 type: object
+              resources:
+                description: |-
+                  Resources defines the compute resources for the CA setup Job.
+                  If not specified, defaults are applied (requests: 200m CPU, 768Mi memory; limits: 1 CPU, 1Gi memory).
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
               storage:
                 description: Storage defines the PVC settings for CA data.
                 properties:

--- a/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -101,6 +101,67 @@ spec:
                 required:
                 - enabled
                 type: object
+              resources:
+                description: |-
+                  Resources defines the compute resources for the CA setup Job.
+                  If not specified, defaults are applied (requests: 200m CPU, 768Mi memory; limits: 1 CPU, 1Gi memory).
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
               storage:
                 description: Storage defines the PVC settings for CA data.
                 properties:

--- a/config/samples/certificateauthority.yaml
+++ b/config/samples/certificateauthority.yaml
@@ -11,3 +11,10 @@ spec:
   autoRenewalCertTTL: 90d
   storage:
     size: 1Gi
+  # resources:
+  #   requests:
+  #     cpu: 200m
+  #     memory: 768Mi
+  #   limits:
+  #     cpu: "1"
+  #     memory: 1Gi

--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -28,6 +28,7 @@ Autosigning is configured via [SigningPolicy](signingpolicy.md) resources that r
 | `allowAutoRenewal` | bool | `true` | Allow agents to automatically renew certificates before expiry |
 | `autoRenewalCertTTL` | string | `90d` | TTL threshold for automatic certificate renewal (duration: `90d`, `30d`, `2160h`) |
 | `crlRefreshInterval` | string | `5m` | How often the operator refreshes the CRL Secret from the CA (Go duration: `5m`, `1h`, `30s`) |
+| `resources` | [ResourceRequirements](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) | requests: 200m/768Mi, limits: 1/1Gi | Compute resources for the CA setup Job |
 | `storage` | [StorageSpec](index.md#storagespec) | - | PVC settings for CA data |
 | `intermediateCA` | [IntermediateCASpec](#intermediatecaspec) | - | Intermediate CA configuration |
 

--- a/internal/controller/certificateauthority_job.go
+++ b/internal/controller/certificateauthority_job.go
@@ -8,6 +8,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -173,6 +174,7 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 							ImagePullPolicy: cfg.Spec.Image.PullPolicy,
 							Command:         []string{"/bin/bash", "-c", script},
 							Env:             envVars,
+							Resources:       resolveCAJobResources(ca),
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "ca-data", MountPath: "/etc/puppetlabs/puppetserver/ca"},
 								{Name: "ssl", MountPath: "/etc/puppetlabs/puppet/ssl"},
@@ -227,6 +229,23 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 					},
 				},
 			},
+		},
+	}
+}
+
+// resolveCAJobResources returns the user-specified resources or sensible defaults for the JVM-based CA setup Job.
+func resolveCAJobResources(ca *openvoxv1alpha1.CertificateAuthority) corev1.ResourceRequirements {
+	if len(ca.Spec.Resources.Requests) > 0 || len(ca.Spec.Resources.Limits) > 0 {
+		return ca.Spec.Resources
+	}
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(DefaultCAJobCPURequest),
+			corev1.ResourceMemory: resource.MustParse(DefaultCAJobMemoryRequest),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(DefaultCAJobCPULimit),
+			corev1.ResourceMemory: resource.MustParse(DefaultCAJobMemoryLimit),
 		},
 	}
 }

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -32,6 +32,14 @@ const (
 	ServerRunAsGroup    = int64(0)
 )
 
+// CA setup Job resource defaults (JRuby/JVM workload).
+const (
+	DefaultCAJobCPURequest    = "200m"
+	DefaultCAJobMemoryRequest = "768Mi"
+	DefaultCAJobCPULimit      = "1"
+	DefaultCAJobMemoryLimit   = "1Gi"
+)
+
 // HPA and PDB defaults for Server resources.
 const (
 	DefaultHPAMaxReplicas = int32(5)


### PR DESCRIPTION
## Summary
- Add optional `spec.resources` field to the CertificateAuthority CRD for configuring compute resources on the CA setup Job
- Apply sensible defaults for the JRuby/JVM workload (requests: 200m CPU, 768Mi memory; limits: 1 CPU, 1Gi memory)
- Users can override defaults by setting `spec.resources` on the CertificateAuthority CR

Closes #117 (part 1)

## Test plan
- [x] `make generate manifests` succeeds
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/controller/...` passes
- [ ] Deploy operator and verify CA setup Job has resource requests/limits
- [ ] Verify custom `spec.resources` overrides the defaults