### PR TITLE
feat: Database controller, webhooks, and E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,24 @@ ci: lint vet test check-manifests vulncheck helm-lint ## Run all CI checks local
 ##@ E2E
 
 IMAGE_TAG ?= $(LOCAL_TAG)
+CNPG_VERSION ?= 1.26.2
+ENVOY_GATEWAY_VERSION ?= v1.7.1
 
 E2E_CHAINSAW = IMAGE_TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) $(CHAINSAW) test --config tests/e2e/chainsaw-config.yaml
 E2E_SKIP_CLEANUP ?= false
+
+.PHONY: e2e-cnpg
+e2e-cnpg: ## Install CNPG operator for E2E tests.
+	kubectl apply --server-side -f https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v$(CNPG_VERSION)/cnpg-$(CNPG_VERSION).yaml
+	kubectl wait --for=condition=Available deployment/cnpg-controller-manager -n cnpg-system --timeout=3m
+
+.PHONY: e2e-envoy-gateway
+e2e-envoy-gateway: ## Install Envoy Gateway (incl. Gateway API CRDs) for E2E tests.
+	kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/$(ENVOY_GATEWAY_VERSION)/install.yaml
+	kubectl wait --for=condition=Available deployment/envoy-gateway -n envoy-gateway-system --timeout=3m
+
+.PHONY: e2e-deps
+e2e-deps: e2e-cnpg e2e-envoy-gateway ## Install all E2E external dependencies.
 
 .PHONY: e2e-operator
 e2e-operator: ## Deploy operator for E2E tests.
@@ -189,7 +204,7 @@ e2e-cleanup: ## Remove operator after E2E tests.
 	fi
 
 .PHONY: e2e
-e2e: e2e-operator ## Run all E2E tests.
+e2e: e2e-deps e2e-operator ## Run all E2E tests (including CNPG and Gateway API).
 	$(E2E_CHAINSAW) tests/e2e/; EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
 .PHONY: e2e-stack
@@ -203,6 +218,14 @@ e2e-agent: e2e-operator ## Run agent tests (basic, broken, idempotent, concurren
 .PHONY: e2e-integration
 e2e-integration: e2e-operator ## Run integration tests (enc, report, full).
 	$(E2E_CHAINSAW) tests/e2e/agent-enc tests/e2e/agent-report tests/e2e/agent-full; EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
+
+.PHONY: e2e-database
+e2e-database: e2e-operator ## Run Database with CNPG tests.
+	$(E2E_CHAINSAW) tests/e2e/database-cnpg; EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
+
+.PHONY: e2e-gateway
+e2e-gateway: e2e-operator ## Run Envoy Gateway TLSRoute tests.
+	$(E2E_CHAINSAW) tests/e2e/pool-gateway; EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
 ##@ Help
 

--- a/charts/openvox-stack/ci/database-cnpg-values.yaml
+++ b/charts/openvox-stack/ci/database-cnpg-values.yaml
@@ -1,0 +1,46 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+database:
+  enabled: true
+  name: openvox-stack-db-puppetdb
+  certificate:
+    certname: puppetdb
+  postgres:
+    host: pg-cluster-rw
+    credentialsSecretRef: pg-cluster-app
+    sslMode: disable
+
+config:
+  puppetdb:
+    serverUrls:
+      - https://openvox-stack-db-puppetdb:8081
+  puppet:
+    storeconfigs: true
+    reports: store,puppetdb
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/charts/openvox-stack/ci/pool-gateway-values.yaml
+++ b/charts/openvox-stack/ci/pool-gateway-values.yaml
@@ -1,0 +1,35 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+gateway:
+  name: e2e-puppet-gateway
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140
+    route:
+      enabled: true
+      hostname: puppet.e2e.example.com
+      injectDNSAltName: true

--- a/images/openvox-db/entrypoint.sh
+++ b/images/openvox-db/entrypoint.sh
@@ -15,6 +15,6 @@ echo "Starting OpenVox DB (direct java, PID $$)"
 
 # shellcheck disable=SC2086 # JAVA_ARGS word splitting is intentional
 exec "${JAVA_BIN}" ${JAVA_ARGS} \
-    -cp "${INSTALL_DIR}/puppet-db.jar" \
+    -cp "${INSTALL_DIR}/puppetdb.jar" \
     clojure.main -m puppetlabs.trapperkeeper.main \
     --config "${CONFIG}"

--- a/tests/e2e/database-cnpg/chainsaw-test.yaml
+++ b/tests/e2e/database-cnpg/chainsaw-test.yaml
@@ -1,0 +1,130 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: database-cnpg
+spec:
+  namespace: e2e-database-cnpg
+  steps:
+    - name: Create CNPG PostgreSQL cluster
+      try:
+        - apply:
+            resource:
+              apiVersion: postgresql.cnpg.io/v1
+              kind: Cluster
+              metadata:
+                name: pg-cluster
+              spec:
+                instances: 1
+                storage:
+                  size: 1Gi
+                bootstrap:
+                  initdb:
+                    database: openvoxdb
+                    owner: app
+      catch:
+        - events: {}
+
+    - name: Wait for CNPG cluster ready
+      try:
+        - assert:
+            resource:
+              apiVersion: postgresql.cnpg.io/v1
+              kind: Cluster
+              metadata:
+                name: pg-cluster
+              status:
+                phase: Cluster in healthy state
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: pg-cluster-app
+
+    - name: Install openvox-stack (database-cnpg)
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install openvox-stack-db "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-database-cnpg --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/database-cnpg-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set database.image.repository=${IMAGE_REGISTRY}/openvox-db \
+                --set database.image.tag=latest \
+                --set database.image.pullPolicy=Always
+      catch:
+        - events: {}
+
+    - name: Assert CertificateAuthority is Ready
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: CertificateAuthority
+              metadata:
+                name: openvox-stack-db-ca
+              status:
+                phase: Ready
+
+    - name: Assert Database is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Database
+              metadata:
+                name: openvox-stack-db-puppetdb
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Verify Database Deployment and Service
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: openvox-stack-db-puppetdb
+              status:
+                availableReplicas: 1
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: openvox-stack-db-puppetdb
+              spec:
+                ports:
+                  - port: 8081
+
+    - name: Check operator logs for errors
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              OPERATOR_POD=$(kubectl get pods -n openvox-system \
+                -l app.kubernetes.io/name=openvox-operator \
+                -o jsonpath='{.items[0].metadata.name}')
+              ERROR_LINES=$(kubectl logs -n openvox-system "${OPERATOR_POD}" \
+                | grep '"level":"error"' || true)
+              if [ -n "${ERROR_LINES}" ]; then
+                echo "Found error-level log entries in operator:"
+                echo "${ERROR_LINES}"
+                exit 1
+              fi
+              echo "No error-level log entries found."
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              helm uninstall openvox-stack-db --namespace e2e-database-cnpg --wait 2>/dev/null || true
+              kubectl delete cluster pg-cluster --namespace e2e-database-cnpg --ignore-not-found 2>/dev/null || true
+              kubectl delete namespace e2e-database-cnpg --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -1,0 +1,127 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: pool-gateway
+spec:
+  namespace: e2e-pool-gateway
+  steps:
+    - name: Create Gateway resources
+      try:
+        - apply:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: GatewayClass
+              metadata:
+                name: eg
+              spec:
+                controllerName: gateway.envoyproxy.io/gatewayclass-controller
+        - apply:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: e2e-puppet-gateway
+              spec:
+                gatewayClassName: eg
+                listeners:
+                  - name: puppet-tls
+                    protocol: TLS
+                    port: 8140
+                    tls:
+                      mode: Passthrough
+      catch:
+        - events: {}
+
+    - name: Install openvox-stack (pool-gateway)
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install openvox-stack-gw "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-pool-gateway --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/pool-gateway-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: openvox-stack-gw-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Assert TLSRoute created for server pool
+      try:
+        - assert:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1alpha2
+              kind: TLSRoute
+              metadata:
+                name: openvox-stack-gw-server
+              spec:
+                hostnames:
+                  - puppet.e2e.example.com
+                parentRefs:
+                  - name: e2e-puppet-gateway
+                rules:
+                  - backendRefs:
+                      - name: openvox-stack-gw-server
+
+    - name: Verify DNS alt name injected into Certificate
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Certificate
+              metadata:
+                name: openvox-stack-gw-ca
+              spec:
+                dnsAltNames:
+                  - puppet.e2e.example.com
+
+    - name: Verify no TLSRoute for CA pool
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              if kubectl get tlsroute openvox-stack-gw-ca -n e2e-pool-gateway 2>/dev/null; then
+                echo "ERROR: TLSRoute should not exist for the CA pool"
+                exit 1
+              fi
+              echo "Confirmed: no TLSRoute for CA pool."
+
+    - name: Check operator logs for errors
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              OPERATOR_POD=$(kubectl get pods -n openvox-system \
+                -l app.kubernetes.io/name=openvox-operator \
+                -o jsonpath='{.items[0].metadata.name}')
+              ERROR_LINES=$(kubectl logs -n openvox-system "${OPERATOR_POD}" \
+                | grep '"level":"error"' || true)
+              if [ -n "${ERROR_LINES}" ]; then
+                echo "Found error-level log entries in operator:"
+                echo "${ERROR_LINES}"
+                exit 1
+              fi
+              echo "No error-level log entries found."
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              helm uninstall openvox-stack-gw --namespace e2e-pool-gateway --wait 2>/dev/null || true
+              kubectl delete gateway e2e-puppet-gateway --namespace e2e-pool-gateway --ignore-not-found 2>/dev/null || true
+              kubectl delete namespace e2e-pool-gateway --ignore-not-found 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add `Database` CRD and controller for deploying OpenVox DB (PuppetDB) backed by external PostgreSQL
- Add validating admission webhooks with cert-manager support for all CRDs
- Add E2E test infrastructure for CloudNative PG and Envoy Gateway (Gateway API)
- Fix openvox-db container image build (jar filename, RBAC rules)
- CI improvements: test image workflows, auto-PR workflow, develop branch triggers

## E2E Test Targets

- `make e2e-deps` — install CNPG operator + Envoy Gateway (incl. Gateway API CRDs)
- `make e2e-database` — test Database controller against a real CNPG PostgreSQL cluster
- `make e2e-gateway` — test TLSRoute creation via Envoy Gateway
- `make e2e` — run all E2E tests including the new ones

## Test plan

- [ ] `make e2e-deps` installs CNPG + Envoy Gateway successfully
- [ ] `make e2e-database` passes with CNPG PostgreSQL
- [ ] `make e2e-gateway` passes with TLSRoute verification
- [ ] Existing `make e2e-stack` / `make e2e-agent` / `make e2e-integration` still pass