### PR TITLE
fix: use ParseDurationToSeconds for crlRefreshInterval

### DIFF
--- a/internal/controller/certificateauthority_crl.go
+++ b/internal/controller/certificateauthority_crl.go
@@ -22,11 +22,11 @@ func (r *CertificateAuthorityReconciler) reconcileCRLRefresh(ctx context.Context
 
 	interval := DefaultCRLRefreshInterval
 	if ca.Spec.CRLRefreshInterval != "" {
-		parsed, err := time.ParseDuration(ca.Spec.CRLRefreshInterval)
+		secs, err := openvoxv1alpha1.ParseDurationToSeconds(ca.Spec.CRLRefreshInterval)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("parsing crlRefreshInterval %q: %w", ca.Spec.CRLRefreshInterval, err)
 		}
-		interval = parsed
+		interval = time.Duration(secs) * time.Second
 	}
 
 	// Resolve CA base URL: external URL or internal CA Service


### PR DESCRIPTION
## Summary

- Replace `time.ParseDuration` with `ParseDurationToSeconds` in `reconcileCRLRefresh`
- The webhook validator already uses `ParseDurationToSeconds` which supports `d` and `y` units, but the controller used Go's `time.ParseDuration` which only supports up to `h`
- Values like `1d` or `7d` passed validation but caused a runtime error loop

Closes #219

## Test plan

- [x] `go build ./...` passes
- [x] Controller tests pass