### PR TITLE
docs: document CA internal service

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -47,13 +47,15 @@ By separating the CA lifecycle (`CertificateAuthority`) from certificate signing
 
 The Certificate Authority is managed by the CertificateAuthority controller:
 
-1. The CertificateAuthority controller creates a **PVC** for CA data and a **Job** that runs `puppetserver ca setup`
+1. The CertificateAuthority controller creates a **PVC** for CA data, an internal **ClusterIP Service** (`{name}-internal`), and a **Job** that runs `puppetserver ca setup`
 2. The Job stores CA keys on the PVC and creates three Kubernetes **Secrets**:
    - `{name}-ca` -- public CA certificate (`ca_crt.pem`)
    - `{name}-ca-key` -- CA private key (`ca_key.pem`, never mounted in pods)
    - `{name}-ca-crl` -- CRL data (`ca_crl.pem`, `infra_crl.pem`)
 3. The CertificateAuthority transitions to the `Ready` phase
-4. The controller periodically fetches the CRL from the CA HTTP API and updates the CRL Secret (configurable via `crlRefreshInterval`, default `5m`)
+4. The controller periodically fetches the CRL from the internal Service and updates the CRL Secret (configurable via `crlRefreshInterval`, default `5m`)
+
+The internal Service (`{name}-internal`) is used exclusively by the operator for CSR signing and CRL refresh. Its FQDN is automatically added as a SAN to the CA server certificate. This is separate from the Pool Service, which users can configure as ClusterIP, LoadBalancer, or NodePort for external access.
 
 ## Certificate Lifecycle
 

--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -16,6 +16,7 @@ sequenceDiagram
 
     User->>Operator: Create CertificateAuthority
     Operator->>K8s: Create PVC ({ca}-data)
+    Operator->>K8s: Create Service ({ca}-internal)
     Operator->>K8s: Create ServiceAccount + RBAC
     Operator->>K8s: Create Job ({ca}-setup)
     Job->>PVC: Run puppetserver ca setup
@@ -88,14 +89,12 @@ The pending Secret ensures idempotency: if the controller restarts mid-signing, 
 
 ### Service Discovery
 
-The Certificate controller discovers the CA server endpoint automatically:
+The Certificate controller connects to the CA via the internal Service created by the CertificateAuthority controller:
 
-1. Find all Configs with `authorityRef` pointing to the CA
-2. Find a Server with `ca: true` referencing one of those Configs
-3. Use the first `poolRef` as the Kubernetes Service name
-4. Endpoint: `https://{pool-name}.{namespace}.svc:8140`
+- **Internal CA:** `https://{ca-name}-internal.{namespace}.svc:8140`
+- **External CA:** Uses the URL from `spec.external.url`
 
-No manual URL configuration is needed.
+The internal Service FQDN is automatically added as a SAN to the CA server certificate during CA setup, so TLS validation works without manual configuration. No Pool or Server discovery is needed.
 
 ## CRL Distribution
 

--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -48,6 +48,8 @@ Autosigning is configured via [SigningPolicy](signingpolicy.md) resources that r
 |---|---|---|
 | `phase` | string | Current lifecycle phase |
 | `caSecretName` | string | Name of the Secret containing `ca_crt.pem` (public CA certificate) |
+| `serviceName` | string | Name of the internal ClusterIP Service for operator communication |
+| `notAfter` | time | Expiry time of the CA certificate |
 | `conditions` | []Condition | `CAReady` |
 
 ## Phases
@@ -57,6 +59,7 @@ Autosigning is configured via [SigningPolicy](signingpolicy.md) resources that r
 | `Pending` | CertificateAuthority created, waiting for reconciliation |
 | `Initializing` | CA setup Job is running |
 | `Ready` | CA Secrets created, Certificates can be signed |
+| `External` | External CA configured (no PVC, Job, or internal Service) |
 | `Error` | CA setup failed |
 
 ## CA Secrets
@@ -90,10 +93,17 @@ sequenceDiagram
     Srv->>Srv: TLS handshake uses new CRL
 ```
 
+## Internal Service
+
+The CertificateAuthority controller creates a dedicated ClusterIP Service named `{name}-internal` for operator-internal communication (CSR signing and CRL refresh). This Service is separate from any Pool Service so that users can freely configure the Pool's Service type (ClusterIP, LoadBalancer, NodePort) without conflicting with the operator.
+
+The internal Service FQDN (`{name}-internal.{namespace}.svc`) is automatically added as a SAN to the CA server certificate during setup, so TLS validation succeeds without manual configuration.
+
 ## Created Resources
 
 | Resource | Name | Description |
 |---|---|---|
+| Service | `{name}-internal` | Internal ClusterIP Service for operator communication (port 8140) |
 | PVC | `{name}-data` | Persistent storage for CA keys and data |
 | ServiceAccount | `{name}-ca-setup` | Job ServiceAccount with permission to create CA Secrets |
 | Role | `{name}-ca-setup` | Scoped to CA Secret creation |


### PR DESCRIPTION
## Summary

- Add Internal Service section to CertificateAuthority reference (`{name}-internal` ClusterIP)
- Add `serviceName` and `notAfter` to status table, `External` to phases
- Update certificate-signing service discovery docs (old Pool-based chain → direct internal Service)
- Update architecture CA lifecycle to mention internal Service and SAN injection