### PR TITLE
fix: auto-pr double-trigger and release title

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'develop'
+      github.event.workflow_run.head_branch == 'develop' &&
+      github.event.workflow_run.event == 'push'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -193,12 +193,12 @@ jobs:
           FIX_COUNT="${{ steps.version.outputs.fix_count }}"
           BREAKING="${{ steps.version.outputs.breaking }}"
 
-          # Extract title from first non-empty line
-          TITLE=$(sed -n '/\S/{ s/^#* //; s/^\*\*//; s/\*\*$//; p; q; }' /tmp/pr_description.txt)
-          if [ -z "$TITLE" ] || echo "$TITLE" | grep -qiE '^(summary|changes|##)'; then
-            TITLE="Release develop -> main"
+          # Build title from release prediction
+          if [ "$BUMP" = "none" ]; then
+            TITLE="Release develop -> main (no release)"
+          else
+            TITLE="Release ${NEXT} (${BUMP})"
           fi
-          TITLE=$(echo "$TITLE" | cut -c1-70)
           echo "title=$TITLE" >> $GITHUB_OUTPUT
 
           # Build version badge


### PR DESCRIPTION
## Summary

- Prevent double-trigger of auto-pr workflow (only react to push-event CI runs, not pull_request)
- Use release version as PR title (e.g. "Release v0.5.0 (minor)")