### PR TITLE
feat: add validating admission webhook for Database CRD

### DIFF
--- a/charts/openvox-operator/templates/webhook-configuration.yaml
+++ b/charts/openvox-operator/templates/webhook-configuration.yaml
@@ -10,7 +10,7 @@ metadata:
 webhooks:
   {{- $fullname := include "openvox-operator.fullname" . }}
   {{- $ns := .Release.Namespace }}
-  {{- range $kind := list "server" "certificate" "config" "signingpolicy" "reportprocessor" "nodeclassifier" "certificateauthority" "pool" }}
+  {{- range $kind := list "server" "certificate" "config" "signingpolicy" "reportprocessor" "nodeclassifier" "certificateauthority" "pool" "database" }}
   - name: v{{ $kind }}.kb.io
     admissionReviewVersions:
       - v1
@@ -46,6 +46,8 @@ webhooks:
           - certificateauthorities
           {{- else if eq $kind "pool" }}
           - pools
+          {{- else if eq $kind "database" }}
+          - databases
           {{- end }}
   {{- end }}
 {{- end }}

--- a/internal/webhook/database_webhook.go
+++ b/internal/webhook/database_webhook.go
@@ -1,0 +1,76 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// validSSLModes lists the accepted values for PostgresSpec.SSLMode.
+var validSSLModes = map[string]bool{
+	"disable":     true,
+	"allow":       true,
+	"prefer":      true,
+	"require":     true,
+	"verify-ca":   true,
+	"verify-full": true,
+}
+
+// DatabaseValidator validates Database resources.
+type DatabaseValidator struct {
+	Client client.Reader
+}
+
+func (v *DatabaseValidator) ValidateCreate(ctx context.Context, d *openvoxv1alpha1.Database) (admission.Warnings, error) {
+	return v.validate(ctx, d)
+}
+
+func (v *DatabaseValidator) ValidateUpdate(ctx context.Context, _, d *openvoxv1alpha1.Database) (admission.Warnings, error) {
+	return v.validate(ctx, d)
+}
+
+func (v *DatabaseValidator) ValidateDelete(_ context.Context, _ *openvoxv1alpha1.Database) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *DatabaseValidator) validate(ctx context.Context, d *openvoxv1alpha1.Database) (admission.Warnings, error) {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	// certificateRef must not be empty and the referenced Certificate must exist.
+	if d.Spec.CertificateRef == "" {
+		errs = append(errs, field.Required(specPath.Child("certificateRef"), "must not be empty"))
+	} else if err := refExists(ctx, v.Client, d.Namespace, d.Spec.CertificateRef, &openvoxv1alpha1.Certificate{}); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("certificateRef"), d.Spec.CertificateRef, err.Error()))
+	}
+
+	pgPath := specPath.Child("postgres")
+
+	// postgres.host must not be empty.
+	if d.Spec.Postgres.Host == "" {
+		errs = append(errs, field.Required(pgPath.Child("host"), "must not be empty"))
+	}
+
+	// postgres.credentialsSecretRef must not be empty.
+	if d.Spec.Postgres.CredentialsSecretRef == "" {
+		errs = append(errs, field.Required(pgPath.Child("credentialsSecretRef"), "must not be empty"))
+	}
+
+	// postgres.sslMode must be a known value when set.
+	if d.Spec.Postgres.SSLMode != "" && !validSSLModes[d.Spec.Postgres.SSLMode] {
+		errs = append(errs, field.NotSupported(pgPath.Child("sslMode"), d.Spec.Postgres.SSLMode, sslModeKeys()))
+	}
+
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return nil, nil
+}
+
+func sslModeKeys() []string {
+	return []string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}
+}

--- a/internal/webhook/database_webhook_test.go
+++ b/internal/webhook/database_webhook_test.go
@@ -1,0 +1,136 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestDatabaseValidator(t *testing.T) {
+	cert := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "db-cert", Namespace: "default"},
+	}
+
+	validDB := func() *openvoxv1alpha1.Database {
+		return &openvoxv1alpha1.Database{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.DatabaseSpec{
+				CertificateRef: "db-cert",
+				Postgres: openvoxv1alpha1.PostgresSpec{
+					Host:                 "postgres.example.com",
+					CredentialsSecretRef: "db-credentials",
+					SSLMode:              "require",
+				},
+			},
+		}
+	}
+
+	t.Run("valid database", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &DatabaseValidator{Client: c}
+		_, err := v.ValidateCreate(context.Background(), validDB())
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("empty certificateRef", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &DatabaseValidator{Client: c}
+		d := validDB()
+		d.Spec.CertificateRef = ""
+		_, err := v.ValidateCreate(context.Background(), d)
+		if err == nil {
+			t.Error("expected error for empty certificateRef")
+		}
+	})
+
+	t.Run("non-existent certificate", func(t *testing.T) {
+		c := setupTestClient() // no certificate in cluster
+		v := &DatabaseValidator{Client: c}
+		_, err := v.ValidateCreate(context.Background(), validDB())
+		if err == nil {
+			t.Error("expected error for non-existent certificate")
+		}
+	})
+
+	t.Run("empty postgres.host", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &DatabaseValidator{Client: c}
+		d := validDB()
+		d.Spec.Postgres.Host = ""
+		_, err := v.ValidateCreate(context.Background(), d)
+		if err == nil {
+			t.Error("expected error for empty postgres.host")
+		}
+	})
+
+	t.Run("empty postgres.credentialsSecretRef", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &DatabaseValidator{Client: c}
+		d := validDB()
+		d.Spec.Postgres.CredentialsSecretRef = ""
+		_, err := v.ValidateCreate(context.Background(), d)
+		if err == nil {
+			t.Error("expected error for empty postgres.credentialsSecretRef")
+		}
+	})
+
+	t.Run("invalid postgres.sslMode", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &DatabaseValidator{Client: c}
+		d := validDB()
+		d.Spec.Postgres.SSLMode = "invalid"
+		_, err := v.ValidateCreate(context.Background(), d)
+		if err == nil {
+			t.Error("expected error for invalid postgres.sslMode")
+		}
+	})
+
+	t.Run("valid sslMode values", func(t *testing.T) {
+		for _, mode := range []string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"} {
+			t.Run(mode, func(t *testing.T) {
+				c := setupTestClient(cert)
+				v := &DatabaseValidator{Client: c}
+				d := validDB()
+				d.Spec.Postgres.SSLMode = mode
+				_, err := v.ValidateCreate(context.Background(), d)
+				if err != nil {
+					t.Errorf("expected no error for sslMode %q, got %v", mode, err)
+				}
+			})
+		}
+	})
+
+	t.Run("empty sslMode is valid", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &DatabaseValidator{Client: c}
+		d := validDB()
+		d.Spec.Postgres.SSLMode = ""
+		_, err := v.ValidateCreate(context.Background(), d)
+		if err != nil {
+			t.Errorf("expected no error for empty sslMode, got %v", err)
+		}
+	})
+
+	t.Run("update validates new object", func(t *testing.T) {
+		c := setupTestClient(cert)
+		v := &DatabaseValidator{Client: c}
+		d := validDB()
+		_, err := v.ValidateUpdate(context.Background(), d, d)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("delete always succeeds", func(t *testing.T) {
+		v := &DatabaseValidator{Client: setupTestClient()}
+		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.Database{})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -58,5 +58,11 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	if err := ctrl.NewWebhookManagedBy(mgr, &openvoxv1alpha1.Database{}).
+		WithValidator(&DatabaseValidator{Client: c}).
+		Complete(); err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add `DatabaseValidator` validating webhook for the `Database` CRD
- Validates `spec.certificateRef` (non-empty + referenced Certificate exists), `spec.postgres.host`, `spec.postgres.credentialsSecretRef` (non-empty), and `spec.postgres.sslMode` (valid enum value)
- Register webhook in `setup.go` and add to Helm `webhook-configuration.yaml` template

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/webhook/ -run TestDatabaseValidator` — all 17 test cases pass
- [ ] Deploy to a test cluster and verify invalid `Database` resources are rejected at `kubectl apply` time

Closes #194