### PR TITLE
fix: expose readOnlyRootFilesystem in openvox-stack Helm chart

### DIFF
--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -20,6 +20,9 @@ spec:
       - https://{{ .Values.database.name }}:8081
       {{- end }}
   {{- end }}
+  {{- if .Values.config.readOnlyRootFilesystem }}
+  readOnlyRootFilesystem: true
+  {{- end }}
   puppet:
     environmentTimeout: {{ .Values.config.puppet.environmentTimeout }}
     storeconfigs: {{ ternary true .Values.config.puppet.storeconfigs .Values.database.enabled }}

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -3,6 +3,7 @@
 
 config:
   name: ""             # default: Release name
+  readOnlyRootFilesystem: false
   image:
     repository: ghcr.io/slauger/openvox-server
     tag: latest


### PR DESCRIPTION
## Summary

- Add `config.readOnlyRootFilesystem` to `values.yaml` (default: `false`)
- Render the field in `config.yaml` template when enabled
- Note: Database pods already have `readOnlyRootFilesystem: true` hardcoded -- no change needed there

Closes #208

## Test plan

- [x] `helm template` without flag: field omitted from output
- [x] `helm template --set config.readOnlyRootFilesystem=true`: field rendered
- [x] `helm lint` passes