### PR TITLE
feat: operator-driven certificate signing for internal CAs

### DIFF
--- a/api/v1alpha1/certificateauthority_types.go
+++ b/api/v1alpha1/certificateauthority_types.go
@@ -150,6 +150,12 @@ type CertificateAuthorityStatus struct {
 	// +optional
 	ServiceName string `json:"serviceName,omitempty"`
 
+	// SigningSecretName is the name of the TLS Secret used for mTLS authentication
+	// when signing certificates via the CA HTTP API. This Secret contains a certificate
+	// with the pp_cli_auth extension.
+	// +optional
+	SigningSecretName string `json:"signingSecretName,omitempty"`
+
 	// NotAfter is the expiration time of the CA certificate.
 	// +optional
 	NotAfter *metav1.Time `json:"notAfter,omitempty"`

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -302,6 +302,12 @@ spec:
                   ServiceName is the name of the ClusterIP Service created for internal operator
                   communication with the CA (CSR signing, CRL refresh).
                 type: string
+              signingSecretName:
+                description: |-
+                  SigningSecretName is the name of the TLS Secret used for mTLS authentication
+                  when signing certificates via the CA HTTP API. This Secret contains a certificate
+                  with the pp_cli_auth extension.
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -302,6 +302,12 @@ spec:
                   ServiceName is the name of the ClusterIP Service created for internal operator
                   communication with the CA (CSR signing, CRL refresh).
                 type: string
+              signingSecretName:
+                description: |-
+                  SigningSecretName is the name of the TLS Secret used for mTLS authentication
+                  when signing certificates via the CA HTTP API. This Secret contains a certificate
+                  with the pp_cli_auth extension.
+                type: string
             type: object
         type: object
     served: true

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -47,13 +47,15 @@ By separating the CA lifecycle (`CertificateAuthority`) from certificate signing
 
 The Certificate Authority is managed by the CertificateAuthority controller:
 
-1. The CertificateAuthority controller creates a **PVC** for CA data and a **Job** that runs `puppetserver ca setup`
+1. The CertificateAuthority controller creates a **PVC** for CA data, an internal **ClusterIP Service** (`{name}-internal`), and a **Job** that runs `puppetserver ca setup`
 2. The Job stores CA keys on the PVC and creates three Kubernetes **Secrets**:
    - `{name}-ca` -- public CA certificate (`ca_crt.pem`)
    - `{name}-ca-key` -- CA private key (`ca_key.pem`, never mounted in pods)
    - `{name}-ca-crl` -- CRL data (`ca_crl.pem`, `infra_crl.pem`)
 3. The CertificateAuthority transitions to the `Ready` phase
-4. The controller periodically fetches the CRL from the CA HTTP API and updates the CRL Secret (configurable via `crlRefreshInterval`, default `5m`)
+4. The controller periodically fetches the CRL from the internal Service and updates the CRL Secret (configurable via `crlRefreshInterval`, default `5m`)
+
+The internal Service (`{name}-internal`) is used exclusively by the operator for CSR signing and CRL refresh. Its FQDN is automatically added as a SAN to the CA server certificate. This is separate from the Pool Service, which users can configure as ClusterIP, LoadBalancer, or NodePort for external access.
 
 ## Certificate Lifecycle
 

--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -66,10 +66,17 @@ sequenceDiagram
     Cert->>K8s: Store key in {cert}-tls-pending Secret
     Cert->>CA: PUT /puppet-ca/v1/certificate_request/{certname}
     CA-->>Cert: 200 OK (CSR accepted)
-
-    loop Poll every 5s
+    Cert->>CA: GET /puppet-ca/v1/certificate/{certname}
+    alt Auto-signed (SigningPolicy matched)
+        CA-->>Cert: Signed certificate
+    else Not auto-signed (internal CA)
+        CA-->>Cert: No certificate yet
+        Cert->>K8s: Read signing Secret (CA server cert with pp_cli_auth)
+        Cert->>CA: PUT /puppet-ca/v1/certificate_status/{certname} (mTLS)
+        Note right of Cert: {"desired_state": "signed"}
+        CA-->>Cert: 204 No Content
         Cert->>CA: GET /puppet-ca/v1/certificate/{certname}
-        CA-->>Cert: Signed certificate (when ready)
+        CA-->>Cert: Signed certificate
     end
 
     Cert->>K8s: Create {cert}-tls Secret (cert.pem + key.pem)
@@ -82,8 +89,11 @@ The controller:
 1. Generates an RSA 4096-bit private key and stores it in a temporary `{cert}-tls-pending` Secret
 2. Creates a CSR with the configured `certname` and `dnsAltNames`
 3. Submits the CSR via HTTP PUT to the CA server's Puppetserver API
-4. Polls for the signed certificate via HTTP GET (every 5 seconds)
-5. Once signed, creates the final `{cert}-tls` Secret and deletes the pending Secret
+4. Checks if the certificate was auto-signed (e.g. by a matching SigningPolicy)
+5. If not auto-signed and the CA has a signing secret (`status.signingSecretName`), the operator signs the CSR directly via the CA HTTP API using mTLS with the CA server's own certificate (which has the `pp_cli_auth` extension required by `auth.conf`)
+6. Once signed, creates the final `{cert}-tls` Secret and deletes the pending Secret
+
+For **external CAs** (where `spec.external` is set), the operator does not attempt to sign the CSR itself. Instead, it falls back to polling until the certificate is signed externally or via the external CA's own autosign mechanism.
 
 The pending Secret ensures idempotency: if the controller restarts mid-signing, it reuses the same key instead of generating a new one.
 

--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -16,6 +16,7 @@ sequenceDiagram
 
     User->>Operator: Create CertificateAuthority
     Operator->>K8s: Create PVC ({ca}-data)
+    Operator->>K8s: Create Service ({ca}-internal)
     Operator->>K8s: Create ServiceAccount + RBAC
     Operator->>K8s: Create Job ({ca}-setup)
     Job->>PVC: Run puppetserver ca setup
@@ -88,14 +89,12 @@ The pending Secret ensures idempotency: if the controller restarts mid-signing, 
 
 ### Service Discovery
 
-The Certificate controller discovers the CA server endpoint automatically:
+The Certificate controller connects to the CA via the internal Service created by the CertificateAuthority controller:
 
-1. Find all Configs with `authorityRef` pointing to the CA
-2. Find a Server with `ca: true` referencing one of those Configs
-3. Use the first `poolRef` as the Kubernetes Service name
-4. Endpoint: `https://{pool-name}.{namespace}.svc:8140`
+- **Internal CA:** `https://{ca-name}-internal.{namespace}.svc:8140`
+- **External CA:** Uses the URL from `spec.external.url`
 
-No manual URL configuration is needed.
+The internal Service FQDN is automatically added as a SAN to the CA server certificate during CA setup, so TLS validation works without manual configuration. No Pool or Server discovery is needed.
 
 ## CRL Distribution
 

--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -48,6 +48,8 @@ Autosigning is configured via [SigningPolicy](signingpolicy.md) resources that r
 |---|---|---|
 | `phase` | string | Current lifecycle phase |
 | `caSecretName` | string | Name of the Secret containing `ca_crt.pem` (public CA certificate) |
+| `serviceName` | string | Name of the internal ClusterIP Service for operator communication |
+| `notAfter` | time | Expiry time of the CA certificate |
 | `conditions` | []Condition | `CAReady` |
 
 ## Phases
@@ -57,6 +59,7 @@ Autosigning is configured via [SigningPolicy](signingpolicy.md) resources that r
 | `Pending` | CertificateAuthority created, waiting for reconciliation |
 | `Initializing` | CA setup Job is running |
 | `Ready` | CA Secrets created, Certificates can be signed |
+| `External` | External CA configured (no PVC, Job, or internal Service) |
 | `Error` | CA setup failed |
 
 ## CA Secrets
@@ -90,10 +93,17 @@ sequenceDiagram
     Srv->>Srv: TLS handshake uses new CRL
 ```
 
+## Internal Service
+
+The CertificateAuthority controller creates a dedicated ClusterIP Service named `{name}-internal` for operator-internal communication (CSR signing and CRL refresh). This Service is separate from any Pool Service so that users can freely configure the Pool's Service type (ClusterIP, LoadBalancer, NodePort) without conflicting with the operator.
+
+The internal Service FQDN (`{name}-internal.{namespace}.svc`) is automatically added as a SAN to the CA server certificate during setup, so TLS validation succeeds without manual configuration.
+
 ## Created Resources
 
 | Resource | Name | Description |
 |---|---|---|
+| Service | `{name}-internal` | Internal ClusterIP Service for operator communication (port 8140) |
 | PVC | `{name}-data` | Persistent storage for CA keys and data |
 | ServiceAccount | `{name}-ca-setup` | Job ServiceAccount with permission to create CA Secrets |
 | Role | `{name}-ca-setup` | Scoped to CA Secret creation |

--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -49,6 +49,7 @@ Autosigning is configured via [SigningPolicy](signingpolicy.md) resources that r
 | `phase` | string | Current lifecycle phase |
 | `caSecretName` | string | Name of the Secret containing `ca_crt.pem` (public CA certificate) |
 | `serviceName` | string | Name of the internal ClusterIP Service for operator communication |
+| `signingSecretName` | string | Name of the TLS Secret used for mTLS authentication when signing certificates via the CA HTTP API |
 | `notAfter` | time | Expiry time of the CA certificate |
 | `conditions` | []Condition | `CAReady` |
 

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -307,6 +307,22 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 	}
 
 	if signedCertPEM == nil {
+		// For internal CAs with a signing secret, sign the CSR directly via the CA API
+		if ca.Spec.External == nil && ca.Status.SigningSecretName != "" {
+			logger.Info("CSR not auto-signed, signing via operator mTLS", "certname", cert.Spec.Certname, "signingSecret", ca.Status.SigningSecretName)
+			if err := r.signCSRViaAPI(ctx, cert, ca, caBaseURL, namespace); err != nil {
+				logger.Info("operator signing failed, falling through to poll", "error", err)
+			} else {
+				// Fetch the now-signed cert immediately
+				signedCertPEM, err = r.fetchSignedCert(ctx, cert, ca, caBaseURL, namespace)
+				if err != nil {
+					logger.Info("failed to fetch cert after operator signing", "error", err)
+				}
+			}
+		}
+	}
+
+	if signedCertPEM == nil {
 		// Read and increment poll attempt count from pending Secret annotation
 		pendingSecretName := fmt.Sprintf("%s-tls-pending", cert.Name)
 		pendingSecret := &corev1.Secret{}
@@ -376,4 +392,74 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 
 	logger.Info("certificate signed successfully", "certname", cert.Spec.Certname)
 	return ctrl.Result{}, nil
+}
+
+// signCSRViaAPI signs a pending CSR via the Puppet CA HTTP API using mTLS with the
+// CA server's own certificate (which has the pp_cli_auth extension required by auth.conf).
+func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {
+	certname := cert.Spec.Certname
+	if certname == "" {
+		certname = "puppet"
+	}
+
+	// Load CA public cert for TLS server verification
+	caCertPEM, err := r.getCAPublicCert(ctx, ca, namespace)
+	if err != nil {
+		return fmt.Errorf("loading CA certificate: %w", err)
+	}
+
+	// Load signing secret (CA server cert + key) for mTLS client auth
+	signingSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: ca.Status.SigningSecretName, Namespace: namespace}, signingSecret); err != nil {
+		return fmt.Errorf("getting signing Secret %s: %w", ca.Status.SigningSecretName, err)
+	}
+
+	clientCertPEM := signingSecret.Data["cert.pem"]
+	clientKeyPEM := signingSecret.Data["key.pem"]
+	if len(clientCertPEM) == 0 || len(clientKeyPEM) == 0 {
+		return fmt.Errorf("signing Secret %s missing cert.pem or key.pem", ca.Status.SigningSecretName)
+	}
+
+	// Build mTLS HTTP client
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCertPEM) {
+		return fmt.Errorf("failed to parse CA certificate PEM")
+	}
+	clientCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	if err != nil {
+		return fmt.Errorf("parsing signing certificate: %w", err)
+	}
+	httpClient := &http.Client{
+		Timeout: HTTPClientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      pool,
+				Certificates: []tls.Certificate{clientCert},
+			},
+		},
+	}
+
+	// PUT /puppet-ca/v1/certificate_status/{certname}?environment=production
+	signURL := fmt.Sprintf("%s/puppet-ca/v1/certificate_status/%s?environment=production", caBaseURL, certname)
+	body := strings.NewReader(`{"desired_state": "signed"}`)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, signURL, body)
+	if err != nil {
+		return fmt.Errorf("building sign request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("signing CSR via API: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("CA rejected sign request (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	log.FromContext(ctx).Info("CSR signed via operator mTLS", "certname", certname)
+	return nil
 }

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -3,11 +3,16 @@ package controller
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"io"
 	"math/big"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,6 +49,7 @@ func TestCSRPollBackoff(t *testing.T) {
 
 // generateTestCert creates a self-signed CA certificate and key pair for testing.
 // Returns PEM-encoded certificate, PEM-encoded private key.
+// The cert includes 127.0.0.1 as an IP SAN for use with httptest.NewTLSServer.
 func generateTestCert(t *testing.T) ([]byte, []byte) {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -56,7 +62,9 @@ func generateTestCert(t *testing.T) ([]byte, []byte) {
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(24 * time.Hour),
 		IsCA:         true,
-		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
 	if err != nil {
@@ -182,4 +190,187 @@ func TestBuildExternalCAHTTPClient_TLSSecretMissingKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when TLS secret is missing tls.key")
 	}
+}
+
+func TestSignCSRViaAPI_Success(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	// Start test HTTPS server that accepts the sign request
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/puppet-ca/v1/certificate_status/test-certname") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"desired_state": "signed"`) {
+			t.Errorf("expected desired_state signed in body, got %s", string(body))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	// Create secrets: CA public cert and signing secret (CA server cert+key)
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.signCSRViaAPI(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSignCSRViaAPI_MissingSigningSecret(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "nonexistent-secret"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+	cert.Spec.Certname = "test-certname"
+
+	// CA public cert exists but signing secret does not
+	certPEM, _ := generateTestCert(t)
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+
+	c := setupTestClient(ca, cert, caSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.signCSRViaAPI(testCtx(), cert, ca, "https://localhost:8140", testNamespace)
+	if err == nil {
+		t.Fatal("expected error when signing secret is missing")
+	}
+	if !strings.Contains(err.Error(), "getting signing Secret") {
+		t.Errorf("expected 'getting signing Secret' error, got: %v", err)
+	}
+}
+
+func TestSignCSRViaAPI_SigningSecretMissingKeys(t *testing.T) {
+	certPEM, _ := generateTestCert(t)
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	// Signing secret exists but is missing cert.pem/key.pem
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"wrong-key": []byte("data"),
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.signCSRViaAPI(testCtx(), cert, ca, "https://localhost:8140", testNamespace)
+	if err == nil {
+		t.Fatal("expected error when signing secret is missing cert.pem/key.pem")
+	}
+	if !strings.Contains(err.Error(), "missing cert.pem or key.pem") {
+		t.Errorf("expected 'missing cert.pem or key.pem' error, got: %v", err)
+	}
+}
+
+func TestSignCSRViaAPI_CARejectsRequest(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("Not Authorized"))
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.signCSRViaAPI(testCtx(), cert, ca, server.URL, testNamespace)
+	if err == nil {
+		t.Fatal("expected error when CA rejects sign request")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Errorf("expected HTTP 403 error, got: %v", err)
+	}
+}
+
+func TestSignCSRViaAPI_DefaultCertname(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	var requestedPath string
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+	cert.Spec.Certname = "" // should default to "puppet"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.signCSRViaAPI(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(requestedPath, "/puppet-ca/v1/certificate_status/puppet") {
+		t.Errorf("expected path with default certname 'puppet', got: %s", requestedPath)
+	}
+}
+
+// newTestTLSServer creates a test HTTPS server using the given cert/key for TLS.
+func newTestTLSServer(t *testing.T, certPEM, keyPEM []byte, handler http.Handler) *httptest.Server {
+	t.Helper()
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("loading test TLS cert: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	server.StartTLS()
+	return server
 }

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -115,6 +115,11 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 	ca.Status.CASecretName = caSecretName
 	ca.Status.ServiceName = caInternalServiceName(ca.Name)
 	ca.Status.NotAfter = r.extractCANotAfter(ctx, caSecretName, ca.Namespace)
+
+	// Find the CA server cert's TLS secret for signing credentials
+	if caCert := r.findCAServerCert(ctx, ca, certs); caCert != nil {
+		ca.Status.SigningSecretName = fmt.Sprintf("%s-tls", caCert.Name)
+	}
 	meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
 		Type:               openvoxv1alpha1.ConditionCAReady,
 		Status:             metav1.ConditionTrue,

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -667,7 +667,7 @@ func TestCAReconcile_StatusSigningSecretName_NoCert(t *testing.T) {
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": []byte("ca-cert"),
 	})
-	// No Certificate or Server objects — findCAServerCert returns nil
+	// No Certificate or Server objects - findCAServerCert returns nil
 	c := setupTestClient(ca, cfg, caSecret)
 	r := newCertificateAuthorityReconciler(c)
 

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -631,6 +631,60 @@ func TestCAReconcile_ExternalCA_SkipsPVCAndJob(t *testing.T) {
 	}
 }
 
+func TestCAReconcile_StatusSigningSecretName(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.Phase = ""
+	cfg := caPrereqs("test-ca")
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": []byte("ca-cert"),
+	})
+	// Create a Server with ca:true and a Certificate for it
+	server := newServer("ca-server", withCA(true), withServerRole(true))
+	server.Spec.ConfigRef = "production"
+	server.Spec.CertificateRef = "ca-cert"
+	cert := newCertificate("ca-cert", "test-ca", openvoxv1alpha1.CertificatePhasePending)
+	c := setupTestClient(ca, cfg, caSecret, server, cert)
+	r := newCertificateAuthorityReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-ca")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	updated := &openvoxv1alpha1.CertificateAuthority{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get CA: %v", err)
+	}
+
+	if updated.Status.SigningSecretName != "ca-cert-tls" {
+		t.Errorf("expected status.signingSecretName %q, got %q", "ca-cert-tls", updated.Status.SigningSecretName)
+	}
+}
+
+func TestCAReconcile_StatusSigningSecretName_NoCert(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.Phase = ""
+	cfg := caPrereqs("test-ca")
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": []byte("ca-cert"),
+	})
+	// No Certificate or Server objects — findCAServerCert returns nil
+	c := setupTestClient(ca, cfg, caSecret)
+	r := newCertificateAuthorityReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-ca")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	updated := &openvoxv1alpha1.CertificateAuthority{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get CA: %v", err)
+	}
+
+	if updated.Status.SigningSecretName != "" {
+		t.Errorf("expected empty status.signingSecretName, got %q", updated.Status.SigningSecretName)
+	}
+}
+
 func TestCAReconcile_ExternalCA_NoConfigRequired(t *testing.T) {
 	// External CA should work without any Config object (unlike internal CA which requires it)
 	ca := newCertificateAuthority("ext-ca", withExternal("https://puppet-ca.example.com:8140"))


### PR DESCRIPTION
## Summary

- For internal CAs, the operator now signs CSRs directly via the Puppet CA HTTP API using mTLS with the CA server's own certificate (`pp_cli_auth` extension), removing the dependency on user-configured SigningPolicies for operator-managed infrastructure certificates
- Adds `status.signingSecretName` to `CertificateAuthority`, populated from the CA server cert's TLS Secret
- When a CSR is not auto-signed and the CA has a signing secret, the operator calls `PUT /puppet-ca/v1/certificate_status/{certname}` with `{"desired_state": "signed"}` — external CAs are unaffected

## Test plan

- [x] `TestCAReconcile_StatusSigningSecretName` — verifies signing secret name is set when CA server cert exists
- [x] `TestCAReconcile_StatusSigningSecretName_NoCert` — verifies signing secret name is empty when no CA server cert
- [x] `TestSignCSRViaAPI_Success` — verifies correct mTLS endpoint call with proper headers and body
- [x] `TestSignCSRViaAPI_MissingSigningSecret` — verifies graceful error when signing secret is missing
- [x] `TestSignCSRViaAPI_SigningSecretMissingKeys` — verifies error on incomplete signing secret
- [x] `TestSignCSRViaAPI_CARejectsRequest` — verifies error handling on HTTP 403
- [x] `TestSignCSRViaAPI_DefaultCertname` — verifies fallback to "puppet" certname
- [ ] Deploy to cluster: create stack without SigningPolicies, verify non-CA server cert reaches Signed
- [ ] Deploy with SigningPolicy: verify autosign still works (operator sign is a fallback)