### PR TITLE
fix: use CA certificate for TLS verification instead of InsecureSkipVerify

### DIFF
--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -50,14 +50,33 @@ func csrPollBackoff(attempts int) time.Duration {
 	}
 }
 
-// caHTTPClient returns an HTTP client for talking to the Puppet CA (internal, self-signed).
-func caHTTPClient() *http.Client {
+// caHTTPClient returns an HTTP client that trusts only the given CA certificate
+// for communication with the Puppet CA service.
+func caHTTPClient(caCertPEM []byte) (*http.Client, error) {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCertPEM) {
+		return nil, fmt.Errorf("failed to parse CA certificate PEM")
+	}
 	return &http.Client{
 		Timeout: HTTPClientTimeout,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // internal CA
+			TLSClientConfig: &tls.Config{RootCAs: pool},
 		},
+	}, nil
+}
+
+// getCAPublicCert reads the CA public certificate from the CA Secret.
+func (r *CertificateReconciler) getCAPublicCert(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, namespace string) ([]byte, error) {
+	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: caSecretName, Namespace: namespace}, secret); err != nil {
+		return nil, fmt.Errorf("getting CA Secret %s: %w", caSecretName, err)
 	}
+	certPEM := secret.Data["ca_crt.pem"]
+	if len(certPEM) == 0 {
+		return nil, fmt.Errorf("CA Secret %s has no ca_crt.pem data", caSecretName)
+	}
+	return certPEM, nil
 }
 
 // submitCSR generates an RSA key (or reuses an existing one from a pending Secret),
@@ -132,7 +151,14 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 	}
 	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 
-	httpClient := caHTTPClient()
+	caCertPEM, err := r.getCAPublicCert(ctx, ca, namespace)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, fmt.Errorf("loading CA certificate: %w", err)
+	}
+	httpClient, err := caHTTPClient(caCertPEM)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("creating CA HTTP client: %w", err)
+	}
 	caBaseURL := fmt.Sprintf("https://%s.%s.svc:8140", caServiceName, namespace)
 	csrURL := fmt.Sprintf("%s/puppet-ca/v1/certificate_request/%s?environment=production", caBaseURL, certname)
 
@@ -166,13 +192,20 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 }
 
 // fetchSignedCert checks if the CA has signed the certificate. Returns the PEM cert or nil.
-func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openvoxv1alpha1.Certificate, caServiceName, namespace string) ([]byte, error) {
+func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caServiceName, namespace string) ([]byte, error) {
 	certname := cert.Spec.Certname
 	if certname == "" {
 		certname = "puppet"
 	}
 
-	httpClient := caHTTPClient()
+	caCertPEM, err := r.getCAPublicCert(ctx, ca, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("loading CA certificate: %w", err)
+	}
+	httpClient, err := caHTTPClient(caCertPEM)
+	if err != nil {
+		return nil, fmt.Errorf("creating CA HTTP client: %w", err)
+	}
 	caBaseURL := fmt.Sprintf("https://%s.%s.svc:8140", caServiceName, namespace)
 	certURL := fmt.Sprintf("%s/puppet-ca/v1/certificate/%s?environment=production", caBaseURL, certname)
 
@@ -215,7 +248,7 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 	}
 
 	// Step 2: Check if cert is signed (non-blocking, single attempt)
-	signedCertPEM, err := r.fetchSignedCert(ctx, cert, caServiceName, namespace)
+	signedCertPEM, err := r.fetchSignedCert(ctx, cert, ca, caServiceName, namespace)
 	if err != nil {
 		logger.Info("failed to fetch signed cert, will retry", "error", err)
 		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil

--- a/internal/controller/certificateauthority_crl.go
+++ b/internal/controller/certificateauthority_crl.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -34,7 +35,7 @@ func (r *CertificateAuthorityReconciler) reconcileCRLRefresh(ctx context.Context
 		return ctrl.Result{RequeueAfter: interval}, nil
 	}
 
-	crlPEM, err := r.fetchCRL(ctx, caServiceName, ca.Namespace)
+	crlPEM, err := r.fetchCRL(ctx, ca, caServiceName, ca.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("fetching CRL: %w", err)
 	}
@@ -49,9 +50,30 @@ func (r *CertificateAuthorityReconciler) reconcileCRLRefresh(ctx context.Context
 	return ctrl.Result{RequeueAfter: interval}, nil
 }
 
+// getCAPublicCert reads the CA public certificate from the CA Secret.
+func (r *CertificateAuthorityReconciler) getCAPublicCert(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, namespace string) ([]byte, error) {
+	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: caSecretName, Namespace: namespace}, secret); err != nil {
+		return nil, fmt.Errorf("getting CA Secret %s: %w", caSecretName, err)
+	}
+	certPEM := secret.Data["ca_crt.pem"]
+	if len(certPEM) == 0 {
+		return nil, fmt.Errorf("CA Secret %s has no ca_crt.pem data", caSecretName)
+	}
+	return certPEM, nil
+}
+
 // fetchCRL retrieves the CRL from the CA HTTP API.
-func (r *CertificateAuthorityReconciler) fetchCRL(ctx context.Context, caServiceName, namespace string) ([]byte, error) {
-	httpClient := caHTTPClient()
+func (r *CertificateAuthorityReconciler) fetchCRL(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, caServiceName, namespace string) ([]byte, error) {
+	caCertPEM, err := r.getCAPublicCert(ctx, ca, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("loading CA certificate: %w", err)
+	}
+	httpClient, err := caHTTPClient(caCertPEM)
+	if err != nil {
+		return nil, fmt.Errorf("creating CA HTTP client: %w", err)
+	}
 
 	crlURL := fmt.Sprintf("https://%s.%s.svc:8140/puppet-ca/v1/certificate_revocation_list/ca?environment=production", caServiceName, namespace)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, crlURL, nil)


### PR DESCRIPTION
## Summary
- Replace InsecureSkipVerify with proper TLS verification using the CA own certificate from the {name}-ca Secret
- Applies to all three HTTP communication paths: CSR submission, signed certificate fetching, and CRL refresh
- Each reconciler loads ca_crt.pem from the CA Secret and uses it as the trusted root CA in the HTTP client

Fixes #80

## Test plan
- [x] go build ./... passes
- [x] go vet ./... passes
- [x] go test ./internal/controller/... passes
- [ ] Deploy operator and verify CSR submission works with TLS verification
- [ ] Verify CRL refresh works with TLS verification
- [ ] Verify certificate signing flow completes successfully