### PR TITLE
fix: adopt secrets in controller instead of setting ownerReferences in job

### DIFF
--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -15,6 +15,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -108,9 +109,18 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 		return result, nil
 	}
 
+	// Adopt CA secrets created by the setup job (sets ownerReference for GC)
+	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
+	caKeySecretName := fmt.Sprintf("%s-ca-key", ca.Name)
+	caCRLSecretName := fmt.Sprintf("%s-ca-crl", ca.Name)
+	for _, secretName := range []string{caSecretName, caKeySecretName, caCRLSecretName} {
+		if err := r.adoptSecret(ctx, ca, secretName); err != nil {
+			return ctrl.Result{}, fmt.Errorf("adopting Secret %s: %w", secretName, err)
+		}
+	}
+
 	// CA is ready
 	wasReady := ca.Status.Phase == openvoxv1alpha1.CertificateAuthorityPhaseReady
-	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
 	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseReady
 	ca.Status.CASecretName = caSecretName
 	ca.Status.ServiceName = caInternalServiceName(ca.Name)
@@ -253,6 +263,30 @@ func (r *CertificateAuthorityReconciler) reconcileExternalCA(ctx context.Context
 		return ctrl.Result{RequeueAfter: RequeueIntervalCRL}, nil
 	}
 	return crlResult, nil
+}
+
+// adoptSecret sets the controller ownerReference on a Secret so it is garbage-collected
+// when the CertificateAuthority is deleted. This replaces the previous approach of setting
+// ownerReferences inside the CA setup job script.
+func (r *CertificateAuthorityReconciler) adoptSecret(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, secretName string) error {
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: ca.Namespace}, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, ref := range secret.OwnerReferences {
+		if ref.UID == ca.UID {
+			return nil
+		}
+	}
+
+	if err := controllerutil.SetControllerReference(ca, secret, r.Scheme); err != nil {
+		return err
+	}
+	return r.Update(ctx, secret)
 }
 
 // extractCANotAfter reads the ca_crt.pem from the CA Secret and returns its NotAfter time.

--- a/internal/controller/certificateauthority_job.go
+++ b/internal/controller/certificateauthority_job.go
@@ -151,7 +151,6 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 		{Name: "CA_KEY_SECRET_NAME", Value: caKeySecretName},
 		{Name: "CA_CRL_SECRET_NAME", Value: caCRLSecretName},
 		{Name: "CA_NAME", Value: ca.Name},
-		{Name: "CA_UID", Value: string(ca.UID)},
 		{Name: "CONFIG_NAME", Value: cfg.Name},
 		{Name: "SSL_SECRET_NAME", Value: tlsSecretName},
 		{Name: "CERT_RESOURCE_NAME", Value: certResourceName},
@@ -305,16 +304,6 @@ create_or_update_secret() {
   echo "Secret '${SECRET_NAME}' created/updated successfully."
 }
 
-# ownerReference block for all Secrets (GC deletes them when the CA is deleted)
-OWNER_REF="\"ownerReferences\": [{
-      \"apiVersion\": \"openvox.voxpupuli.org/v1alpha1\",
-      \"kind\": \"CertificateAuthority\",
-      \"name\": \"${CA_NAME}\",
-      \"uid\": \"${CA_UID}\",
-      \"controller\": true,
-      \"blockOwnerDeletion\": true
-    }]"
-
 # CA public cert secret (mounted in all pods)
 CA_CRT=$(base64 -w0 /etc/puppetlabs/puppetserver/ca/ca_crt.pem)
 create_or_update_secret "${CA_SECRET_NAME}" "{
@@ -327,8 +316,7 @@ create_or_update_secret "${CA_SECRET_NAME}" "{
       \"app.kubernetes.io/managed-by\": \"openvox-operator\",
       \"app.kubernetes.io/name\": \"openvox\",
       \"openvox.voxpupuli.org/certificateauthority\": \"${CA_NAME}\"
-    },
-    ${OWNER_REF}
+    }
   },
   \"data\": {
     \"ca_crt.pem\": \"${CA_CRT}\"
@@ -347,8 +335,7 @@ create_or_update_secret "${CA_KEY_SECRET_NAME}" "{
       \"app.kubernetes.io/managed-by\": \"openvox-operator\",
       \"app.kubernetes.io/name\": \"openvox\",
       \"openvox.voxpupuli.org/certificateauthority\": \"${CA_NAME}\"
-    },
-    ${OWNER_REF}
+    }
   },
   \"data\": {
     \"ca_key.pem\": \"${CA_KEY}\"
@@ -368,8 +355,7 @@ create_or_update_secret "${CA_CRL_SECRET_NAME}" "{
       \"app.kubernetes.io/managed-by\": \"openvox-operator\",
       \"app.kubernetes.io/name\": \"openvox\",
       \"openvox.voxpupuli.org/certificateauthority\": \"${CA_NAME}\"
-    },
-    ${OWNER_REF}
+    }
   },
   \"data\": {
     \"ca_crl.pem\": \"${CA_CRL}\",
@@ -396,8 +382,7 @@ if [ -n "${SSL_SECRET_NAME}" ] && [ -f "/etc/puppetlabs/puppet/ssl/certs/${CERTN
         \"app.kubernetes.io/name\": \"openvox\",
         \"openvox.voxpupuli.org/certificateauthority\": \"${CA_NAME}\",
         \"openvox.voxpupuli.org/certificate\": \"${CERT_RESOURCE_NAME}\"
-      },
-      ${OWNER_REF}
+      }
     },
     \"data\": {
       \"cert.pem\": \"${CERT}\",


### PR DESCRIPTION
## Summary

- The CA setup job previously set `controller: true` ownerReferences on all secrets, pointing to the CertificateAuthority. When the Certificate controller tried to adopt the TLS secret (`-tls`) via `SetControllerReference`, it failed because Kubernetes only allows one controller-owner per object. This caused the CA Certificate to stay stuck in `Pending`, blocking the entire bootstrap chain (Server → `WaitingForCert` → no CA pod → CSR `connection refused`).
- Moves ownerReference management from the job script into the controllers where it belongs: `CertificateAuthorityReconciler.adoptSecret()` for CA secrets (`-ca`, `-ca-key`, `-ca-crl`) and the existing `CertificateReconciler.adoptTLSSecret()` for the TLS secret.
- Removes the `OWNER_REF` block and `CA_UID` env var from the job script.

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/controller/...` passes
- [ ] Deploy to cluster and verify full bootstrap: CA setup → Certificate `Signed` → Server pods start
- [ ] Verify `kubectl get secret <name> -o jsonpath='{.metadata.ownerReferences}'` shows correct controller-owner after adoption
- [ ] Delete CertificateAuthority and verify all secrets are garbage-collected