### PR TITLE
docs: add merge strategy guidelines to AGENT.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -15,6 +15,11 @@ git checkout -b feat/my-feature origin/develop
 gh pr create --base develop
 ```
 
+## Merge Strategy
+
+- **Feature/fix PRs into `develop`:** Use standard merge by default. Use squash only when the branch has many noisy commits that logically belong together (e.g. lots of trial-and-error or CI fix-ups).
+- **`develop` into `main`:** Always rebase, so that `develop` and `main` stay identical after merge.
+
 ## Commit Messages
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/). Semantic-release on `main` uses these to determine version bumps.
@@ -36,7 +41,7 @@ test: add unit tests for helpers
 
 ## Pull Requests
 
-- Title follows the same conventional commit format as the squash-merge commit
+- Title follows conventional commit format
 - Keep the title short (under 72 chars)
 - Body should include a `## Summary` with bullet points and a `## Test plan`
 - Reference related issues with `Closes #<number>`

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ All resources use the API group `openvox.voxpupuli.org/v1alpha1`.
 | **`NodeClassifier`** | External Node Classifier (ENC) endpoint (custom HTTP) | *(rendered into Config's ENC Secret)* |
 | **`ReportProcessor`** | Report forwarding endpoint (generic webhook or PuppetDB Wire Format v8) | *(rendered into Config's report-webhook Secret)* |
 | **`Certificate`** | Lifecycle of a single certificate (request, sign) | TLS Secret |
-| **`Server`** | OpenVox Server instance pool (CA and/or server role), declares pool membership via `poolRefs` | Deployment |
-| **`Database`** | OpenVox DB with external PostgreSQL | Deployment, Service, ConfigMap, Secret |
+| **`Server`** | OpenVox Server instance pool (CA and/or server role), declares pool membership via `poolRefs` | Deployment, HPA, PDB, NetworkPolicy |
+| **`Database`** | OpenVox DB with external PostgreSQL | Deployment, Service, ConfigMap, Secret, PDB, NetworkPolicy |
 | **`Pool`** | Networking resource: Service + optional Gateway API TLSRoute for Servers that reference this Pool | Service, TLSRoute (optional) |
 
 ## Differences to VM-based Installations
@@ -166,7 +166,7 @@ helm install openvox-operator \
 
 ### 2. Deploy a Stack
 
-The `openvox-stack` chart deploys a complete OpenVox stack (Config, CertificateAuthority, SigningPolicy, Certificate, Server, Pool) with a single Helm release:
+The `openvox-stack` chart deploys a complete OpenVox stack (Config, CertificateAuthority, SigningPolicy, Certificate, Server, Pool, and optionally Database) with a single Helm release:
 
 ```bash
 helm install production \
@@ -279,6 +279,22 @@ See [Testing](docs/development/testing.md) for details.
 | `e2e-gateway` | Run Envoy Gateway TLSRoute tests |
 | `e2e-deps` | Install CNPG + Envoy Gateway for E2E tests |
 | `ci` | Run all CI checks locally (lint, vet, test, manifests, vulncheck, helm-lint) |
+
+## Supply Chain Security
+
+All container images are:
+
+- **Signed** with [cosign](https://docs.sigstore.dev/cosign/) keyless signing (Sigstore OIDC)
+- **Attested** with [SLSA provenance](https://slsa.dev/) via `docker/build-push-action`
+- **SBOM** generated and attached to each image
+
+Verify image signatures:
+
+```bash
+cosign verify ghcr.io/slauger/openvox-operator:latest \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'github\.com/slauger/openvox-operator'
+```
 
 ## Documentation
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -18,10 +18,13 @@ graph TD
     Cert["Certificate"]
     Srv["Server"]
     Pool["Pool"]
+    DB["Database"]
     Cfg -->|authorityRef| CA
+    Cfg -.->|databaseRef| DB
     Cfg -.->|nodeClassifierRef| NC
     SP -.->|certificateAuthorityRef| CA
     Cert -->|authorityRef| CA
+    DB -->|certificateRef| Cert
     Srv -->|certificateRef| Cert
     Srv -->|configRef| Cfg
     RP -.->|configRef| Cfg
@@ -34,6 +37,7 @@ graph TD
 - A **NodeClassifier** is an optional standalone resource defining an External Node Classifier endpoint. A Config references it via `nodeClassifierRef`. The Config controller renders the classifier configuration into an ENC Secret, and puppet.conf gets `node_terminus = exec`. See [External Node Classification](external-node-classification.md).
 - A **ReportProcessor** is an optional standalone resource that defines an external endpoint for Puppet run reports. One or more ReportProcessors can reference the same Config via `configRef`. The Config controller collects all matching ReportProcessors, renders a `report-webhook.yaml` config, and sets `reports = webhook` in puppet.conf. A minimal Ruby shim (`webhook.rb`) pipes each report as JSON to the `openvox-report` binary, which forwards it to all configured endpoints. Supports built-in PuppetDB wire format v8 (`processor: puppetdb`) and generic HTTP webhooks with configurable auth (mTLS, Bearer, Basic, custom headers). See [Report Processing](report-processing.md).
 - A **Certificate** references a CertificateAuthority and manages the lifecycle of a single certificate: signing Job and TLS Secret.
+- A **Database** creates a Deployment of OpenVox DB pods. It references a Certificate for SSL and connects to an external PostgreSQL instance. A Config can reference a Database via `databaseRef` to automatically wire the PuppetDB connection URL from its `status.url`.
 - A **Server** references a Config and a Certificate. It creates a Deployment (with Recreate strategy for CA, RollingUpdate for servers). The Server waits for the Certificate to reach the `Signed` phase before creating its Deployment. A Server declares pool membership via `poolRefs`.
 - A **Pool** is a pure networking resource that creates a Kubernetes Service. Servers join a Pool by listing its name in their `poolRefs`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,11 +30,12 @@ The operator manages OpenVox Server infrastructure through a set of Custom Resou
 | **SigningPolicy** | Declarative CSR signing policy (any, pattern, CSR attributes) | *(rendered into Config's autosign Secret)* |
 | **NodeClassifier** | External Node Classifier (ENC) endpoint (Foreman, PE, custom HTTP) | *(rendered into Config's ENC Secret)* |
 | **Certificate** | Lifecycle of a single certificate (request, sign) | TLS Secret |
-| **Server** | OpenVox Server instance pool (CA and/or server role), declares pool membership via `poolRefs` | Deployment |
+| **Server** | OpenVox Server instance pool (CA and/or server role), declares pool membership via `poolRefs` | Deployment, HPA, PDB, NetworkPolicy |
 | **Pool** | Networking resource: Service + optional Gateway API TLSRoute for Servers that reference this Pool | Service, TLSRoute (optional) |
+| **Database** | OpenVox DB (PuppetDB) instance with external PostgreSQL backend | Deployment, Service, ConfigMap, Secret, PDB, NetworkPolicy |
 | **ReportProcessor** | Webhook-based report forwarding (OpenVox DB or custom HTTP endpoints) | *(rendered into Config's report-webhook Secret)* |
 
-For details on the CRD hierarchy and design rationale, see [Architecture](concepts/architecture.md). Puppet code is deployed via [OCI image volumes or PVCs](concepts/code-deployment.md). External Node Classifiers (Foreman, PE, custom HTTP) are configured via the [NodeClassifier CRD](concepts/external-node-classification.md). Report forwarding is configured via the [ReportProcessor CRD](concepts/report-processing.md). Pools support optional [Gateway API TLSRoute](concepts/gateway-api.md) for SNI-based routing. See [Traffic Flow](concepts/traffic-flow.md) for how agents connect to servers.
+For details on the CRD hierarchy and design rationale, see [Architecture](concepts/architecture.md). Puppet code is deployed via [OCI image volumes or PVCs](concepts/code-deployment.md). External Node Classifiers (Foreman, PE, custom HTTP) are configured via the [NodeClassifier CRD](concepts/external-node-classification.md). Report forwarding is configured via the [ReportProcessor CRD](concepts/report-processing.md). OpenVox DB is managed via the [Database CRD](reference/database.md). Pools support optional [Gateway API TLSRoute](concepts/gateway-api.md) for SNI-based routing. See [Traffic Flow](concepts/traffic-flow.md) for how agents connect to servers.
 
 ## License
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,6 +1,6 @@
 # Config
 
-A Config holds shared configuration for all Servers: the default container image, puppet.conf settings, and OpenVox DB (PuppetDB) connection. It is the root resource in the CRD hierarchy. The `authorityRef` field references a CertificateAuthority; CA settings (`ca_ttl`, `autosign`) are automatically pulled from it.
+A Config holds shared configuration for all Servers: the default container image, puppet.conf settings, and OpenVox DB (PuppetDB) connection. It is the root resource in the CRD hierarchy. The `authorityRef` field references a CertificateAuthority; CA settings (`ca_ttl`, `autosign`) are automatically pulled from it. The `databaseRef` field can reference a [Database](database.md) resource to automatically wire the PuppetDB connection URL from its status.
 
 ## Example
 
@@ -29,9 +29,10 @@ spec:
 |---|---|---|---|
 | `image` | [ImageSpec](index.md#imagespec) | **required** | Default container image for all Servers |
 | `authorityRef` | string | - | Reference to the CertificateAuthority used by this Config |
+| `databaseRef` | string | - | Reference to a [Database](database.md) whose `status.url` is used for `puppetdb.conf` (mutually exclusive with `puppetdb`) |
 | `nodeClassifierRef` | string | - | Reference to a [NodeClassifier](nodeclassifier.md) for ENC support |
 | `puppet` | [PuppetSpec](#puppetspec) | - | Shared puppet.conf settings |
-| `puppetdb` | [PuppetDBSpec](#puppetdbspec) | - | OpenVox DB (PuppetDB) connection settings |
+| `puppetdb` | [PuppetDBSpec](#puppetdbspec) | - | OpenVox DB (PuppetDB) connection settings (mutually exclusive with `databaseRef`) |
 | `puppetserver` | [PuppetServerSpec](#puppetserverspec) | - | puppetserver.conf, webserver.conf, and auth.conf settings |
 | `logging` | [LoggingSpec](#loggingspec) | - | Logback.xml log level configuration |
 | `metrics` | [MetricsSpec](#metricsspec) | - | Puppet Server metrics (JMX, Graphite) |

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -41,7 +41,26 @@ spec:
 | `resources` | ResourceRequirements | - | CPU/memory requests and limits |
 | `replicas` | int32 | `1` | Number of pod replicas |
 | `javaArgs` | string | - | JVM arguments |
+| `pdb` | [PDBSpec](#pdbspec) | - | PodDisruptionBudget configuration |
+| `networkPolicy` | [NetworkPolicySpec](#networkpolicyspec) | - | NetworkPolicy configuration |
 | `service` | [DatabaseServiceSpec](#databaseservicespec) | - | Service configuration |
+
+### PDBSpec
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Activate the PodDisruptionBudget |
+| `minAvailable` | int or string | - | Minimum pods that must be available (mutually exclusive with `maxUnavailable`) |
+| `maxUnavailable` | int or string | - | Maximum pods that can be unavailable (mutually exclusive with `minAvailable`) |
+
+### NetworkPolicySpec
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Activate the NetworkPolicy |
+| `additionalIngress` | []NetworkPolicyIngressRule | - | Extra ingress rules appended to the defaults |
+
+When enabled, the default policy allows TCP/8081 only from pods with `app.kubernetes.io/name: openvox` in the same namespace. Additional ingress rules are appended to this default (e.g. to allow PuppetBoard access).
 
 ### PostgresSpec
 
@@ -113,6 +132,8 @@ The init container copies TLS certificates from Secrets into the writable `ssl` 
 | Service | `{name}` | HTTPS endpoint on port 8081 |
 | ConfigMap | `{name}-config` | `jetty.ini` and `config.ini` |
 | Secret | `{name}-db` | `database.ini` with PostgreSQL credentials |
+| PDB | `{name}` | Only when `pdb.enabled: true` |
+| NetworkPolicy | `{name}-netpol` | Only when `networkPolicy.enabled: true` |
 
 ## Prerequisites
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -39,6 +39,7 @@ spec:
 | `topologySpreadConstraints` | []TopologySpreadConstraint | - | Pod spread constraints across topology domains |
 | `affinity` | Affinity | - | Pod affinity/anti-affinity rules |
 | `pdb` | [PDBSpec](#pdbspec) | - | PodDisruptionBudget configuration |
+| `networkPolicy` | [NetworkPolicySpec](#networkpolicyspec) | - | NetworkPolicy configuration |
 
 ### PDBSpec
 
@@ -47,6 +48,15 @@ spec:
 | `enabled` | bool | `false` | Activate the PodDisruptionBudget |
 | `minAvailable` | int or string | - | Minimum pods that must be available (mutually exclusive with `maxUnavailable`) |
 | `maxUnavailable` | int or string | - | Maximum pods that can be unavailable (mutually exclusive with `minAvailable`) |
+
+### NetworkPolicySpec
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Activate the NetworkPolicy |
+| `additionalIngress` | []NetworkPolicyIngressRule | - | Extra ingress rules appended to the defaults |
+
+When enabled, the default policy allows TCP/8140 from all sources (agents may connect from outside the cluster). Additional ingress rules are appended to this default.
 
 ### AutoscalingSpec
 
@@ -144,3 +154,4 @@ Key differences:
 | Deployment | `{name}` | OpenVox Server pods |
 | HPA | `{name}` | Only when `autoscaling.enabled: true` |
 | PDB | `{name}` | Only when `pdb.enabled: true` |
+| NetworkPolicy | `{name}-netpol` | Only when `networkPolicy.enabled: true` |


### PR DESCRIPTION
## Summary

- Add merge strategy section: standard merge for PRs into develop, squash only for noisy branches, rebase-only for develop into main
- Fix PR section that incorrectly assumed squash-merge