### PR TITLE
feat: patch jvm-ssl-utils to fix nsComment extension parsing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,6 +46,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       image_name: openvox-code
       dockerfile: images/openvox-code/Containerfile
@@ -59,6 +60,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       image_name: openvox-agent
       dockerfile: images/openvox-agent/Containerfile
@@ -72,6 +74,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       image_name: openvox-mock
       dockerfile: images/openvox-mock/Containerfile

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,4 @@
 ignored:
+  - DL3008  # apt-get version pinning -- transient build stage, not runtime
   - DL3041  # dnf version pinning -- versions come from UBI9 repos
   - DL3003  # WORKDIR vs cd -- tarball extraction requires cd

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -14,6 +14,8 @@ ARG OPENVOXSERVER_VERSION=8.12.1
 ARG OPENVOXDB_TERMINI_VERSION=8.12.1
 # renovate: datasource=github-releases depName=OpenVoxProject/openvox
 ARG OPENVOX_VERSION=8.25.0
+# renovate: datasource=git-refs depName=https://github.com/OpenVoxProject/jvm-ssl-utils versioning=git
+ARG JVM_SSL_UTILS_VERSION=ad7d28f8c3413c199242a318fb85d10a1fea4b70
 
 ################################################################################
 # Stage: base — JRE + minimal runtime deps (no Ruby)
@@ -159,6 +161,22 @@ RUN find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/action/setup.rb' \
     ; true
 
 ################################################################################
+# Stage: jvm-ssl-utils — patch and build jvm-ssl-utils from upstream
+################################################################################
+FROM docker.io/library/clojure:temurin-17-lein AS jvm-ssl-utils
+
+ARG JVM_SSL_UTILS_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone https://github.com/OpenVoxProject/jvm-ssl-utils.git . \
+    && git checkout ${JVM_SSL_UTILS_VERSION}
+COPY images/openvox-server/patches/jvm-ssl-utils-nscomment.patch /tmp/
+RUN git apply /tmp/jvm-ssl-utils-nscomment.patch \
+    && lein jar
+
+################################################################################
 # Stage: autosign — compile the openvox-autosign Go binary
 ################################################################################
 FROM docker.io/library/golang:1.26 AS autosign
@@ -221,6 +239,7 @@ COPY images/openvox-server/puppet.conf              /etc/puppetlabs/puppet/puppe
 COPY images/openvox-server/entrypoint.sh /entrypoint.sh
 COPY images/openvox-server/healthcheck.sh /healthcheck.sh
 COPY images/openvox-server/cli-ca.sh /opt/puppetlabs/server/apps/puppetserver/cli/apps/ca
+COPY --from=jvm-ssl-utils /src/target/ssl-utils-*.jar /opt/puppetlabs/server/apps/puppetserver/jvm-ssl-utils-patch.jar
 COPY --from=autosign /openvox-autosign /usr/local/bin/openvox-autosign
 COPY --from=enc /openvox-enc /usr/local/bin/openvox-enc
 

--- a/images/openvox-server/entrypoint.sh
+++ b/images/openvox-server/entrypoint.sh
@@ -22,7 +22,7 @@ exec "${JAVA_BIN}" ${JAVA_ARGS} \
     --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
     --add-opens java.base/java.io=ALL-UNNAMED \
     -Dlogappender=STDOUT \
-    -cp "${INSTALL_DIR}/puppet-server-release.jar" \
+    -cp "${INSTALL_DIR}/jvm-ssl-utils-patch.jar:${INSTALL_DIR}/puppet-server-release.jar" \
     clojure.main -m puppetlabs.trapperkeeper.main \
     --config "${CONFIG}" \
     --bootstrap-config "${BOOTSTRAP_CONFIG}"

--- a/images/openvox-server/patches/jvm-ssl-utils-nscomment.patch
+++ b/images/openvox-server/patches/jvm-ssl-utils-nscomment.patch
@@ -1,0 +1,20 @@
+diff --git a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+index 90c9ca6..f0ace71 100644
+--- a/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
++++ b/src/java/com/puppetlabs/ssl_utils/ExtensionsUtils.java
+@@ -662,7 +662,14 @@ public class ExtensionsUtils {
+             ASN1String str = (ASN1String)asn1Prim;
+             return str.getString();
+         } else if (asn1Prim instanceof ASN1OctetString) {
+-            return ASN1Primitive.fromByteArray(((ASN1OctetString) asn1Prim).getOctets()).toString();
++            byte[] octets = ((ASN1OctetString) asn1Prim).getOctets();
++            try {
++                return ASN1Primitive.fromByteArray(octets).toString();
++            } catch (IOException e) {
++                // Some extensions (e.g. Netscape Comment from JRuby-OpenSSL) store
++                // raw strings without proper ASN.1 wrapping (missing IA5String tag).
++                return new String(octets, java.nio.charset.StandardCharsets.US_ASCII);
++            }
+         } else if (asn1Prim instanceof X500Name) {
+             X500Name name = (X500Name) asn1Prim;
+             return name.toString();


### PR DESCRIPTION
## Summary

- Build jvm-ssl-utils from upstream (pinned commit) with a patch applied during container build
- Fixes BouncyCastle crash when parsing Netscape Comment extension created by JRuby-OpenSSL
- Patched JAR is prepended to classpath, overriding the bundled version in the uber-JAR

## Problem

JRuby-OpenSSL encodes `nsComment` as a double-wrapped OCTET STRING with raw ASCII instead of IA5String. When BouncyCastle tries to parse the inner bytes as ASN.1, it crashes with `IOException: corrupted stream - out of bounds length found`. This blocks all mTLS-authenticated certificate signing via the `certificate_status` API.

See [slauger/jvm-ssl-utils#1](https://github.com/slauger/jvm-ssl-utils/pull/1) for the full root cause analysis.

## Changes

- `images/openvox-server/patches/jvm-ssl-utils-nscomment.patch` - try-catch fallback in `asn1ObjToObj`
- `images/openvox-server/Containerfile` - new `jvm-ssl-utils` build stage (clone upstream, apply patch, `lein jar`)
- `images/openvox-server/entrypoint.sh` - prepend patch JAR to classpath

Upstream commit pinned with Renovate `git-refs` tracking. Build breaks if patch no longer applies.

## Test plan

- [ ] CI builds openvox-server image successfully (patch applies, lein jar succeeds)
- [ ] Deploy to cluster: certificate signing works without `corrupted stream` error
- [ ] Server certificate transitions from `Requesting` to `Signed`
- [ ] Server pods start (exit `WaitingForCert`)