### PR TITLE
docs: document injectDNSAltName re-signing side effect

### DIFF
--- a/docs/concepts/gateway-api.md
+++ b/docs/concepts/gateway-api.md
@@ -82,6 +82,8 @@ When `injectDNSAltName: true`, the operator adds the route hostname to the `dnsA
 
 Without this, agents connecting via the SNI hostname would see a certificate mismatch because the server certificate wouldn't include that hostname as a SAN.
 
+**Side effect:** Modifying the Certificate's `dnsAltNames` resets its phase to `Pending`, which triggers re-signing and recreates the TLS Secret. This causes a brief restart of affected Server pods. This only happens once per hostname -- subsequent reconciles detect the hostname is already present and skip the update.
+
 ## Gateway Setup Example
 
 The Gateway resource is not managed by the operator. A cluster admin creates it:

--- a/docs/reference/pool.md
+++ b/docs/reference/pool.md
@@ -40,7 +40,7 @@ spec:
 | `enabled` | bool | `false` | Activates TLSRoute creation for this Pool |
 | `hostname` | string | - | SNI hostname (required when enabled) |
 | `gatewayRef` | [GatewayReference](#gatewayreference) | - | Gateway to attach the TLSRoute to (required when enabled) |
-| `injectDNSAltName` | bool | `false` | Add hostname to Certificate dnsAltNames of Servers that reference this Pool |
+| `injectDNSAltName` | bool | `false` | Add hostname to Certificate dnsAltNames of Servers that reference this Pool. **Note:** this modifies the Certificate spec and triggers re-signing, which briefly recreates the TLS Secret. |
 
 ### GatewayReference
 


### PR DESCRIPTION
## Summary

- Document that `injectDNSAltName: true` triggers Certificate re-signing and TLS Secret recreation
- Updated in both `docs/reference/pool.md` and `docs/concepts/gateway-api.md`
- Clarify this is a one-time side effect per hostname

Closes #211