### PR TITLE
fix: disable successComment in semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,9 +34,9 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Run semantic-release
         id: semantic
@@ -106,7 +106,7 @@ jobs:
           done
 
       - name: Upload chart artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: helm-charts
           path: '*.tgz'
@@ -119,7 +119,7 @@ jobs:
       contents: write
     steps:
       - name: Download chart artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: helm-charts
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,8 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    ["@semantic-release/github", {
+      "successComment": false
+    }]
   ]
 }

--- a/images/openvox-agent/Containerfile
+++ b/images/openvox-agent/Containerfile
@@ -9,7 +9,7 @@
 # renovate: datasource=github-releases depName=OpenVoxProject/openvox-agent versioning=loose
 ARG OPENVOX_AGENT_VERSION=8.25.0
 
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1773895171
+FROM registry.access.redhat.com/ubi9/ubi:9.7-1774227732
 
 ARG OPENVOX_AGENT_VERSION
 

--- a/images/openvox-code/Containerfile
+++ b/images/openvox-code/Containerfile
@@ -8,7 +8,7 @@
 #   podman build -t openvox-code:latest -f images/openvox-code/Containerfile .
 
 # Stage 1: Install modules with r10k
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1773895171 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.7-1774227732 AS builder
 
 RUN dnf module enable ruby:3.3 -y \
     && dnf install -y --setopt=install_weak_deps=False ruby ruby-devel rubygem-bundler git gcc make redhat-rpm-config libffi-devel \

--- a/images/openvox-db/Containerfile
+++ b/images/openvox-db/Containerfile
@@ -1,7 +1,7 @@
 # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
 ARG OPENVOXDB_VERSION=8.12.1
 
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1773895171
+FROM registry.access.redhat.com/ubi9/ubi:9.7-1774227732
 
 LABEL org.opencontainers.image.title="OpenVox DB" \
       org.opencontainers.image.description="OpenVox DB for Kubernetes/OpenShift" \

--- a/images/openvox-server-reference/Containerfile
+++ b/images/openvox-server-reference/Containerfile
@@ -4,7 +4,7 @@
 # Build:
 #   podman build -t openvox-server-reference:latest images/openvox-server-reference/
 
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1773895171
+FROM registry.access.redhat.com/ubi9/ubi:9.7-1774227732
 
 RUN rpm -Uvh https://yum.voxpupuli.org/openvox8-release-el-9.noarch.rpm \
     && dnf install -y --setopt=install_weak_deps=False openvox-server \

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -20,7 +20,7 @@ ARG JVM_SSL_UTILS_VERSION=ad7d28f8c3413c199242a318fb85d10a1fea4b70
 ################################################################################
 # Stage: base — JRE + minimal runtime deps (no Ruby)
 ################################################################################
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1773895171 AS base
+FROM registry.access.redhat.com/ubi9/ubi:9.7-1774227732 AS base
 
 ARG JDK_VERSION=17
 


### PR DESCRIPTION
## Summary
- Disable `successComment` in `@semantic-release/github` plugin
- The success step fails when referenced issues no longer exist (e.g. #95), which prevents the container image builds and helm chart publishing from running
- Release v0.1.0 was deleted so it can be re-created cleanly after this merge

## Test plan
- [ ] Merge and verify the release workflow creates v0.1.0 with container images and helm charts