### PR TITLE
fix: switch release workflow to manual dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,12 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary
- Replace workflow_run trigger with workflow_dispatch for manual-only releases
- Fixes unintended release workflow runs on develop branch caused by GitHub workflow_run branch filter not working as expected
- Branch guard ensures releases can only be dispatched from main

## Test plan
- [ ] Verify workflow appears under Actions tab with manual Run workflow button
- [ ] Verify dispatch from main runs semantic-release
- [ ] Verify dispatch from other branches is skipped by the if guard