### PR TITLE
fix: enable stdout logging for OpenVox DB

### DIFF
--- a/images/openvox-db/entrypoint.sh
+++ b/images/openvox-db/entrypoint.sh
@@ -7,7 +7,7 @@ set -o pipefail
 set -o nounset
 
 JAVA_BIN="/usr/bin/java"
-JAVA_ARGS="${JAVA_ARGS:--Xms256m -Xmx256m}"
+JAVA_ARGS="${JAVA_ARGS:--Xms256m -Xmx256m} -Dlogappender=STDOUT"
 INSTALL_DIR="/opt/puppetlabs/server/apps/puppetdb"
 CONFIG="/etc/puppetlabs/puppetdb/conf.d"
 BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetdb/bootstrap.cfg"


### PR DESCRIPTION
## Summary

Add `-Dlogappender=STDOUT` to JAVA_ARGS so PuppetDB logs appear in `kubectl logs` instead of only going to file.

## Test plan

- [ ] `kubectl logs` shows PuppetDB log output after container start