### PR TITLE
fix: enable pg_trgm extension in CNPG E2E cluster

### DIFF
--- a/tests/e2e/database-cnpg/chainsaw-test.yaml
+++ b/tests/e2e/database-cnpg/chainsaw-test.yaml
@@ -21,6 +21,8 @@ spec:
                   initdb:
                     database: openvoxdb
                     owner: app
+                    postInitSQL:
+                      - CREATE EXTENSION IF NOT EXISTS pg_trgm
       catch:
         - events: {}
 


### PR DESCRIPTION
PuppetDB requires the `pg_trgm` PostgreSQL extension. Add `postInitSQL` to the CNPG Cluster bootstrap.