### PR TITLE
feat: support BYO TLS secret for admission webhooks

### DIFF
--- a/charts/openvox-operator/ci/webhook-byo-values.yaml
+++ b/charts/openvox-operator/ci/webhook-byo-values.yaml
@@ -1,0 +1,8 @@
+webhook:
+  enabled: true
+  port: 9443
+  certManager:
+    enabled: false
+  tls:
+    certSecret: my-webhook-cert
+    caBundle: LS0tLS1CRUdJTi...

--- a/charts/openvox-operator/ci/webhook-values.yaml
+++ b/charts/openvox-operator/ci/webhook-values.yaml
@@ -2,5 +2,6 @@ webhook:
   enabled: true
   port: 9443
   certManager:
+    enabled: true
     duration: 8760h
     renewBefore: 720h

--- a/charts/openvox-operator/templates/deployment.yaml
+++ b/charts/openvox-operator/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
       volumes:
         - name: webhook-certs
           secret:
-            secretName: {{ include "openvox-operator.fullname" . }}-webhook-cert
+            secretName: {{ .Values.webhook.tls.certSecret | default (printf "%s-webhook-cert" (include "openvox-operator.fullname" .)) }}
       {{- end }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.nodeSelector }}

--- a/charts/openvox-operator/templates/webhook-certmanager.yaml
+++ b/charts/openvox-operator/templates/webhook-certmanager.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if and .Values.webhook.enabled .Values.webhook.certManager.enabled }}
 ---
 # Self-signed issuer for bootstrapping
 apiVersion: cert-manager.io/v1

--- a/charts/openvox-operator/templates/webhook-configuration.yaml
+++ b/charts/openvox-operator/templates/webhook-configuration.yaml
@@ -3,18 +3,25 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "openvox-operator.fullname" . }}
+  {{- if .Values.webhook.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "openvox-operator.fullname" . }}-webhook
+  {{- end }}
   labels:
     {{- include "openvox-operator.labels" . | nindent 4 }}
 webhooks:
   {{- $fullname := include "openvox-operator.fullname" . }}
   {{- $ns := .Release.Namespace }}
+  {{- $certManagerEnabled := .Values.webhook.certManager.enabled }}
+  {{- $caBundle := .Values.webhook.tls.caBundle }}
   {{- range $kind := list "server" "certificate" "config" "signingpolicy" "reportprocessor" "nodeclassifier" "certificateauthority" "pool" "database" }}
   - name: v{{ $kind }}.kb.io
     admissionReviewVersions:
       - v1
     clientConfig:
+      {{- if and (not $certManagerEnabled) $caBundle }}
+      caBundle: {{ $caBundle }}
+      {{- end }}
       service:
         name: {{ $fullname }}-webhook
         namespace: {{ $ns }}

--- a/charts/openvox-operator/values.yaml
+++ b/charts/openvox-operator/values.yaml
@@ -31,13 +31,17 @@ resources:
     cpu: 10m
     memory: 64Mi
 
-# Admission webhook configuration (requires cert-manager)
+# Admission webhook configuration
 webhook:
   enabled: false
   port: 9443
   certManager:
-    duration: 8760h    # 1 year
-    renewBefore: 720h  # 30 days
+    enabled: true        # set to false to skip cert-manager resources
+    duration: 8760h      # 1 year
+    renewBefore: 720h    # 30 days
+  tls:
+    certSecret: ""       # name of an existing TLS Secret (tls.crt, tls.key, ca.crt)
+    caBundle: ""         # base64-encoded CA certificate for webhook config
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## Summary

- Add `webhook.certManager.enabled` toggle (default `true`) to make cert-manager optional
- Add `webhook.tls.certSecret` and `webhook.tls.caBundle` for bringing your own TLS secret
- Skip cert-manager resources (Issuer, Certificate) when `certManager.enabled: false`
- Inject `caBundle` directly into `ValidatingWebhookConfiguration` in BYO mode
- Reference user-provided secret in Deployment volume instead of cert-manager generated one

## Test plan

- [ ] `helm template` with default values renders no webhook resources
- [ ] `helm template -f ci/webhook-values.yaml` renders cert-manager flow unchanged (Issuer, Certificate, annotation)
- [ ] `helm template -f ci/webhook-byo-values.yaml` renders no cert-manager resources, uses custom secret and caBundle
- [ ] `helm lint` passes for all three value combinations
- [ ] E2E: deploy webhooks with self-signed cert secret, verify webhook validation works

Closes #231