### PR TITLE
fix: auto-enable storeconfigs when database is enabled in Helm chart

### DIFF
--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -20,12 +20,10 @@ spec:
       - https://{{ .Values.database.name }}:8081
       {{- end }}
   {{- end }}
-  {{- with .Values.config.puppet }}
   puppet:
-    environmentTimeout: {{ .environmentTimeout }}
-    storeconfigs: {{ .storeconfigs }}
-    reports: {{ .reports }}
-  {{- end }}
+    environmentTimeout: {{ .Values.config.puppet.environmentTimeout }}
+    storeconfigs: {{ ternary true .Values.config.puppet.storeconfigs .Values.database.enabled }}
+    reports: {{ .Values.config.puppet.reports }}
   {{- with .Values.config.code }}
   {{- if or .image .claimName }}
   code:


### PR DESCRIPTION
## Summary

- Use Helm `ternary` to automatically set `storeconfigs: true` when `database.enabled: true`
- Without database: keeps the existing default (`false`)
- Explicit `config.puppet.storeconfigs` override still works
- Resolves the inconsistency between CRD default (`true`) and Helm chart default (`false`)

Closes #209

## Test plan

- [x] `helm template` without database: storeconfigs=false
- [x] `helm template` with database.enabled=true: storeconfigs=true
- [x] `helm template` with explicit storeconfigs=true (no database): storeconfigs=true
- [x] `helm lint` passes