### PR TITLE
fix: remove broken Go workflow badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # 🦊 openvox-operator
 
 [![CI](https://github.com/slauger/openvox-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/slauger/openvox-operator/actions/workflows/ci.yaml)
-[![Go](https://github.com/slauger/openvox-operator/actions/workflows/go.yaml/badge.svg)](https://github.com/slauger/openvox-operator/actions/workflows/go.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/slauger/openvox-operator)](https://goreportcard.com/report/github.com/slauger/openvox-operator)
 [![Go Reference](https://pkg.go.dev/badge/github.com/slauger/openvox-operator.svg)](https://pkg.go.dev/github.com/slauger/openvox-operator)
 [![License](https://img.shields.io/github/license/slauger/openvox-operator)](LICENSE)


### PR DESCRIPTION
## Summary

- Remove broken Go workflow badge that referenced non-existent `go.yaml`
- The actual workflow is `_go.yaml` (reusable workflow, no standalone badge)
- Go checks are already covered by the CI badge