### PR TITLE
fix: use localhost HTTP listener for Database health probes

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -45,6 +45,7 @@ const (
 	DatabaseRunAsUser  = int64(1001)
 	DatabaseRunAsGroup = int64(0)
 	DatabaseHTTPSPort  = int32(8081)
+	DatabaseHTTPPort   = int32(8080)
 )
 
 // HPA and PDB defaults for Server resources.

--- a/internal/controller/database_controller_test.go
+++ b/internal/controller/database_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -239,6 +240,49 @@ func TestDatabaseReconcile_AnnotationHashes(t *testing.T) {
 	} {
 		if v, ok := annotations[key]; !ok || v == "" {
 			t.Errorf("annotation %q missing or empty", key)
+		}
+	}
+}
+
+func TestDatabaseReconcile_ExecProbes(t *testing.T) {
+	objs := append(databasePrereqs(), newDatabase("test-db"))
+	c := setupTestClient(objs...)
+	r := newDatabaseReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("Deployment not created: %v", err)
+	}
+
+	container := deploy.Spec.Template.Spec.Containers[0]
+	expectedCmd := []string{"curl", "-sf", fmt.Sprintf("http://127.0.0.1:%d/status/v1/simple", DatabaseHTTPPort)}
+
+	probes := map[string]*corev1.Probe{
+		"startup":   container.StartupProbe,
+		"readiness": container.ReadinessProbe,
+		"liveness":  container.LivenessProbe,
+	}
+	for name, probe := range probes {
+		if probe == nil {
+			t.Errorf("%s probe is nil", name)
+			continue
+		}
+		if probe.Exec == nil {
+			t.Errorf("%s probe: expected Exec handler, got nil", name)
+			continue
+		}
+		if len(probe.Exec.Command) != len(expectedCmd) {
+			t.Errorf("%s probe: expected command %v, got %v", name, expectedCmd, probe.Exec.Command)
+			continue
+		}
+		for i, arg := range expectedCmd {
+			if probe.Exec.Command[i] != arg {
+				t.Errorf("%s probe: command[%d] expected %q, got %q", name, i, arg, probe.Exec.Command[i])
+			}
 		}
 	}
 }

--- a/internal/controller/database_deployment.go
+++ b/internal/controller/database_deployment.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -191,10 +190,8 @@ func (r *DatabaseReconciler) buildPodSpec(db *openvoxv1alpha1.Database, cert *op
 		VolumeMounts: volumeMounts,
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/status/v1/simple",
-					Port:   intstr.FromInt32(DatabaseHTTPSPort),
-					Scheme: corev1.URISchemeHTTPS,
+				Exec: &corev1.ExecAction{
+					Command: []string{"curl", "-sf", fmt.Sprintf("http://127.0.0.1:%d/status/v1/simple", DatabaseHTTPPort)},
 				},
 			},
 			PeriodSeconds:    5,
@@ -202,20 +199,16 @@ func (r *DatabaseReconciler) buildPodSpec(db *openvoxv1alpha1.Database, cert *op
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/status/v1/simple",
-					Port:   intstr.FromInt32(DatabaseHTTPSPort),
-					Scheme: corev1.URISchemeHTTPS,
+				Exec: &corev1.ExecAction{
+					Command: []string{"curl", "-sf", fmt.Sprintf("http://127.0.0.1:%d/status/v1/simple", DatabaseHTTPPort)},
 				},
 			},
 			PeriodSeconds: 10,
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/status/v1/simple",
-					Port:   intstr.FromInt32(DatabaseHTTPSPort),
-					Scheme: corev1.URISchemeHTTPS,
+				Exec: &corev1.ExecAction{
+					Command: []string{"curl", "-sf", fmt.Sprintf("http://127.0.0.1:%d/status/v1/simple", DatabaseHTTPPort)},
 				},
 			},
 			PeriodSeconds: 30,

--- a/internal/controller/database_rendering.go
+++ b/internal/controller/database_rendering.go
@@ -47,14 +47,16 @@ password = %s
 // renderJettyIni renders the jetty.ini configuration file for OpenVox DB.
 // It configures the HTTPS listener with TLS certificate paths.
 func renderJettyIni(certname string) string {
-	port := DatabaseHTTPSPort
 	return fmt.Sprintf(`[jetty]
+host = 127.0.0.1
+port = %d
 ssl-host = 0.0.0.0
 ssl-port = %d
 ssl-key = /etc/puppetlabs/puppetdb/ssl/private_keys/%s.pem
 ssl-cert = /etc/puppetlabs/puppetdb/ssl/certs/%s.pem
 ssl-ca-cert = /etc/puppetlabs/puppetdb/ssl/certs/ca.pem
-`, port, certname, certname)
+client-auth = need
+`, DatabaseHTTPPort, DatabaseHTTPSPort, certname, certname)
 }
 
 // renderConfigIni renders the config.ini configuration file for OpenVox DB.

--- a/internal/controller/database_rendering_test.go
+++ b/internal/controller/database_rendering_test.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRenderJettyIni(t *testing.T) {
+	ini := renderJettyIni("puppetdb.example.com")
+
+	checks := map[string]string{
+		"cleartext host":  "host = 127.0.0.1",
+		"cleartext port":  fmt.Sprintf("port = %d", DatabaseHTTPPort),
+		"ssl host":        "ssl-host = 0.0.0.0",
+		"ssl port":        fmt.Sprintf("ssl-port = %d", DatabaseHTTPSPort),
+		"client-auth":     "client-auth = need",
+		"ssl-key path":    "ssl-key = /etc/puppetlabs/puppetdb/ssl/private_keys/puppetdb.example.com.pem",
+		"ssl-cert path":   "ssl-cert = /etc/puppetlabs/puppetdb/ssl/certs/puppetdb.example.com.pem",
+		"ssl-ca-cert path": "ssl-ca-cert = /etc/puppetlabs/puppetdb/ssl/certs/ca.pem",
+	}
+	for name, expected := range checks {
+		if !strings.Contains(ini, expected) {
+			t.Errorf("jetty.ini missing %s: expected %q in output:\n%s", name, expected, ini)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- PuppetDB Jetty defaults to `client-auth=need` when `ssl-ca-cert` is set, causing kubelet HTTPS probes to fail with `tls: bad certificate` (no client certificate)
- Adds a cleartext HTTP listener on `127.0.0.1:8080` for health checks — only reachable from within the pod
- Switches all probes (startup, readiness, liveness) to exec-based `curl -sf http://127.0.0.1:8080/status/v1/simple`
- HTTPS port (8081) retains strict mTLS with explicit `client-auth = need`
- HTTP port is NOT exposed in the Kubernetes Service

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/controller/...`
- [x] `go vet ./...`
- [ ] Deploy to E2E cluster and verify PuppetDB pod starts without crash-looping
- [ ] Verify HTTPS port still requires client certificate for API access
