### PR TITLE
ci: add develop branch to CI workflow triggers

### DIFF
--- a/.github/workflows/ci-test-images.yaml
+++ b/.github/workflows/ci-test-images.yaml
@@ -2,7 +2,7 @@ name: CI (Test Images)
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'images/openvox-agent/**'
       - 'images/openvox-code/**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   unicode:


### PR DESCRIPTION
## Summary

- Add `develop` to push/pull_request triggers in `ci.yaml`
- Add `develop` to push trigger in `ci-test-images.yaml`
- Prepares for a develop branch workflow where PRs merge to `develop` first, and only `develop → main` merges trigger releases

No changes needed to `release.yaml`, `docs.yaml`, or `_container-build.yaml` — they already scope to `main` only. Image push and `:latest` tagging only happens on `refs/heads/main`.

## Manual steps after merge

1. Create `develop` branch from `main`
2. Set `develop` as default branch
3. Copy branch protection rules from `main` to `develop`
4. Protect `main`: require PR, only allow merges from `develop`

[skip ci]