### PR TITLE
chore: grant id-token permission for test image builds

### DIFF
--- a/.github/workflows/ci-test-images.yaml
+++ b/.github/workflows/ci-test-images.yaml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       image_name: openvox-agent
       dockerfile: images/openvox-agent/Containerfile
@@ -27,6 +28,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       image_name: openvox-code
       dockerfile: images/openvox-code/Containerfile
@@ -38,6 +40,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       image_name: openvox-mock
       dockerfile: images/openvox-mock/Containerfile


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to CI test images workflow
- The reusable container build workflow requires this permission for the manifest job, causing `startup_failure` without it

## Test plan
- [ ] Trigger `CI (Test Images)` via workflow_dispatch after merge and verify it runs successfully