### PR TITLE
feat: add validating admission webhooks with cert-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: build
 
 .PHONY: manifests
 manifests: ## Generate CRD manifests.
-	$(CONTROLLER_GEN) crd paths="./api/..." output:crd:dir=config/crd/bases
+	$(CONTROLLER_GEN) crd webhook paths="./..." output:crd:dir=config/crd/bases output:webhook:dir=config/webhook
 	cp config/crd/bases/*.yaml charts/openvox-operator/crds/
 
 .PHONY: generate

--- a/charts/openvox-operator/ci/webhook-values.yaml
+++ b/charts/openvox-operator/ci/webhook-values.yaml
@@ -1,0 +1,6 @@
+webhook:
+  enabled: true
+  port: 9443
+  certManager:
+    duration: 8760h
+    renewBefore: 720h

--- a/charts/openvox-operator/templates/deployment.yaml
+++ b/charts/openvox-operator/templates/deployment.yaml
@@ -43,10 +43,18 @@ spec:
             {{- if eq .Values.scope.mode "namespace" }}
             - --watch-namespace={{ .Values.scope.watchNamespace | default .Release.Namespace }}
             {{- end }}
+            {{- if .Values.webhook.enabled }}
+            - --enable-webhooks
+            {{- end }}
           ports:
             - name: health
               containerPort: 8081
               protocol: TCP
+            {{- if .Values.webhook.enabled }}
+            - name: webhook
+              containerPort: {{ .Values.webhook.port | default 9443 }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -69,6 +77,18 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.webhook.enabled }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+          {{- end }}
+      {{- if .Values.webhook.enabled }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: {{ include "openvox-operator.fullname" . }}-webhook-cert
+      {{- end }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openvox-operator/templates/webhook-certmanager.yaml
+++ b/charts/openvox-operator/templates/webhook-certmanager.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.webhook.enabled }}
+---
+# Self-signed issuer for bootstrapping
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "openvox-operator.fullname" . }}-selfsigned
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openvox-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+# CA certificate signed by the self-signed issuer
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "openvox-operator.fullname" . }}-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openvox-operator.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  commonName: {{ include "openvox-operator.fullname" . }}-ca
+  secretName: {{ include "openvox-operator.fullname" . }}-ca-cert
+  duration: 87600h # 10 years
+  renewBefore: 720h # 30 days
+  issuerRef:
+    name: {{ include "openvox-operator.fullname" . }}-selfsigned
+    kind: Issuer
+    group: cert-manager.io
+---
+# CA issuer using the CA certificate
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "openvox-operator.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openvox-operator.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "openvox-operator.fullname" . }}-ca-cert
+---
+# Webhook serving certificate signed by the CA issuer
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "openvox-operator.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openvox-operator.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "openvox-operator.fullname" . }}-webhook-cert
+  duration: {{ .Values.webhook.certManager.duration | default "8760h" }}
+  renewBefore: {{ .Values.webhook.certManager.renewBefore | default "720h" }}
+  dnsNames:
+    - {{ include "openvox-operator.fullname" . }}-webhook
+    - {{ include "openvox-operator.fullname" . }}-webhook.{{ .Release.Namespace }}
+    - {{ include "openvox-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+    - {{ include "openvox-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: {{ include "openvox-operator.fullname" . }}-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- end }}

--- a/charts/openvox-operator/templates/webhook-configuration.yaml
+++ b/charts/openvox-operator/templates/webhook-configuration.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "openvox-operator.fullname" . }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "openvox-operator.fullname" . }}-webhook
+  labels:
+    {{- include "openvox-operator.labels" . | nindent 4 }}
+webhooks:
+  {{- $fullname := include "openvox-operator.fullname" . }}
+  {{- $ns := .Release.Namespace }}
+  {{- range $kind := list "server" "certificate" "config" "signingpolicy" "reportprocessor" "nodeclassifier" "certificateauthority" "pool" }}
+  - name: v{{ $kind }}.kb.io
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ $fullname }}-webhook
+        namespace: {{ $ns }}
+        path: /validate-openvox-voxpupuli-org-v1alpha1-{{ $kind }}
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - openvox.voxpupuli.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          {{- if eq $kind "server" }}
+          - servers
+          {{- else if eq $kind "certificate" }}
+          - certificates
+          {{- else if eq $kind "config" }}
+          - configs
+          {{- else if eq $kind "signingpolicy" }}
+          - signingpolicies
+          {{- else if eq $kind "reportprocessor" }}
+          - reportprocessors
+          {{- else if eq $kind "nodeclassifier" }}
+          - nodeclassifiers
+          {{- else if eq $kind "certificateauthority" }}
+          - certificateauthorities
+          {{- else if eq $kind "pool" }}
+          - pools
+          {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/openvox-operator/templates/webhook-service.yaml
+++ b/charts/openvox-operator/templates/webhook-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openvox-operator.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openvox-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: webhook
+      protocol: TCP
+  selector:
+    {{- include "openvox-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/openvox-operator/values.yaml
+++ b/charts/openvox-operator/values.yaml
@@ -31,6 +31,14 @@ resources:
     cpu: 10m
     memory: 64Mi
 
+# Admission webhook configuration (requires cert-manager)
+webhook:
+  enabled: false
+  port: 9443
+  certManager:
+    duration: 8760h    # 1 year
+    renewBefore: 720h  # 30 days
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,10 +13,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 	"github.com/slauger/openvox-operator/internal/controller"
+	"github.com/slauger/openvox-operator/internal/webhook"
 )
 
 var (
@@ -34,6 +36,7 @@ func main() {
 	var metricsAddr string
 	var probeAddr string
 	var enableLeaderElection bool
+	var enableWebhooks bool
 	var watchNamespace string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -41,6 +44,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&enableWebhooks, "enable-webhooks", false, "Enable admission webhooks.")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
 		"Namespace to restrict the operator to. If empty, the operator watches all namespaces (cluster-wide).")
 
@@ -56,6 +60,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "openvox-operator.voxpupuli.org",
+	}
+
+	if enableWebhooks {
+		mgrOptions.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{Port: 9443})
 	}
 
 	if watchNamespace != "" {
@@ -138,6 +146,13 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ReportProcessor")
 		os.Exit(1)
+	}
+
+	if enableWebhooks {
+		if err := webhook.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to set up webhooks")
+			os.Exit(1)
+		}
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/internal/webhook/certificate_webhook.go
+++ b/internal/webhook/certificate_webhook.go
@@ -1,0 +1,60 @@
+package webhook
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// CertificateValidator validates Certificate resources.
+type CertificateValidator struct {
+	Client client.Reader
+}
+
+func (v *CertificateValidator) ValidateCreate(ctx context.Context, c *openvoxv1alpha1.Certificate) (admission.Warnings, error) {
+	return v.validate(ctx, c)
+}
+
+func (v *CertificateValidator) ValidateUpdate(ctx context.Context, _, c *openvoxv1alpha1.Certificate) (admission.Warnings, error) {
+	return v.validate(ctx, c)
+}
+
+func (v *CertificateValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.Certificate) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *CertificateValidator) validate(ctx context.Context, c *openvoxv1alpha1.Certificate) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	if err := refExists(ctx, v.Client, c.Namespace, c.Spec.AuthorityRef, &openvoxv1alpha1.CertificateAuthority{}); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("authorityRef"), c.Spec.AuthorityRef, err.Error()))
+	}
+
+	if c.Spec.Certname != "" {
+		if msgs := validation.IsDNS1123Subdomain(strings.ToLower(c.Spec.Certname)); len(msgs) > 0 {
+			errs = append(errs, field.Invalid(specPath.Child("certname"), c.Spec.Certname, "must be a valid hostname: "+strings.Join(msgs, "; ")))
+		}
+	}
+
+	for i, san := range c.Spec.DNSAltNames {
+		if net.ParseIP(san) != nil {
+			continue // IP SANs are valid
+		}
+		if msgs := validation.IsDNS1123Subdomain(strings.ToLower(san)); len(msgs) > 0 {
+			errs = append(errs, field.Invalid(specPath.Child("dnsAltNames").Index(i), san, "must be a valid DNS name or IP: "+strings.Join(msgs, "; ")))
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}

--- a/internal/webhook/certificate_webhook_test.go
+++ b/internal/webhook/certificate_webhook_test.go
@@ -1,0 +1,90 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestCertificateValidator(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+
+	t.Run("valid certificate", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &CertificateValidator{Client: c}
+		cert := &openvoxv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateSpec{
+				AuthorityRef: "my-ca",
+				Certname:     "puppet",
+				DNSAltNames:  []string{"puppet.example.com", "10.0.0.1"},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cert)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing authorityRef", func(t *testing.T) {
+		c := setupTestClient()
+		v := &CertificateValidator{Client: c}
+		cert := &openvoxv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateSpec{
+				AuthorityRef: "missing-ca",
+				Certname:     "puppet",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cert)
+		if err == nil {
+			t.Error("expected error for missing authorityRef")
+		}
+	})
+
+	t.Run("invalid certname", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &CertificateValidator{Client: c}
+		cert := &openvoxv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateSpec{
+				AuthorityRef: "my-ca",
+				Certname:     "INVALID HOST NAME!!!",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cert)
+		if err == nil {
+			t.Error("expected error for invalid certname")
+		}
+	})
+
+	t.Run("invalid dnsAltName", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &CertificateValidator{Client: c}
+		cert := &openvoxv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateSpec{
+				AuthorityRef: "my-ca",
+				Certname:     "puppet",
+				DNSAltNames:  []string{"valid.example.com", "INVALID!!!"},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cert)
+		if err == nil {
+			t.Error("expected error for invalid dnsAltName")
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &CertificateValidator{Client: setupTestClient()}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.Certificate{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/certificateauthority_webhook.go
+++ b/internal/webhook/certificateauthority_webhook.go
@@ -1,0 +1,54 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// CertificateAuthorityValidator validates CertificateAuthority resources.
+type CertificateAuthorityValidator struct{}
+
+func (v *CertificateAuthorityValidator) ValidateCreate(_ context.Context, ca *openvoxv1alpha1.CertificateAuthority) (admission.Warnings, error) {
+	return v.validate(ca)
+}
+
+func (v *CertificateAuthorityValidator) ValidateUpdate(_ context.Context, _, ca *openvoxv1alpha1.CertificateAuthority) (admission.Warnings, error) {
+	return v.validate(ca)
+}
+
+func (v *CertificateAuthorityValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.CertificateAuthority) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *CertificateAuthorityValidator) validate(ca *openvoxv1alpha1.CertificateAuthority) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	if err := validateDuration(ca.Spec.TTL, "ttl"); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("ttl"), ca.Spec.TTL, err.Error()))
+	}
+
+	if err := validateDuration(ca.Spec.AutoRenewalCertTTL, "autoRenewalCertTTL"); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("autoRenewalCertTTL"), ca.Spec.AutoRenewalCertTTL, err.Error()))
+	}
+
+	if err := validateDuration(ca.Spec.CRLRefreshInterval, "crlRefreshInterval"); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("crlRefreshInterval"), ca.Spec.CRLRefreshInterval, err.Error()))
+	}
+
+	if ca.Spec.Storage.Size != "" {
+		if _, err := resource.ParseQuantity(ca.Spec.Storage.Size); err != nil {
+			errs = append(errs, field.Invalid(specPath.Child("storage", "size"), ca.Spec.Storage.Size, "must be a valid Kubernetes quantity (e.g. 1Gi, 500Mi)"))
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}

--- a/internal/webhook/certificateauthority_webhook_test.go
+++ b/internal/webhook/certificateauthority_webhook_test.go
@@ -1,0 +1,108 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestCertificateAuthorityValidator(t *testing.T) {
+	t.Run("valid CA", func(t *testing.T) {
+		v := &CertificateAuthorityValidator{}
+		ca := &openvoxv1alpha1.CertificateAuthority{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+				TTL:                "5y",
+				AutoRenewalCertTTL: "90d",
+				CRLRefreshInterval: "5m",
+				Storage:            openvoxv1alpha1.StorageSpec{Size: "1Gi"},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), ca)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("invalid TTL", func(t *testing.T) {
+		v := &CertificateAuthorityValidator{}
+		ca := &openvoxv1alpha1.CertificateAuthority{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+				TTL: "invalid",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), ca)
+		if err == nil {
+			t.Error("expected error for invalid TTL")
+		}
+	})
+
+	t.Run("invalid autoRenewalCertTTL", func(t *testing.T) {
+		v := &CertificateAuthorityValidator{}
+		ca := &openvoxv1alpha1.CertificateAuthority{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+				TTL:                "5y",
+				AutoRenewalCertTTL: "bad",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), ca)
+		if err == nil {
+			t.Error("expected error for invalid autoRenewalCertTTL")
+		}
+	})
+
+	t.Run("invalid crlRefreshInterval", func(t *testing.T) {
+		v := &CertificateAuthorityValidator{}
+		ca := &openvoxv1alpha1.CertificateAuthority{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+				TTL:                "5y",
+				CRLRefreshInterval: "nope",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), ca)
+		if err == nil {
+			t.Error("expected error for invalid crlRefreshInterval")
+		}
+	})
+
+	t.Run("invalid storage size", func(t *testing.T) {
+		v := &CertificateAuthorityValidator{}
+		ca := &openvoxv1alpha1.CertificateAuthority{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+				TTL:     "5y",
+				Storage: openvoxv1alpha1.StorageSpec{Size: "not-a-quantity"},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), ca)
+		if err == nil {
+			t.Error("expected error for invalid storage size")
+		}
+	})
+
+	t.Run("empty durations are valid", func(t *testing.T) {
+		v := &CertificateAuthorityValidator{}
+		ca := &openvoxv1alpha1.CertificateAuthority{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       openvoxv1alpha1.CertificateAuthoritySpec{},
+		}
+		_, err := v.ValidateCreate(context.Background(), ca)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &CertificateAuthorityValidator{}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.CertificateAuthority{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/config_webhook.go
+++ b/internal/webhook/config_webhook.go
@@ -1,0 +1,50 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// ConfigValidator validates Config resources.
+type ConfigValidator struct {
+	Client client.Reader
+}
+
+func (v *ConfigValidator) ValidateCreate(ctx context.Context, c *openvoxv1alpha1.Config) (admission.Warnings, error) {
+	return v.validate(ctx, c)
+}
+
+func (v *ConfigValidator) ValidateUpdate(ctx context.Context, _, c *openvoxv1alpha1.Config) (admission.Warnings, error) {
+	return v.validate(ctx, c)
+}
+
+func (v *ConfigValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.Config) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *ConfigValidator) validate(ctx context.Context, c *openvoxv1alpha1.Config) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	if c.Spec.AuthorityRef != "" {
+		if err := refExists(ctx, v.Client, c.Namespace, c.Spec.AuthorityRef, &openvoxv1alpha1.CertificateAuthority{}); err != nil {
+			errs = append(errs, field.Invalid(specPath.Child("authorityRef"), c.Spec.AuthorityRef, err.Error()))
+		}
+	}
+
+	if c.Spec.NodeClassifierRef != "" {
+		if err := refExists(ctx, v.Client, c.Namespace, c.Spec.NodeClassifierRef, &openvoxv1alpha1.NodeClassifier{}); err != nil {
+			errs = append(errs, field.Invalid(specPath.Child("nodeClassifierRef"), c.Spec.NodeClassifierRef, err.Error()))
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}

--- a/internal/webhook/config_webhook_test.go
+++ b/internal/webhook/config_webhook_test.go
@@ -1,0 +1,86 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestConfigValidator(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+	nc := &openvoxv1alpha1.NodeClassifier{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-nc", Namespace: "default"},
+	}
+
+	t.Run("valid with refs", func(t *testing.T) {
+		c := setupTestClient(ca, nc)
+		v := &ConfigValidator{Client: c}
+		cfg := &openvoxv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ConfigSpec{
+				AuthorityRef:      "my-ca",
+				NodeClassifierRef: "my-nc",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cfg)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("valid without optional refs", func(t *testing.T) {
+		c := setupTestClient()
+		v := &ConfigValidator{Client: c}
+		cfg := &openvoxv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       openvoxv1alpha1.ConfigSpec{},
+		}
+		_, err := v.ValidateCreate(context.Background(), cfg)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing authorityRef", func(t *testing.T) {
+		c := setupTestClient()
+		v := &ConfigValidator{Client: c}
+		cfg := &openvoxv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ConfigSpec{
+				AuthorityRef: "missing-ca",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cfg)
+		if err == nil {
+			t.Error("expected error for missing authorityRef")
+		}
+	})
+
+	t.Run("missing nodeClassifierRef", func(t *testing.T) {
+		c := setupTestClient()
+		v := &ConfigValidator{Client: c}
+		cfg := &openvoxv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ConfigSpec{
+				NodeClassifierRef: "missing-nc",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cfg)
+		if err == nil {
+			t.Error("expected error for missing nodeClassifierRef")
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &ConfigValidator{Client: setupTestClient()}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.Config{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/helpers.go
+++ b/internal/webhook/helpers.go
@@ -1,0 +1,51 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// refExists checks whether a same-namespace resource of type T exists.
+func refExists[T client.Object](ctx context.Context, c client.Reader, ns, name string, obj T) error {
+	key := types.NamespacedName{Namespace: ns, Name: name}
+	if err := c.Get(ctx, key, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("referenced %T %q not found", obj, name)
+		}
+		return fmt.Errorf("looking up %T %q: %w", obj, name, err)
+	}
+	return nil
+}
+
+// validateURL checks whether s is a valid URL with an http or https scheme.
+func validateURL(s, fieldName string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("%s: invalid URL %q: %w", fieldName, s, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s: URL %q must use http or https scheme", fieldName, s)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%s: URL %q must include a host", fieldName, s)
+	}
+	return nil
+}
+
+// validateDuration checks whether s parses as an OpenVox duration string.
+func validateDuration(s, fieldName string) error {
+	if s == "" {
+		return nil
+	}
+	if _, err := openvoxv1alpha1.ParseDurationToSeconds(s); err != nil {
+		return fmt.Errorf("%s: %w", fieldName, err)
+	}
+	return nil
+}

--- a/internal/webhook/helpers_test.go
+++ b/internal/webhook/helpers_test.go
@@ -1,0 +1,97 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(openvoxv1alpha1.AddToScheme(s))
+	return s
+}
+
+func setupTestClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		Build()
+}
+
+func TestRefExists(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+	c := setupTestClient(ca)
+
+	t.Run("found", func(t *testing.T) {
+		if err := refExists(context.Background(), c, "default", "my-ca", &openvoxv1alpha1.CertificateAuthority{}); err != nil {
+			t.Errorf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		if err := refExists(context.Background(), c, "default", "missing", &openvoxv1alpha1.CertificateAuthority{}); err == nil {
+			t.Error("expected error for missing ref")
+		}
+	})
+}
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"valid https", "https://example.com", false},
+		{"valid http", "http://example.com:8080/path", false},
+		{"no scheme", "example.com", true},
+		{"ftp scheme", "ftp://example.com", true},
+		{"empty", "", true},
+		{"just scheme", "https://", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateURL(tt.url, "test")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		dur     string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"valid years", "5y", false},
+		{"valid days", "90d", false},
+		{"valid hours", "8760h", false},
+		{"valid minutes", "5m", false},
+		{"valid seconds", "300s", false},
+		{"plain number", "86400", false},
+		{"invalid unit", "5x", true},
+		{"invalid format", "abc", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDuration(tt.dur, "test")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateDuration(%q) error = %v, wantErr %v", tt.dur, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/webhook/nodeclassifier_webhook.go
+++ b/internal/webhook/nodeclassifier_webhook.go
@@ -1,0 +1,39 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// NodeClassifierValidator validates NodeClassifier resources.
+type NodeClassifierValidator struct{}
+
+func (v *NodeClassifierValidator) ValidateCreate(_ context.Context, nc *openvoxv1alpha1.NodeClassifier) (admission.Warnings, error) {
+	return v.validate(nc)
+}
+
+func (v *NodeClassifierValidator) ValidateUpdate(_ context.Context, _, nc *openvoxv1alpha1.NodeClassifier) (admission.Warnings, error) {
+	return v.validate(nc)
+}
+
+func (v *NodeClassifierValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.NodeClassifier) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *NodeClassifierValidator) validate(nc *openvoxv1alpha1.NodeClassifier) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	if err := validateURL(nc.Spec.URL, "url"); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("url"), nc.Spec.URL, err.Error()))
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}

--- a/internal/webhook/nodeclassifier_webhook_test.go
+++ b/internal/webhook/nodeclassifier_webhook_test.go
@@ -1,0 +1,48 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestNodeClassifierValidator(t *testing.T) {
+	t.Run("valid URL", func(t *testing.T) {
+		v := &NodeClassifierValidator{}
+		nc := &openvoxv1alpha1.NodeClassifier{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.NodeClassifierSpec{
+				URL: "https://enc.example.com",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), nc)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		v := &NodeClassifierValidator{}
+		nc := &openvoxv1alpha1.NodeClassifier{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.NodeClassifierSpec{
+				URL: "not-a-url",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), nc)
+		if err == nil {
+			t.Error("expected error for invalid URL")
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &NodeClassifierValidator{}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.NodeClassifier{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/pool_webhook.go
+++ b/internal/webhook/pool_webhook.go
@@ -1,0 +1,39 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// PoolValidator validates Pool resources.
+type PoolValidator struct{}
+
+func (v *PoolValidator) ValidateCreate(_ context.Context, p *openvoxv1alpha1.Pool) (admission.Warnings, error) {
+	return v.validate(p)
+}
+
+func (v *PoolValidator) ValidateUpdate(_ context.Context, _, p *openvoxv1alpha1.Pool) (admission.Warnings, error) {
+	return v.validate(p)
+}
+
+func (v *PoolValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.Pool) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *PoolValidator) validate(p *openvoxv1alpha1.Pool) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	if p.Spec.Service.Port != 0 && (p.Spec.Service.Port < 1 || p.Spec.Service.Port > 65535) {
+		errs = append(errs, field.Invalid(specPath.Child("service", "port"), p.Spec.Service.Port, "must be between 1 and 65535"))
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}

--- a/internal/webhook/pool_webhook_test.go
+++ b/internal/webhook/pool_webhook_test.go
@@ -1,0 +1,76 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestPoolValidator(t *testing.T) {
+	t.Run("valid port", func(t *testing.T) {
+		v := &PoolValidator{}
+		p := &openvoxv1alpha1.Pool{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.PoolSpec{
+				Service: openvoxv1alpha1.PoolServiceSpec{Port: 8140},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), p)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("zero port is valid (default)", func(t *testing.T) {
+		v := &PoolValidator{}
+		p := &openvoxv1alpha1.Pool{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.PoolSpec{
+				Service: openvoxv1alpha1.PoolServiceSpec{Port: 0},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), p)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("port too high", func(t *testing.T) {
+		v := &PoolValidator{}
+		p := &openvoxv1alpha1.Pool{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.PoolSpec{
+				Service: openvoxv1alpha1.PoolServiceSpec{Port: 70000},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), p)
+		if err == nil {
+			t.Error("expected error for port > 65535")
+		}
+	})
+
+	t.Run("negative port", func(t *testing.T) {
+		v := &PoolValidator{}
+		p := &openvoxv1alpha1.Pool{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.PoolSpec{
+				Service: openvoxv1alpha1.PoolServiceSpec{Port: -1},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), p)
+		if err == nil {
+			t.Error("expected error for negative port")
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &PoolValidator{}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.Pool{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/reportprocessor_webhook.go
+++ b/internal/webhook/reportprocessor_webhook.go
@@ -1,0 +1,46 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// ReportProcessorValidator validates ReportProcessor resources.
+type ReportProcessorValidator struct {
+	Client client.Reader
+}
+
+func (v *ReportProcessorValidator) ValidateCreate(ctx context.Context, rp *openvoxv1alpha1.ReportProcessor) (admission.Warnings, error) {
+	return v.validate(ctx, rp)
+}
+
+func (v *ReportProcessorValidator) ValidateUpdate(ctx context.Context, _, rp *openvoxv1alpha1.ReportProcessor) (admission.Warnings, error) {
+	return v.validate(ctx, rp)
+}
+
+func (v *ReportProcessorValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.ReportProcessor) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *ReportProcessorValidator) validate(ctx context.Context, rp *openvoxv1alpha1.ReportProcessor) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	if err := refExists(ctx, v.Client, rp.Namespace, rp.Spec.ConfigRef, &openvoxv1alpha1.Config{}); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("configRef"), rp.Spec.ConfigRef, err.Error()))
+	}
+
+	if err := validateURL(rp.Spec.URL, "url"); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("url"), rp.Spec.URL, err.Error()))
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}

--- a/internal/webhook/reportprocessor_webhook_test.go
+++ b/internal/webhook/reportprocessor_webhook_test.go
@@ -1,0 +1,72 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestReportProcessorValidator(t *testing.T) {
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "production", Namespace: "default"},
+	}
+
+	t.Run("valid report processor", func(t *testing.T) {
+		c := setupTestClient(cfg)
+		v := &ReportProcessorValidator{Client: c}
+		rp := &openvoxv1alpha1.ReportProcessor{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "production",
+				URL:       "https://puppetdb.example.com:8081/pdb/cmd/v1",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), rp)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing configRef", func(t *testing.T) {
+		c := setupTestClient()
+		v := &ReportProcessorValidator{Client: c}
+		rp := &openvoxv1alpha1.ReportProcessor{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "missing",
+				URL:       "https://example.com",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), rp)
+		if err == nil {
+			t.Error("expected error for missing configRef")
+		}
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		c := setupTestClient(cfg)
+		v := &ReportProcessorValidator{Client: c}
+		rp := &openvoxv1alpha1.ReportProcessor{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "production",
+				URL:       "not-a-url",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), rp)
+		if err == nil {
+			t.Error("expected error for invalid URL")
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &ReportProcessorValidator{Client: setupTestClient()}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.ReportProcessor{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/server_webhook.go
+++ b/internal/webhook/server_webhook.go
@@ -1,0 +1,58 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// ServerValidator validates Server resources.
+type ServerValidator struct {
+	Client client.Reader
+}
+
+func (v *ServerValidator) ValidateCreate(ctx context.Context, s *openvoxv1alpha1.Server) (admission.Warnings, error) {
+	return v.validate(ctx, s)
+}
+
+func (v *ServerValidator) ValidateUpdate(ctx context.Context, _, s *openvoxv1alpha1.Server) (admission.Warnings, error) {
+	return v.validate(ctx, s)
+}
+
+func (v *ServerValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.Server) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *ServerValidator) validate(ctx context.Context, s *openvoxv1alpha1.Server) (admission.Warnings, error) {
+	var errs field.ErrorList
+	var warnings admission.Warnings
+	specPath := field.NewPath("spec")
+
+	if err := refExists(ctx, v.Client, s.Namespace, s.Spec.ConfigRef, &openvoxv1alpha1.Config{}); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("configRef"), s.Spec.ConfigRef, err.Error()))
+	}
+
+	if err := refExists(ctx, v.Client, s.Namespace, s.Spec.CertificateRef, &openvoxv1alpha1.Certificate{}); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("certificateRef"), s.Spec.CertificateRef, err.Error()))
+	}
+
+	for i, ref := range s.Spec.PoolRefs {
+		if err := refExists(ctx, v.Client, s.Namespace, ref, &openvoxv1alpha1.Pool{}); err != nil {
+			errs = append(errs, field.Invalid(specPath.Child("poolRefs").Index(i), ref, err.Error()))
+		}
+	}
+
+	if s.Spec.CA && s.Spec.Replicas != nil && *s.Spec.Replicas > 1 {
+		warnings = append(warnings, fmt.Sprintf("running CA role with %d replicas; CA data is stored on a PVC and concurrent writes may cause issues", *s.Spec.Replicas))
+	}
+
+	if len(errs) > 0 {
+		return warnings, errs.ToAggregate()
+	}
+	return warnings, nil
+}

--- a/internal/webhook/server_webhook_test.go
+++ b/internal/webhook/server_webhook_test.go
@@ -1,0 +1,139 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestServerValidator(t *testing.T) {
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "production", Namespace: "default"},
+	}
+	cert := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "production-cert", Namespace: "default"},
+	}
+	pool := &openvoxv1alpha1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-pool", Namespace: "default"},
+	}
+
+	t.Run("valid server", func(t *testing.T) {
+		c := setupTestClient(cfg, cert, pool)
+		v := &ServerValidator{Client: c}
+		replicas := int32(1)
+		s := &openvoxv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ServerSpec{
+				ConfigRef:      "production",
+				CertificateRef: "production-cert",
+				PoolRefs:       []string{"default-pool"},
+				Replicas:       &replicas,
+			},
+		}
+		warnings, err := v.ValidateCreate(context.Background(), s)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if len(warnings) > 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("missing configRef", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &ServerValidator{Client: c}
+		s := &openvoxv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ServerSpec{
+				ConfigRef:      "missing",
+				CertificateRef: "production-cert",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), s)
+		if err == nil {
+			t.Error("expected error for missing configRef")
+		}
+	})
+
+	t.Run("missing certificateRef", func(t *testing.T) {
+		c := setupTestClient(cfg)
+		v := &ServerValidator{Client: c}
+		s := &openvoxv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ServerSpec{
+				ConfigRef:      "production",
+				CertificateRef: "missing-cert",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), s)
+		if err == nil {
+			t.Error("expected error for missing certificateRef")
+		}
+	})
+
+	t.Run("missing poolRef", func(t *testing.T) {
+		c := setupTestClient(cfg, cert)
+		v := &ServerValidator{Client: c}
+		s := &openvoxv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ServerSpec{
+				ConfigRef:      "production",
+				CertificateRef: "production-cert",
+				PoolRefs:       []string{"missing-pool"},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), s)
+		if err == nil {
+			t.Error("expected error for missing poolRef")
+		}
+	})
+
+	t.Run("CA with multiple replicas warns", func(t *testing.T) {
+		c := setupTestClient(cfg, cert)
+		v := &ServerValidator{Client: c}
+		replicas := int32(3)
+		s := &openvoxv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ServerSpec{
+				ConfigRef:      "production",
+				CertificateRef: "production-cert",
+				CA:             true,
+				Replicas:       &replicas,
+			},
+		}
+		warnings, err := v.ValidateCreate(context.Background(), s)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if len(warnings) != 1 {
+			t.Errorf("expected 1 warning, got %d", len(warnings))
+		}
+	})
+
+	t.Run("update validates new object", func(t *testing.T) {
+		c := setupTestClient(cfg, cert)
+		v := &ServerValidator{Client: c}
+		s := &openvoxv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ServerSpec{
+				ConfigRef:      "production",
+				CertificateRef: "production-cert",
+			},
+		}
+		_, err := v.ValidateUpdate(context.Background(), s, s)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &ServerValidator{Client: setupTestClient()}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.Server{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -1,0 +1,62 @@
+package webhook
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// SetupWithManager registers all validating webhooks with the manager.
+func SetupWithManager(mgr ctrl.Manager) error {
+	c := mgr.GetClient()
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.Server{}).
+		WithValidator(&ServerValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.Certificate{}).
+		WithValidator(&CertificateValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.Config{}).
+		WithValidator(&ConfigValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.SigningPolicy{}).
+		WithValidator(&SigningPolicyValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.ReportProcessor{}).
+		WithValidator(&ReportProcessorValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.NodeClassifier{}).
+		WithValidator(&NodeClassifierValidator{}).
+		Complete(); err != nil {
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.CertificateAuthority{}).
+		WithValidator(&CertificateAuthorityValidator{}).
+		Complete(); err != nil {
+		return err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.Pool{}).
+		WithValidator(&PoolValidator{}).
+		Complete(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/webhook/signingpolicy_webhook.go
+++ b/internal/webhook/signingpolicy_webhook.go
@@ -1,0 +1,58 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// SigningPolicyValidator validates SigningPolicy resources.
+type SigningPolicyValidator struct {
+	Client client.Reader
+}
+
+func (v *SigningPolicyValidator) ValidateCreate(ctx context.Context, sp *openvoxv1alpha1.SigningPolicy) (admission.Warnings, error) {
+	return v.validate(ctx, sp)
+}
+
+func (v *SigningPolicyValidator) ValidateUpdate(ctx context.Context, _, sp *openvoxv1alpha1.SigningPolicy) (admission.Warnings, error) {
+	return v.validate(ctx, sp)
+}
+
+func (v *SigningPolicyValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.SigningPolicy) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *SigningPolicyValidator) validate(ctx context.Context, sp *openvoxv1alpha1.SigningPolicy) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	if err := refExists(ctx, v.Client, sp.Namespace, sp.Spec.CertificateAuthorityRef, &openvoxv1alpha1.CertificateAuthority{}); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("certificateAuthorityRef"), sp.Spec.CertificateAuthorityRef, err.Error()))
+	}
+
+	if sp.Spec.Pattern != nil {
+		for i, pattern := range sp.Spec.Pattern.Allow {
+			if pattern == "" {
+				errs = append(errs, field.Invalid(specPath.Child("pattern", "allow").Index(i), pattern, "pattern must not be empty"))
+			}
+		}
+	}
+
+	if sp.Spec.DNSAltNames != nil {
+		for i, pattern := range sp.Spec.DNSAltNames.Allow {
+			if pattern == "" {
+				errs = append(errs, field.Invalid(specPath.Child("dnsAltNames", "allow").Index(i), pattern, "pattern must not be empty"))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}

--- a/internal/webhook/signingpolicy_webhook_test.go
+++ b/internal/webhook/signingpolicy_webhook_test.go
@@ -1,0 +1,93 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestSigningPolicyValidator(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+
+	t.Run("valid signing policy", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &SigningPolicyValidator{Client: c}
+		sp := &openvoxv1alpha1.SigningPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.SigningPolicySpec{
+				CertificateAuthorityRef: "my-ca",
+				Pattern: &openvoxv1alpha1.PatternSpec{
+					Allow: []string{"*.example.com"},
+				},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), sp)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing CA ref", func(t *testing.T) {
+		c := setupTestClient()
+		v := &SigningPolicyValidator{Client: c}
+		sp := &openvoxv1alpha1.SigningPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.SigningPolicySpec{
+				CertificateAuthorityRef: "missing-ca",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), sp)
+		if err == nil {
+			t.Error("expected error for missing CA ref")
+		}
+	})
+
+	t.Run("empty pattern in allow list", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &SigningPolicyValidator{Client: c}
+		sp := &openvoxv1alpha1.SigningPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.SigningPolicySpec{
+				CertificateAuthorityRef: "my-ca",
+				Pattern: &openvoxv1alpha1.PatternSpec{
+					Allow: []string{"*.example.com", ""},
+				},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), sp)
+		if err == nil {
+			t.Error("expected error for empty pattern")
+		}
+	})
+
+	t.Run("empty dnsAltNames pattern", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &SigningPolicyValidator{Client: c}
+		sp := &openvoxv1alpha1.SigningPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.SigningPolicySpec{
+				CertificateAuthorityRef: "my-ca",
+				DNSAltNames: &openvoxv1alpha1.PatternSpec{
+					Allow: []string{""},
+				},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), sp)
+		if err == nil {
+			t.Error("expected error for empty dnsAltNames pattern")
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &SigningPolicyValidator{Client: setupTestClient()}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.SigningPolicy{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add validating admission webhooks for all 8 CRDs with cross-resource reference checks and semantic validation (URLs, durations, quantities, hostnames)
- Gated behind `--enable-webhooks` flag (default off) and Helm `webhook.enabled: false`
- cert-manager integration for automatic TLS certificate management (self-signed -> CA -> webhook cert chain)

### Webhook validations per CRD

| CRD | Validations |
|-----|-------------|
| Server | configRef, certificateRef, poolRefs[] exist; warn if CA + replicas > 1 |
| Certificate | authorityRef exists; certname valid hostname; dnsAltNames valid |
| Config | authorityRef exists (if set); nodeClassifierRef exists (if set) |
| SigningPolicy | certificateAuthorityRef exists; pattern.allow[] non-empty |
| ReportProcessor | configRef exists; url valid |
| NodeClassifier | url valid |
| CertificateAuthority | ttl/autoRenewalCertTTL/crlRefreshInterval parse as durations; storage.size valid quantity |
| Pool | service.port in 1-65535 |

### Files

- `internal/webhook/` - 8 validators + helpers + setup + tests (19 files)
- `cmd/main.go` - `--enable-webhooks` flag, conditional webhook server
- `charts/openvox-operator/` - Helm templates for cert-manager chain, webhook Service, ValidatingWebhookConfiguration
- `Makefile` - webhook output in controller-gen manifests target

## Test plan

- [x] All 30 webhook unit tests pass (`go test ./internal/webhook/`)
- [x] `go build ./...` compiles cleanly
- [x] `helm lint` passes with and without `webhook.enabled`
- [x] `helm template` (default) renders zero webhook resources
- [x] `helm template --set webhook.enabled=true` renders all webhook resources
- [ ] Deploy with webhooks enabled: creating a Server with non-existent configRef is rejected immediately

Closes #32