### PR TITLE
fix: correct jar filename in openvox-db Containerfile

### DIFF
--- a/images/openvox-db/Containerfile
+++ b/images/openvox-db/Containerfile
@@ -63,7 +63,7 @@ RUN tar -xzf /openvoxdb-${OPENVOXDB_VERSION}.tar.gz \
     && install -m 0644 ext/config/logback.xml           "${etc_dir}/puppetdb/logback.xml" \
     && install -m 0644 ext/config/conf.d/jetty.ini     "${etc_dir}/puppetdb/conf.d/jetty.ini" \
     # --- jar + CLI tools ---
-    && install -m 0644 puppet-db.jar                    "${apps_dir}/puppetdb/" \
+    && install -m 0644 puppetdb.jar                      "${apps_dir}/puppetdb/" \
     && install -m 0755 ext/bin/puppetdb                 "${bindir}/puppetdb" \
     && install -m 0755 ext/cli_defaults/cli-defaults.sh "${apps_dir}/puppetdb/cli/" \
     && install -m 0755 ext/cli/foreground               "${apps_dir}/puppetdb/cli/apps/foreground" \


### PR DESCRIPTION
## Summary
- Fix `puppet-db.jar` → `puppetdb.jar` in openvox-db Containerfile
- The upstream openvoxdb tarball ships `puppetdb.jar`, not `puppet-db.jar`

## Verification
- Checked tarball contents: `puppetdb-8.12.1/puppetdb.jar`
- Local build succeeds with the fix