### PR TITLE
feat: add databaseRef to Config for automatic PuppetDB wiring

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -41,7 +41,13 @@ type ConfigSpec struct {
 	// +optional
 	AuthorityRef string `json:"authorityRef,omitempty"`
 
+	// DatabaseRef references a Database whose status.URL is used for puppetdb.conf.
+	// Mutually exclusive with PuppetDB.ServerURLs.
+	// +optional
+	DatabaseRef string `json:"databaseRef,omitempty"`
+
 	// PuppetDB defines the OpenVox DB connection settings.
+	// Mutually exclusive with DatabaseRef.
 	// +optional
 	PuppetDB PuppetDBSpec `json:"puppetdb,omitempty"`
 

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -92,6 +92,11 @@ spec:
                 - message: either image or claimName must be set
                   rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
                     && size(self.claimName) > 0)
+              databaseRef:
+                description: |-
+                  DatabaseRef references a Database whose status.URL is used for puppetdb.conf.
+                  Mutually exclusive with PuppetDB.ServerURLs.
+                type: string
               image:
                 description: Image defines the default container image for all Servers
                   in this Config.
@@ -228,7 +233,9 @@ spec:
                     type: boolean
                 type: object
               puppetdb:
-                description: PuppetDB defines the OpenVox DB connection settings.
+                description: |-
+                  PuppetDB defines the OpenVox DB connection settings.
+                  Mutually exclusive with DatabaseRef.
                 properties:
                   serverUrls:
                     description: ServerURLs is a list of OpenVox DB server URLs.

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -92,6 +92,11 @@ spec:
                 - message: either image or claimName must be set
                   rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
                     && size(self.claimName) > 0)
+              databaseRef:
+                description: |-
+                  DatabaseRef references a Database whose status.URL is used for puppetdb.conf.
+                  Mutually exclusive with PuppetDB.ServerURLs.
+                type: string
               image:
                 description: Image defines the default container image for all Servers
                   in this Config.
@@ -228,7 +233,9 @@ spec:
                     type: boolean
                 type: object
               puppetdb:
-                description: PuppetDB defines the OpenVox DB connection settings.
+                description: |-
+                  PuppetDB defines the OpenVox DB connection settings.
+                  Mutually exclusive with DatabaseRef.
                 properties:
                   serverUrls:
                     description: ServerURLs is a list of OpenVox DB server URLs.

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -9,6 +9,9 @@ spec:
   image:
     repository: ghcr.io/slauger/openvox-server
     tag: "8.12.1"
+  # Use databaseRef to auto-resolve the PuppetDB URL from a Database CR.
+  # Mutually exclusive with puppetdb.serverUrls.
+  # databaseRef: production-db
   puppetdb:
     serverUrls:
       - https://openvoxdb:8081

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -34,6 +35,7 @@ type ConfigReconciler struct {
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=signingpolicies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=nodeclassifiers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=nodeclassifiers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=databases,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=reportprocessors,verbs=get;list;watch
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=reportprocessors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=configmaps;serviceaccounts;secrets,verbs=get;list;watch;create;update;patch;delete
@@ -115,6 +117,9 @@ func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&openvoxv1alpha1.ReportProcessor{}, handler.EnqueueRequestsFromMapFunc(
 			r.enqueueConfigsForReportProcessor(mgr.GetClient()),
 		)).
+		Watches(&openvoxv1alpha1.Database{}, handler.EnqueueRequestsFromMapFunc(
+			r.enqueueConfigsForDatabase(mgr.GetClient()),
+		)).
 		Complete(r)
 }
 
@@ -129,11 +134,16 @@ func (r *ConfigReconciler) reconcileConfigMap(ctx context.Context, cfg *openvoxv
 		return fmt.Errorf("rendering puppet.conf: %w", err)
 	}
 
+	puppetDBConf, err := r.renderPuppetDBConf(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("rendering puppetdb.conf: %w", err)
+	}
+
 	ca := r.findCertificateAuthority(ctx, cfg)
 
 	data := map[string]string{
 		"puppet.conf":       puppetConf,
-		"puppetdb.conf":     r.renderPuppetDBConf(cfg),
+		"puppetdb.conf":     puppetDBConf,
 		"webserver.conf":    r.renderWebserverConf(cfg),
 		"webserver-ca.conf": r.renderWebserverConfCA(cfg),
 		"puppetserver.conf": r.renderPuppetserverConf(cfg),
@@ -195,6 +205,31 @@ func (r *ConfigReconciler) reconcileSecret(ctx context.Context, cfg *openvoxv1al
 
 	existing.Data = data
 	return r.Update(ctx, existing)
+}
+
+func (r *ConfigReconciler) enqueueConfigsForDatabase(c client.Reader) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		db, ok := obj.(*openvoxv1alpha1.Database)
+		if !ok {
+			return nil
+		}
+
+		cfgList := &openvoxv1alpha1.ConfigList{}
+		if err := c.List(ctx, cfgList, client.InNamespace(db.Namespace)); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list Configs in watcher")
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, cfg := range cfgList.Items {
+			if cfg.Spec.DatabaseRef == db.Name {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace},
+				})
+			}
+		}
+		return requests
+	}
 }
 
 func (r *ConfigReconciler) findCertificateAuthority(ctx context.Context, cfg *openvoxv1alpha1.Config) *openvoxv1alpha1.CertificateAuthority {

--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -529,6 +529,53 @@ func TestConfigReconcile_ReportWebhookSecret(t *testing.T) {
 	}
 }
 
+func TestConfigReconcile_PuppetDBConfWithDatabaseRef(t *testing.T) {
+	db := newDatabase("production-db",
+		withDatabaseStatusURL("https://production-db.default.svc.cluster.local:8081"),
+	)
+	cfg := newConfig("production", withDatabaseRef("production-db"))
+	c := setupTestClient(cfg, db)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	puppetDBConf := cm.Data["puppetdb.conf"]
+	expected := "https://production-db.default.svc.cluster.local:8081"
+	if !strings.Contains(puppetDBConf, expected) {
+		t.Errorf("puppetdb.conf missing Database URL %q\n---\n%s", expected, puppetDBConf)
+	}
+}
+
+func TestConfigReconcile_PuppetDBConfNoConfig(t *testing.T) {
+	cfg := newConfig("production")
+	c := setupTestClient(cfg)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	puppetDBConf := cm.Data["puppetdb.conf"]
+	if strings.Contains(puppetDBConf, "server_urls") {
+		t.Errorf("puppetdb.conf should not contain server_urls when neither databaseRef nor serverUrls is set\n---\n%s", puppetDBConf)
+	}
+	if !strings.Contains(puppetDBConf, "soft_write_failure = true") {
+		t.Errorf("puppetdb.conf missing soft_write_failure\n---\n%s", puppetDBConf)
+	}
+}
+
 func TestConfigReconcile_UpdateExistingConfigMap(t *testing.T) {
 	cfg := newConfig("production")
 	existingCM := newConfigMap("production-config", map[string]string{

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -104,7 +104,7 @@ func (r *ConfigReconciler) renderPuppetDBConf(ctx context.Context, cfg *openvoxv
 			return "", fmt.Errorf("looking up Database %q: %w", cfg.Spec.DatabaseRef, err)
 		}
 		if db.Status.URL == "" {
-			return "", fmt.Errorf("Database %q has no status.URL yet", cfg.Spec.DatabaseRef)
+			return "", fmt.Errorf("database %q has no status.URL yet", cfg.Spec.DatabaseRef)
 		}
 		return fmt.Sprintf("[main]\nserver_urls = %s\nsoft_write_failure = true\n", db.Status.URL), nil
 	}

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
@@ -94,12 +96,23 @@ func (r *ConfigReconciler) renderPuppetConf(ctx context.Context, cfg *openvoxv1a
 	return sb.String(), nil
 }
 
-func (r *ConfigReconciler) renderPuppetDBConf(cfg *openvoxv1alpha1.Config) string {
-	if len(cfg.Spec.PuppetDB.ServerURLs) == 0 {
-		return "[main]\nserver_urls = https://openvoxdb:8081\nsoft_write_failure = true\n"
+func (r *ConfigReconciler) renderPuppetDBConf(ctx context.Context, cfg *openvoxv1alpha1.Config) (string, error) {
+	if cfg.Spec.DatabaseRef != "" {
+		db := &openvoxv1alpha1.Database{}
+		key := types.NamespacedName{Name: cfg.Spec.DatabaseRef, Namespace: cfg.Namespace}
+		if err := r.Get(ctx, key, db); err != nil {
+			return "", fmt.Errorf("looking up Database %q: %w", cfg.Spec.DatabaseRef, err)
+		}
+		if db.Status.URL == "" {
+			return "", fmt.Errorf("Database %q has no status.URL yet", cfg.Spec.DatabaseRef)
+		}
+		return fmt.Sprintf("[main]\nserver_urls = %s\nsoft_write_failure = true\n", db.Status.URL), nil
 	}
-	return fmt.Sprintf("[main]\nserver_urls = %s\nsoft_write_failure = true\n",
-		strings.Join(cfg.Spec.PuppetDB.ServerURLs, ","))
+	if len(cfg.Spec.PuppetDB.ServerURLs) > 0 {
+		return fmt.Sprintf("[main]\nserver_urls = %s\nsoft_write_failure = true\n",
+			strings.Join(cfg.Spec.PuppetDB.ServerURLs, ",")), nil
+	}
+	return "[main]\nsoft_write_failure = true\n", nil
 }
 
 // renderWebserverConf returns the webserver.conf for non-CA servers.

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -149,6 +149,12 @@ func withPuppetServerSpec(ps openvoxv1alpha1.PuppetServerSpec) configOption {
 	}
 }
 
+func withDatabaseRef(ref string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.DatabaseRef = ref
+	}
+}
+
 func withPuppetSpec(p openvoxv1alpha1.PuppetSpec) configOption {
 	return func(c *openvoxv1alpha1.Config) {
 		c.Spec.Puppet = p
@@ -497,6 +503,12 @@ func newDatabase(name string, opts ...databaseOption) *openvoxv1alpha1.Database 
 func withDatabaseReplicas(r int32) databaseOption {
 	return func(db *openvoxv1alpha1.Database) {
 		db.Spec.Replicas = &r
+	}
+}
+
+func withDatabaseStatusURL(url string) databaseOption {
+	return func(db *openvoxv1alpha1.Database) {
+		db.Status.URL = url
 	}
 }
 

--- a/internal/webhook/config_webhook.go
+++ b/internal/webhook/config_webhook.go
@@ -43,6 +43,16 @@ func (v *ConfigValidator) validate(ctx context.Context, c *openvoxv1alpha1.Confi
 		}
 	}
 
+	if c.Spec.DatabaseRef != "" && len(c.Spec.PuppetDB.ServerURLs) > 0 {
+		errs = append(errs, field.Invalid(specPath.Child("databaseRef"), c.Spec.DatabaseRef, "databaseRef and puppetdb.serverUrls are mutually exclusive"))
+	}
+
+	if c.Spec.DatabaseRef != "" {
+		if err := refExists(ctx, v.Client, c.Namespace, c.Spec.DatabaseRef, &openvoxv1alpha1.Database{}); err != nil {
+			errs = append(errs, field.Invalid(specPath.Child("databaseRef"), c.Spec.DatabaseRef, err.Error()))
+		}
+	}
+
 	if len(errs) > 0 {
 		return nil, errs.ToAggregate()
 	}

--- a/internal/webhook/config_webhook_test.go
+++ b/internal/webhook/config_webhook_test.go
@@ -76,6 +76,60 @@ func TestConfigValidator(t *testing.T) {
 		}
 	})
 
+	t.Run("valid databaseRef", func(t *testing.T) {
+		db := &openvoxv1alpha1.Database{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"},
+		}
+		c := setupTestClient(db)
+		v := &ConfigValidator{Client: c}
+		cfg := &openvoxv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ConfigSpec{
+				DatabaseRef: "my-db",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cfg)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing databaseRef", func(t *testing.T) {
+		c := setupTestClient()
+		v := &ConfigValidator{Client: c}
+		cfg := &openvoxv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ConfigSpec{
+				DatabaseRef: "missing-db",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cfg)
+		if err == nil {
+			t.Error("expected error for missing databaseRef")
+		}
+	})
+
+	t.Run("databaseRef and serverUrls mutually exclusive", func(t *testing.T) {
+		db := &openvoxv1alpha1.Database{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-db", Namespace: "default"},
+		}
+		c := setupTestClient(db)
+		v := &ConfigValidator{Client: c}
+		cfg := &openvoxv1alpha1.Config{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.ConfigSpec{
+				DatabaseRef: "my-db",
+				PuppetDB: openvoxv1alpha1.PuppetDBSpec{
+					ServerURLs: []string{"https://external:8081"},
+				},
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cfg)
+		if err == nil {
+			t.Error("expected error for databaseRef + serverUrls")
+		}
+	})
+
 	t.Run("delete always succeeds", func(t *testing.T) {
 		v := &ConfigValidator{Client: setupTestClient()}
 		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.Config{})


### PR DESCRIPTION
## Summary

- Add optional `Config.spec.databaseRef` field that references a Database CR
- When set, the Config controller resolves `Database.status.URL` for `puppetdb.conf` instead of requiring manual `serverUrls`
- `databaseRef` and `puppetdb.serverUrls` are mutually exclusive (enforced by validating webhook)
- Config controller watches Database resources to re-reconcile on changes
- Removes hardcoded default PuppetDB URL — when neither `databaseRef` nor `serverUrls` is set, `puppetdb.conf` is rendered without `server_urls`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/ -run TestConfig` passes
- [x] `go test ./internal/webhook/ -run TestConfig` passes
- [x] CRD and RBAC manifests regenerated via `make generate manifests`

Fixes #182