### PR TITLE
fix: requeue when NotAfter cannot be extracted (#114)

### DIFF
--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -102,6 +102,9 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 		r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateSigned, "Reconcile", "Certificate signed and available in Secret %s", tlsSecretName)
+		if cert.Status.NotAfter == nil {
+			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -175,6 +178,9 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 		return ctrl.Result{}, err
 	}
 
+	if cert.Status.NotAfter == nil {
+		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -119,6 +119,12 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 		r.Recorder.Eventf(ca, nil, corev1.EventTypeNormal, EventReasonCAInitialized, "Reconcile", "CA is initialized and ready")
 	}
 
+	// Requeue if NotAfter could not be extracted (informer cache may not have synced yet)
+	if ca.Status.NotAfter == nil {
+		logger.Info("NotAfter not yet available, requeueing", "secret", caSecretName)
+		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
+	}
+
 	// Periodic CRL refresh: fetch CRL from CA service and update the CRL secret
 	crlResult, err := r.reconcileCRLRefresh(ctx, ca)
 	if err != nil {


### PR DESCRIPTION
## Summary
- When the CA setup Job creates secrets via the Kubernetes API, the controller informer cache may not have synced yet
- If `NotAfter` is `nil` after extraction, requeue after a short interval (5s) so it gets populated on the next reconcile
- Applies to all three code paths: CertificateAuthority ready, Certificate adopted, and Certificate signed

Fixes #114

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/controller/...` passes
- [ ] Deploy operator and verify NotAfter column shows valid dates after CA setup