### PR TITLE
fix: use databaseRef in openvox-stack and fix openvox-db-postgres NOTES.txt

### DIFF
--- a/charts/openvox-db-postgres/templates/NOTES.txt
+++ b/charts/openvox-db-postgres/templates/NOTES.txt
@@ -8,6 +8,11 @@ Connection details:
 Example openvox-stack values:
 
   database:
-    backend: cnpg
-    cnpg:
-      clusterName: {{ include "openvox-db-postgres.name" . }}
+    enabled: true
+    name: puppetdb
+    certificate:
+      certname: puppetdb
+    postgres:
+      host: {{ include "openvox-db-postgres.name" . }}-rw
+      credentialsSecretRef: {{ include "openvox-db-postgres.name" . }}-app
+      database: {{ .Values.database }}

--- a/charts/openvox-stack/ci/database-cnpg-values.yaml
+++ b/charts/openvox-stack/ci/database-cnpg-values.yaml
@@ -13,11 +13,7 @@ database:
     sslMode: disable
 
 config:
-  puppetdb:
-    serverUrls:
-      - https://openvox-stack-db-puppetdb:8081
   puppet:
-    storeconfigs: true
     reports: store,puppetdb
 
 servers:

--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -11,14 +11,12 @@ spec:
     repository: {{ .Values.config.image.repository }}
     tag: {{ .Values.config.image.tag | quote }}
     pullPolicy: {{ .Values.config.image.pullPolicy }}
-  {{- if or .Values.config.puppetdb.serverUrls (and .Values.database.enabled .Values.database.name) }}
+  {{- if .Values.config.puppetdb.serverUrls }}
   puppetdb:
     serverUrls:
-      {{- if .Values.config.puppetdb.serverUrls }}
       {{- toYaml .Values.config.puppetdb.serverUrls | nindent 6 }}
-      {{- else }}
-      - https://{{ .Values.database.name }}:8081
-      {{- end }}
+  {{- else if and .Values.database.enabled .Values.database.name }}
+  databaseRef: {{ .Values.database.name }}
   {{- end }}
   {{- if .Values.config.readOnlyRootFilesystem }}
   readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

- **openvox-stack**: Use `databaseRef` instead of hardcoded `puppetdb.serverUrls` when `database.enabled` is true. Explicit `serverUrls` still take precedence. Also removes redundant `storeconfigs: true` from CI values (handled automatically by the ternary from #209).
- **openvox-db-postgres**: Fix NOTES.txt which referenced non-existent `database.backend` and `database.cnpg` fields. Now shows correct `openvox-stack` values.

Closes #222
Closes #223

## Test plan

- [x] `helm template` with database enabled: renders `databaseRef` instead of `puppetdb.serverUrls`
- [x] `helm template` without database: no `databaseRef` or `puppetdb` block
- [x] `helm template` with explicit `serverUrls`: renders `puppetdb.serverUrls` (takes precedence)
- [x] `helm lint` passes for both charts