### PR TITLE
fix: add attestations:write permission to all container build callers

### DIFF
--- a/.github/workflows/ci-test-images.yaml
+++ b/.github/workflows/ci-test-images.yaml
@@ -17,6 +17,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-agent
       dockerfile: images/openvox-agent/Containerfile
@@ -29,6 +30,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-code
       dockerfile: images/openvox-code/Containerfile
@@ -41,6 +43,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-mock
       dockerfile: images/openvox-mock/Containerfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-operator
       dockerfile: images/openvox-operator/Containerfile
@@ -38,6 +39,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-server
       dockerfile: images/openvox-server/Containerfile
@@ -50,6 +52,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-db
       dockerfile: images/openvox-db/Containerfile

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 jobs:
   openvox-operator:
@@ -23,6 +24,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-operator
       dockerfile: images/openvox-operator/Containerfile
@@ -36,6 +38,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-server
       dockerfile: images/openvox-server/Containerfile
@@ -49,6 +52,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-code
       dockerfile: images/openvox-code/Containerfile
@@ -63,6 +67,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-agent
       dockerfile: images/openvox-agent/Containerfile
@@ -77,6 +82,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-db
       dockerfile: images/openvox-db/Containerfile
@@ -90,6 +96,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-mock
       dockerfile: images/openvox-mock/Containerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-operator
       dockerfile: images/openvox-operator/Containerfile
@@ -67,6 +68,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       image_name: openvox-server
       dockerfile: images/openvox-server/Containerfile


### PR DESCRIPTION
## Summary

- Add missing `attestations: write` permission to all workflow jobs that call `_container-build.yaml`
- Fixes validation error after enabling SBOM/provenance: nested job requesting `attestations: write` but caller only allowed `attestations: none`
- Updated workflows: ci.yaml, e2e.yaml, ci-test-images.yaml, release.yaml