### PR TITLE
ci: move openvox-db to ci.yaml and e2e.yaml

### DIFF
--- a/.github/workflows/ci-test-images.yaml
+++ b/.github/workflows/ci-test-images.yaml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'images/openvox-agent/**'
       - 'images/openvox-code/**'
-      - 'images/openvox-db/**'
       - 'images/openvox-mock/**'
       - 'cmd/mock/**'
   workflow_dispatch:
@@ -33,18 +32,6 @@ jobs:
     with:
       image_name: openvox-code
       dockerfile: images/openvox-code/Containerfile
-      context: '.'
-      sign: false
-
-  openvox-db:
-    uses: ./.github/workflows/_container-build.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    with:
-      image_name: openvox-db
-      dockerfile: images/openvox-db/Containerfile
       context: '.'
       sign: false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,3 +42,15 @@ jobs:
       image_name: openvox-server
       dockerfile: images/openvox-server/Containerfile
       context: '.'
+
+  openvox-db:
+    needs: shellcheck
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      image_name: openvox-db
+      dockerfile: images/openvox-db/Containerfile
+      context: '.'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -69,6 +69,19 @@ jobs:
       image_tag: ${{ inputs.image_tag }}
       sign: false
 
+  openvox-db:
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      image_name: openvox-db
+      dockerfile: images/openvox-db/Containerfile
+      context: '.'
+      push: true
+      image_tag: ${{ inputs.image_tag }}
+
   openvox-mock:
     uses: ./.github/workflows/_container-build.yaml
     permissions:


### PR DESCRIPTION
## Summary
- Remove openvox-db from ci-test-images.yaml (test/helper images only)
- Add openvox-db to ci.yaml as production image (alongside operator and server)
- Add openvox-db to e2e.yaml for full image builds

## Context
openvox-db is a production image, not a test image. It was incorrectly added to ci-test-images.yaml in #170.