### PR TITLE
refactor: clarify if/else pattern in reconcileServerServiceAccount

### DIFF
--- a/internal/controller/config_serviceaccount.go
+++ b/internal/controller/config_serviceaccount.go
@@ -18,7 +18,8 @@ func (r *ConfigReconciler) reconcileServerServiceAccount(ctx context.Context, cf
 	automount := false
 
 	sa := &corev1.ServiceAccount{}
-	if err := r.Get(ctx, types.NamespacedName{Name: saName, Namespace: cfg.Namespace}, sa); errors.IsNotFound(err) {
+	err := r.Get(ctx, types.NamespacedName{Name: saName, Namespace: cfg.Namespace}, sa)
+	if errors.IsNotFound(err) {
 		sa = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      saName,
@@ -31,7 +32,8 @@ func (r *ConfigReconciler) reconcileServerServiceAccount(ctx context.Context, cf
 			return err
 		}
 		return r.Create(ctx, sa)
-	} else {
+	} else if err != nil {
 		return err
 	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Separate the `Get` error check into explicit branches: NotFound, other errors, and already-exists
- Replaces the confusing `else { return err }` which implicitly returned `nil` when the SA already existed

Closes #224

## Test plan

- [x] `go build ./...` passes
- [x] Config controller tests pass