### PR TITLE
fix: add missing bootstrap.cfg and fix entrypoint for OpenVox DB

### DIFF
--- a/images/openvox-db/Containerfile
+++ b/images/openvox-db/Containerfile
@@ -61,6 +61,8 @@ RUN tar -xzf /openvoxdb-${OPENVOXDB_VERSION}.tar.gz \
     && install -m 0644 ext/config/conf.d/database.ini  "${etc_dir}/puppetdb/conf.d/database.ini" \
     && install -m 0644 ext/config/conf.d/repl.ini      "${etc_dir}/puppetdb/conf.d/repl.ini" \
     && install -m 0644 ext/config/logback.xml           "${etc_dir}/puppetdb/logback.xml" \
+    && install -m 0644 ext/config/bootstrap.cfg        "${etc_dir}/puppetdb/bootstrap.cfg" \
+    && install -m 0644 ext/config/request-logging.xml  "${etc_dir}/puppetdb/request-logging.xml" \
     && install -m 0644 ext/config/conf.d/jetty.ini     "${etc_dir}/puppetdb/conf.d/jetty.ini" \
     && install -m 0644 ext/config/conf.d/auth.conf    "${etc_dir}/puppetdb/conf.d/auth.conf" \
     # --- jar + CLI tools ---

--- a/images/openvox-db/entrypoint.sh
+++ b/images/openvox-db/entrypoint.sh
@@ -10,11 +10,13 @@ JAVA_BIN="/usr/bin/java"
 JAVA_ARGS="${JAVA_ARGS:--Xms256m -Xmx256m}"
 INSTALL_DIR="/opt/puppetlabs/server/apps/puppetdb"
 CONFIG="/etc/puppetlabs/puppetdb/conf.d"
+BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetdb/bootstrap.cfg"
 
 echo "Starting OpenVox DB (direct java, PID $$)"
 
 # shellcheck disable=SC2086 # JAVA_ARGS word splitting is intentional
 exec "${JAVA_BIN}" ${JAVA_ARGS} \
     -cp "${INSTALL_DIR}/puppetdb.jar" \
-    clojure.main -m puppetlabs.trapperkeeper.main \
-    --config "${CONFIG}"
+    clojure.main -m puppetlabs.puppetdb.cli.services \
+    --config "${CONFIG}" \
+    --bootstrap-config "${BOOTSTRAP_CONFIG}"


### PR DESCRIPTION
## Summary

- Add `bootstrap.cfg` and `request-logging.xml` from upstream tarball to the container image
- Fix entrypoint to use `puppetlabs.puppetdb.cli.services` main class (matching upstream) instead of `puppetlabs.trapperkeeper.main`
- Pass `--bootstrap-config` flag so TrapperKeeper can discover the web-router-service

Without these, PuppetDB fails with:
```
IllegalArgumentException: :web-router-service section of configuration not present
```

## Test plan

- [x] Local `docker run` confirms PuppetDB starts past bootstrap and only stops at missing DB config (expected without PostgreSQL)