### PR TITLE
feat: add helm-unittest test suite for all charts

### DIFF
--- a/.github/workflows/_helm.yaml
+++ b/.github/workflows/_helm.yaml
@@ -19,8 +19,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
 
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+
       - name: Helm lint
         run: helm lint charts/${{ matrix.chart }}
 
       - name: Helm template
         run: helm template test charts/${{ matrix.chart }}
+
+      - name: Helm unittest
+        run: helm unittest charts/${{ matrix.chart }}

--- a/.github/workflows/_helm.yaml
+++ b/.github/workflows/_helm.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: azure/setup-helm@v5
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        run: helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest
 
       - name: Helm lint
         run: helm lint charts/${{ matrix.chart }}

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,12 @@ helm-lint: ## Lint the Helm chart.
 	helm lint charts/openvox-stack
 	helm lint charts/openvox-db-postgres
 
+.PHONY: helm-unittest
+helm-unittest: ## Run helm-unittest for all charts.
+	helm unittest charts/openvox-operator
+	helm unittest charts/openvox-stack
+	helm unittest charts/openvox-db-postgres
+
 .PHONY: helm-template
 helm-template: ## Render Helm chart templates locally.
 	helm template openvox-operator charts/openvox-operator
@@ -161,7 +167,7 @@ check-manifests: manifests generate ## Check for CRD and deepcopy drift.
 	fi
 
 .PHONY: ci
-ci: lint vet test check-manifests vulncheck helm-lint ## Run all CI checks locally.
+ci: lint vet test check-manifests vulncheck helm-lint helm-unittest ## Run all CI checks locally.
 	@echo "All CI checks passed."
 
 ##@ E2E

--- a/charts/openvox-db-postgres/tests/cluster_test.yaml
+++ b/charts/openvox-db-postgres/tests/cluster_test.yaml
@@ -1,0 +1,95 @@
+suite: CNPG Cluster
+templates:
+  - templates/cluster.yaml
+tests:
+  - it: should render a Cluster with default values
+    asserts:
+      - isKind:
+          of: Cluster
+      - isAPIVersion:
+          of: postgresql.cnpg.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME
+      - equal:
+          path: spec.instances
+          value: 1
+      - equal:
+          path: spec.storage.size
+          value: 1Gi
+      - isNull:
+          path: spec.storage.storageClassName
+      - equal:
+          path: spec.bootstrap.initdb.database
+          value: openvoxdb
+      - equal:
+          path: spec.bootstrap.initdb.owner
+          value: app
+
+  - it: should always include pg_trgm extension
+    asserts:
+      - contains:
+          path: spec.bootstrap.initdb.postInitApplicationSQL
+          content: CREATE EXTENSION IF NOT EXISTS pg_trgm
+
+  - it: should override instance count
+    set:
+      instances: 3
+    asserts:
+      - equal:
+          path: spec.instances
+          value: 3
+
+  - it: should set storageClassName when storageClass is provided
+    set:
+      storage:
+        size: 5Gi
+        storageClass: premium-rwo
+    asserts:
+      - equal:
+          path: spec.storage.storageClassName
+          value: premium-rwo
+      - equal:
+          path: spec.storage.size
+          value: 5Gi
+
+  - it: should not set storageClassName when storageClass is empty
+    asserts:
+      - isNull:
+          path: spec.storage.storageClassName
+
+  - it: should append postInitSQL after pg_trgm
+    set:
+      postInitSQL:
+        - "CREATE INDEX idx_reports ON reports (certname)"
+    asserts:
+      - equal:
+          path: spec.bootstrap.initdb.postInitApplicationSQL[0]
+          value: CREATE EXTENSION IF NOT EXISTS pg_trgm
+      - equal:
+          path: spec.bootstrap.initdb.postInitApplicationSQL[1]
+          value: "CREATE INDEX idx_reports ON reports (certname)"
+
+  - it: should include only pg_trgm with empty postInitSQL
+    set:
+      postInitSQL: []
+    asserts:
+      - lengthEqual:
+          path: spec.bootstrap.initdb.postInitApplicationSQL
+          count: 1
+
+  - it: should use custom database name
+    set:
+      database: customdb
+    asserts:
+      - equal:
+          path: spec.bootstrap.initdb.database
+          value: customdb
+
+  - it: should use custom name override
+    set:
+      name: my-pg-cluster
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-pg-cluster

--- a/charts/openvox-operator/tests/clusterrole_test.yaml
+++ b/charts/openvox-operator/tests/clusterrole_test.yaml
@@ -1,0 +1,81 @@
+suite: ClusterRole
+templates:
+  - templates/clusterrole.yaml
+tests:
+  - it: should render a ClusterRole in cluster mode (default)
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-openvox-operator
+      - isNull:
+          path: metadata.namespace
+
+  - it: should render a Role in namespace mode
+    set:
+      scope:
+        mode: namespace
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should use custom watchNamespace in namespace mode
+    set:
+      scope:
+        mode: namespace
+        watchNamespace: custom-ns
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: should contain openvox CRD rules
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["openvox.voxpupuli.org"]
+            resources: ["configs", "pools", "servers", "certificateauthorities", "certificates", "signingpolicies", "nodeclassifiers", "reportprocessors", "databases"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: should contain networkpolicies rule
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["networkpolicies"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: should contain poddisruptionbudgets rule
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["policy"]
+            resources: ["poddisruptionbudgets"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: should contain horizontalpodautoscalers rule
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["autoscaling"]
+            resources: ["horizontalpodautoscalers"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: should contain leases rule
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/charts/openvox-operator/tests/clusterrolebinding_test.yaml
+++ b/charts/openvox-operator/tests/clusterrolebinding_test.yaml
@@ -1,0 +1,42 @@
+suite: ClusterRoleBinding
+templates:
+  - templates/clusterrolebinding.yaml
+tests:
+  - it: should render a ClusterRoleBinding in cluster mode (default)
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-openvox-operator
+      - isNull:
+          path: metadata.namespace
+
+  - it: should render a RoleBinding in namespace mode
+    set:
+      scope:
+        mode: namespace
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should reference the correct ServiceAccount
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-openvox-operator
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE

--- a/charts/openvox-operator/tests/deployment_test.yaml
+++ b/charts/openvox-operator/tests/deployment_test.yaml
@@ -1,0 +1,111 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should render a Deployment with default values
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-openvox-operator
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should use tag-based image by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/slauger/openvox-operator:latest"
+
+  - it: should use digest-based image when digest is set
+    set:
+      image:
+        repository: ghcr.io/slauger/openvox-operator
+        digest: sha256:abc123def456
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/slauger/openvox-operator@sha256:abc123def456"
+
+  - it: should enable leader election by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect
+
+  - it: should not have any args when leaderElect is false
+    set:
+      leaderElect: false
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.containers[0].args
+
+  - it: should not have webhook port or args when webhook is disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: webhook
+          any: true
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts
+      - isNull:
+          path: spec.template.spec.volumes
+
+  - it: should have webhook port and args when webhook is enabled
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-webhooks
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: webhook
+            containerPort: 9443
+            protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: webhook-certs
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: webhook-certs
+
+  - it: should not have watch-namespace arg in cluster mode
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --watch-namespace=NAMESPACE
+          any: true
+
+  - it: should have watch-namespace arg in namespace mode
+    set:
+      scope:
+        mode: namespace
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --watch-namespace=NAMESPACE
+
+  - it: should use custom watchNamespace in namespace mode
+    set:
+      scope:
+        mode: namespace
+        watchNamespace: custom-ns
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --watch-namespace=custom-ns
+
+  - it: should propagate resources
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi

--- a/charts/openvox-operator/tests/serviceaccount_test.yaml
+++ b/charts/openvox-operator/tests/serviceaccount_test.yaml
@@ -1,0 +1,41 @@
+suite: ServiceAccount
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: should render a ServiceAccount by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-openvox-operator
+
+  - it: should not render when create is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use custom name
+    set:
+      serviceAccount:
+        create: true
+        name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should add annotations
+    set:
+      serviceAccount:
+        create: true
+        annotations:
+          my-annotation: my-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            my-annotation: my-value

--- a/charts/openvox-operator/tests/webhook-certmanager_test.yaml
+++ b/charts/openvox-operator/tests/webhook-certmanager_test.yaml
@@ -1,0 +1,93 @@
+suite: Webhook cert-manager resources
+templates:
+  - templates/webhook-certmanager.yaml
+tests:
+  - it: should not render when webhook is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render 4 resources when webhook is enabled
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: should render a self-signed Issuer as first document
+    set:
+      webhook:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Issuer
+      - isAPIVersion:
+          of: cert-manager.io/v1
+      - exists:
+          path: spec.selfSigned
+
+  - it: should render a CA Certificate as second document
+    set:
+      webhook:
+        enabled: true
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.isCA
+          value: true
+      - equal:
+          path: spec.duration
+          value: 87600h
+
+  - it: should render a CA Issuer as third document
+    set:
+      webhook:
+        enabled: true
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: Issuer
+      - equal:
+          path: spec.ca.secretName
+          value: RELEASE-NAME-openvox-operator-ca-cert
+
+  - it: should render a webhook Certificate as fourth document
+    set:
+      webhook:
+        enabled: true
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.secretName
+          value: RELEASE-NAME-openvox-operator-webhook-cert
+      - equal:
+          path: spec.duration
+          value: 8760h
+      - equal:
+          path: spec.renewBefore
+          value: 720h
+      - lengthEqual:
+          path: spec.dnsNames
+          count: 4
+
+  - it: should use custom cert-manager duration and renewBefore
+    set:
+      webhook:
+        enabled: true
+        certManager:
+          duration: 17520h
+          renewBefore: 1440h
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: spec.duration
+          value: 17520h
+      - equal:
+          path: spec.renewBefore
+          value: 1440h

--- a/charts/openvox-operator/tests/webhook-configuration_test.yaml
+++ b/charts/openvox-operator/tests/webhook-configuration_test.yaml
@@ -1,0 +1,61 @@
+suite: ValidatingWebhookConfiguration
+templates:
+  - templates/webhook-configuration.yaml
+tests:
+  - it: should not render when webhook is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ValidatingWebhookConfiguration when webhook is enabled
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ValidatingWebhookConfiguration
+      - isAPIVersion:
+          of: admissionregistration.k8s.io/v1
+
+  - it: should have cert-manager inject-ca-from annotation
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            cert-manager.io/inject-ca-from: NAMESPACE/RELEASE-NAME-openvox-operator-webhook
+
+  - it: should have 9 webhook entries for all CRD types
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - lengthEqual:
+          path: webhooks
+          count: 9
+
+  - it: should have correct webhook path for server
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - equal:
+          path: webhooks[0].clientConfig.service.path
+          value: /validate-openvox-voxpupuli-org-v1alpha1-server
+      - equal:
+          path: webhooks[0].name
+          value: vserver.kb.io
+
+  - it: should have correct webhook path for database
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - equal:
+          path: webhooks[8].clientConfig.service.path
+          value: /validate-openvox-voxpupuli-org-v1alpha1-database
+      - equal:
+          path: webhooks[8].rules[0].resources[0]
+          value: databases

--- a/charts/openvox-operator/tests/webhook-service_test.yaml
+++ b/charts/openvox-operator/tests/webhook-service_test.yaml
@@ -1,0 +1,25 @@
+suite: Webhook Service
+templates:
+  - templates/webhook-service.yaml
+tests:
+  - it: should not render when webhook is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a Service when webhook is enabled
+    set:
+      webhook:
+        enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-openvox-operator-webhook
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      - equal:
+          path: spec.ports[0].targetPort
+          value: webhook

--- a/charts/openvox-stack/tests/certificateauthority_test.yaml
+++ b/charts/openvox-stack/tests/certificateauthority_test.yaml
@@ -1,0 +1,53 @@
+suite: CertificateAuthority
+templates:
+  - templates/certificateauthority.yaml
+tests:
+  - it: should render a CertificateAuthority with default values
+    asserts:
+      - isKind:
+          of: CertificateAuthority
+      - isAPIVersion:
+          of: openvox.voxpupuli.org/v1alpha1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.ttl
+          value: 5y
+      - equal:
+          path: spec.storage.size
+          value: 1Gi
+
+  - it: should propagate custom ttl
+    set:
+      ca:
+        ttl: 10y
+    asserts:
+      - equal:
+          path: spec.ttl
+          value: 10y
+
+  - it: should set storageClass when provided
+    set:
+      ca:
+        storage:
+          size: 5Gi
+          storageClass: fast-ssd
+    asserts:
+      - equal:
+          path: spec.storage.storageClass
+          value: fast-ssd
+
+  - it: should not set storageClass when empty (default)
+    asserts:
+      - isNull:
+          path: spec.storage.storageClass
+
+  - it: should use custom name
+    set:
+      ca:
+        name: my-custom-ca
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-ca

--- a/charts/openvox-stack/tests/certificates_test.yaml
+++ b/charts/openvox-stack/tests/certificates_test.yaml
@@ -1,0 +1,83 @@
+suite: Certificates
+templates:
+  - templates/certificates.yaml
+tests:
+  - it: should render 2 Certificates for default 2 servers
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should render first Certificate for ca server
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.authorityRef
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.certname
+          value: puppet
+
+  - it: should auto-generate dnsAltNames for ca server
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.dnsAltNames
+          content: RELEASE-NAME-ca
+      - contains:
+          path: spec.dnsAltNames
+          content: puppet
+
+  - it: should render second Certificate for server
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-server
+      - equal:
+          path: spec.certname
+          value: server
+
+  - it: should auto-generate dnsAltNames for server
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.dnsAltNames
+          content: RELEASE-NAME-server
+      - contains:
+          path: spec.dnsAltNames
+          content: puppet
+
+  - it: should render 1 Certificate for single server
+    set:
+      servers:
+        - name: single
+          certificate:
+            certname: puppet
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should merge custom dnsAltNames with auto-generated ones
+    set:
+      servers:
+        - name: myserver
+          certificate:
+            certname: puppet
+            dnsAltNames:
+              - custom.example.com
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.dnsAltNames
+          content: RELEASE-NAME-myserver
+      - contains:
+          path: spec.dnsAltNames
+          content: puppet
+      - contains:
+          path: spec.dnsAltNames
+          content: custom.example.com

--- a/charts/openvox-stack/tests/config_test.yaml
+++ b/charts/openvox-stack/tests/config_test.yaml
@@ -1,0 +1,121 @@
+suite: Config
+templates:
+  - templates/config.yaml
+tests:
+  - it: should render a Config with default values
+    asserts:
+      - isKind:
+          of: Config
+      - isAPIVersion:
+          of: openvox.voxpupuli.org/v1alpha1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME
+      - equal:
+          path: spec.authorityRef
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.image.repository
+          value: ghcr.io/slauger/openvox-server
+
+  - it: should set readOnlyRootFilesystem when true
+    set:
+      config:
+        readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.readOnlyRootFilesystem
+          value: true
+
+  - it: should not set readOnlyRootFilesystem when false (default)
+    asserts:
+      - isNull:
+          path: spec.readOnlyRootFilesystem
+
+  - it: should use databaseRef when database is enabled and no serverUrls
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+    asserts:
+      - equal:
+          path: spec.databaseRef
+          value: my-puppetdb
+      - isNull:
+          path: spec.puppetdb
+
+  - it: should use puppetdb.serverUrls when set explicitly
+    set:
+      config:
+        puppetdb:
+          serverUrls:
+            - https://puppetdb:8081
+    asserts:
+      - equal:
+          path: spec.puppetdb.serverUrls[0]
+          value: https://puppetdb:8081
+      - isNull:
+          path: spec.databaseRef
+
+  - it: should prefer puppetdb.serverUrls over databaseRef
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+      config:
+        puppetdb:
+          serverUrls:
+            - https://puppetdb:8081
+    asserts:
+      - isNotEmpty:
+          path: spec.puppetdb.serverUrls
+      - isNull:
+          path: spec.databaseRef
+
+  - it: should force storeconfigs true when database is enabled
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+      config:
+        puppet:
+          storeconfigs: false
+    asserts:
+      - equal:
+          path: spec.puppet.storeconfigs
+          value: true
+
+  - it: should keep storeconfigs false when database is disabled
+    asserts:
+      - equal:
+          path: spec.puppet.storeconfigs
+          value: false
+
+  - it: should include nodeClassifierRef when nodeClassifier is enabled
+    set:
+      nodeClassifier:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.nodeClassifierRef
+          value: RELEASE-NAME-enc
+
+  - it: should not include nodeClassifierRef when nodeClassifier is disabled
+    asserts:
+      - isNull:
+          path: spec.nodeClassifierRef
+
+  - it: should render code section when code image is set
+    set:
+      config:
+        code:
+          image: ghcr.io/slauger/openvox-code:latest
+    asserts:
+      - equal:
+          path: spec.code.image
+          value: ghcr.io/slauger/openvox-code:latest
+
+  - it: should not render code section when image and claimName are empty
+    asserts:
+      - isNull:
+          path: spec.code

--- a/charts/openvox-stack/tests/database_test.yaml
+++ b/charts/openvox-stack/tests/database_test.yaml
@@ -1,0 +1,181 @@
+suite: Database
+templates:
+  - templates/database.yaml
+tests:
+  - it: should not render when database is disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when database.name is missing
+    set:
+      database:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.name is required when database.enabled is true"
+
+  - it: should fail when database.certificate.certname is missing
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.certificate.certname is required when database.enabled is true"
+
+  - it: should fail when database.postgres.host is missing
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.postgres.host is required when database.enabled is true"
+
+  - it: should fail when database.postgres.credentialsSecretRef is missing
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.postgres.credentialsSecretRef is required when database.enabled is true"
+
+  - it: should render Certificate and Database when all required fields are set
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should render Certificate as first document
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: my-puppetdb
+      - equal:
+          path: spec.authorityRef
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.certname
+          value: puppetdb
+
+  - it: should render Database as second document
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Database
+      - equal:
+          path: metadata.name
+          value: my-puppetdb
+      - equal:
+          path: spec.certificateRef
+          value: my-puppetdb
+      - equal:
+          path: spec.postgres.host
+          value: pg-cluster-rw.postgres.svc
+      - equal:
+          path: spec.postgres.port
+          value: 5432
+      - equal:
+          path: spec.postgres.database
+          value: openvoxdb
+      - equal:
+          path: spec.postgres.credentialsSecretRef
+          value: pg-credentials
+      - equal:
+          path: spec.postgres.sslMode
+          value: require
+
+  - it: should propagate javaArgs
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+        javaArgs: "-Xmx512m -Xms256m"
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.javaArgs
+          value: "-Xmx512m -Xms256m"
+
+  - it: should propagate resources
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.resources.requests.cpu
+          value: 500m
+      - equal:
+          path: spec.resources.requests.memory
+          value: 1Gi
+
+  - it: should render dnsAltNames on Certificate when set
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+          dnsAltNames:
+            - puppetdb.example.com
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.dnsAltNames
+          content: puppetdb.example.com

--- a/charts/openvox-stack/tests/nodeclassifier_test.yaml
+++ b/charts/openvox-stack/tests/nodeclassifier_test.yaml
@@ -1,0 +1,137 @@
+suite: NodeClassifier
+templates:
+  - templates/nodeclassifier.yaml
+tests:
+  - it: should not render when disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render NodeClassifier when enabled
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+    asserts:
+      - isKind:
+          of: NodeClassifier
+      - isAPIVersion:
+          of: openvox.voxpupuli.org/v1alpha1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-enc
+
+  - it: should propagate url, method, path, and format
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+        request:
+          method: POST
+          path: /classify/{certname}
+        response:
+          format: json
+    asserts:
+      - equal:
+          path: spec.url
+          value: https://enc.example.com
+      - equal:
+          path: spec.request.method
+          value: POST
+      - equal:
+          path: spec.request.path
+          value: /classify/{certname}
+      - equal:
+          path: spec.response.format
+          value: json
+
+  - it: should set timeoutSeconds
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+        timeoutSeconds: 30
+    asserts:
+      - equal:
+          path: spec.timeoutSeconds
+          value: 30
+
+  - it: should enable mtls auth
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+        auth:
+          mtls: true
+    asserts:
+      - equal:
+          path: spec.auth.mtls
+          value: true
+
+  - it: should enable token auth
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+        auth:
+          token:
+            header: X-Auth-Token
+            secretKeyRef:
+              name: enc-secret
+              key: token
+    asserts:
+      - equal:
+          path: spec.auth.token.header
+          value: X-Auth-Token
+      - equal:
+          path: spec.auth.token.secretKeyRef.name
+          value: enc-secret
+
+  - it: should not render auth when no auth methods are set
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+        auth:
+          mtls: false
+    asserts:
+      - isNull:
+          path: spec.auth
+
+  - it: should enable cache
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+        cache:
+          enabled: true
+          directory: /var/cache/enc
+    asserts:
+      - equal:
+          path: spec.cache.enabled
+          value: true
+      - equal:
+          path: spec.cache.directory
+          value: /var/cache/enc
+
+  - it: should not render cache when disabled
+    set:
+      nodeClassifier:
+        enabled: true
+        url: https://enc.example.com
+        cache:
+          enabled: false
+    asserts:
+      - isNull:
+          path: spec.cache
+
+  - it: should use custom name
+    set:
+      nodeClassifier:
+        enabled: true
+        name: my-custom-enc
+        url: https://enc.example.com
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-enc

--- a/charts/openvox-stack/tests/pools_test.yaml
+++ b/charts/openvox-stack/tests/pools_test.yaml
@@ -1,0 +1,108 @@
+suite: Pools
+templates:
+  - templates/pools.yaml
+tests:
+  - it: should render 2 Pools by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should render pool with default service settings
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Pool
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.service.type
+          value: ClusterIP
+      - equal:
+          path: spec.service.port
+          value: 8140
+
+  - it: should not render route when not configured
+    documentIndex: 0
+    asserts:
+      - isNull:
+          path: spec.route
+
+  - it: should render route when enabled with gateway
+    set:
+      gateway:
+        name: my-gateway
+      pools:
+        - name: ca
+          service:
+            type: ClusterIP
+            port: 8140
+          route:
+            enabled: true
+            hostname: puppet.example.com
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.route.enabled
+          value: true
+      - equal:
+          path: spec.route.hostname
+          value: puppet.example.com
+      - equal:
+          path: spec.route.gatewayRef.name
+          value: my-gateway
+
+  - it: should propagate gateway sectionName
+    set:
+      gateway:
+        name: my-gateway
+        sectionName: https-listener
+      pools:
+        - name: ca
+          service:
+            type: ClusterIP
+            port: 8140
+          route:
+            enabled: true
+            hostname: puppet.example.com
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.route.gatewayRef.sectionName
+          value: https-listener
+
+  - it: should not set sectionName when gateway.sectionName is empty
+    set:
+      gateway:
+        name: my-gateway
+      pools:
+        - name: ca
+          service:
+            type: ClusterIP
+            port: 8140
+          route:
+            enabled: true
+            hostname: puppet.example.com
+    documentIndex: 0
+    asserts:
+      - isNull:
+          path: spec.route.gatewayRef.sectionName
+
+  - it: should set injectDNSAltName when enabled
+    set:
+      gateway:
+        name: my-gateway
+      pools:
+        - name: ca
+          service:
+            type: ClusterIP
+            port: 8140
+          route:
+            enabled: true
+            hostname: puppet.example.com
+            injectDNSAltName: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.route.injectDNSAltName
+          value: true

--- a/charts/openvox-stack/tests/reportprocessor_test.yaml
+++ b/charts/openvox-stack/tests/reportprocessor_test.yaml
@@ -1,0 +1,88 @@
+suite: ReportProcessor
+templates:
+  - templates/reportprocessor.yaml
+tests:
+  - it: should not render when reportProcessors is empty (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ReportProcessor
+    set:
+      reportProcessors:
+        - name: my-webhook
+          url: http://my-webhook:8080/reports
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ReportProcessor
+      - equal:
+          path: metadata.name
+          value: my-webhook
+      - equal:
+          path: spec.configRef
+          value: RELEASE-NAME
+      - equal:
+          path: spec.url
+          value: http://my-webhook:8080/reports
+
+  - it: should render with processor field
+    set:
+      reportProcessors:
+        - name: my-puppetdb
+          url: http://my-puppetdb:8080/pdb/cmd/v1
+          processor: puppetdb
+    asserts:
+      - equal:
+          path: spec.processor
+          value: puppetdb
+
+  - it: should render multiple ReportProcessors
+    set:
+      reportProcessors:
+        - name: webhook
+          url: http://webhook:8080/reports
+        - name: puppetdb
+          url: http://puppetdb:8080/pdb/cmd/v1
+          processor: puppetdb
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should use auto-generated name when name is not set
+    set:
+      reportProcessors:
+        - url: http://webhook:8080/reports
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-report-processor-0
+
+  - it: should render headers
+    set:
+      reportProcessors:
+        - name: my-webhook
+          url: http://webhook:8080/reports
+          headers:
+            - name: Authorization
+              value: "Bearer my-token"
+    asserts:
+      - equal:
+          path: spec.headers[0].name
+          value: Authorization
+      - equal:
+          path: spec.headers[0].value
+          value: "Bearer my-token"
+
+  - it: should render auth with mtls
+    set:
+      reportProcessors:
+        - name: my-webhook
+          url: http://webhook:8080/reports
+          auth:
+            mtls: true
+    asserts:
+      - equal:
+          path: spec.auth.mtls
+          value: true

--- a/charts/openvox-stack/tests/servers_test.yaml
+++ b/charts/openvox-stack/tests/servers_test.yaml
@@ -1,0 +1,87 @@
+suite: Servers
+templates:
+  - templates/servers.yaml
+tests:
+  - it: should render 2 Servers by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should render ca server with ca flag true
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Server
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.ca
+          value: true
+      - equal:
+          path: spec.server
+          value: true
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should set configRef and certificateRef
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.configRef
+          value: RELEASE-NAME
+      - equal:
+          path: spec.certificateRef
+          value: RELEASE-NAME-ca
+
+  - it: should expand poolRefs to full names
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.poolRefs
+          content: RELEASE-NAME-ca
+      - contains:
+          path: spec.poolRefs
+          content: RELEASE-NAME-server
+
+  - it: should render second server with ca false
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-server
+      - equal:
+          path: spec.ca
+          value: false
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: should propagate resources
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.resources.requests.cpu
+          value: 500m
+      - equal:
+          path: spec.resources.limits.memory
+          value: 2Gi
+
+  - it: should render single server
+    set:
+      servers:
+        - name: standalone
+          ca: true
+          server: true
+          certificate:
+            certname: puppet
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-standalone
+      - equal:
+          path: spec.replicas
+          value: 1

--- a/charts/openvox-stack/tests/signingpolicy_test.yaml
+++ b/charts/openvox-stack/tests/signingpolicy_test.yaml
@@ -1,0 +1,102 @@
+suite: SigningPolicy
+templates:
+  - templates/signingpolicy.yaml
+tests:
+  - it: should not render when signingPolicies is empty (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a SigningPolicy with any true
+    set:
+      signingPolicies:
+        - name: autosign-any
+          any: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: SigningPolicy
+      - equal:
+          path: metadata.name
+          value: autosign-any
+      - equal:
+          path: spec.certificateAuthorityRef
+          value: RELEASE-NAME-ca
+      - equal:
+          path: spec.any
+          value: true
+
+  - it: should render a SigningPolicy with pattern
+    set:
+      signingPolicies:
+        - name: domain-only
+          pattern:
+            allow:
+              - "*.example.com"
+              - "*.test.local"
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.pattern.allow
+          content: "*.example.com"
+      - contains:
+          path: spec.pattern.allow
+          content: "*.test.local"
+
+  - it: should render a SigningPolicy with csrAttributes
+    set:
+      signingPolicies:
+        - name: preshared-key
+          csrAttributes:
+            - name: pp_preshared_key
+              value: "my-secret-token"
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.csrAttributes[0].name
+          value: pp_preshared_key
+      - equal:
+          path: spec.csrAttributes[0].value
+          value: "my-secret-token"
+
+  - it: should render csrAttributes with valueFrom
+    set:
+      signingPolicies:
+        - name: secret-key
+          csrAttributes:
+            - name: pp_preshared_key
+              valueFrom:
+                secretKeyRef:
+                  name: signing-secret
+                  key: psk
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.csrAttributes[0].valueFrom.secretKeyRef.name
+          value: signing-secret
+      - equal:
+          path: spec.csrAttributes[0].valueFrom.secretKeyRef.key
+          value: psk
+
+  - it: should render multiple SigningPolicies
+    set:
+      signingPolicies:
+        - name: policy-a
+          any: true
+        - name: policy-b
+          pattern:
+            allow:
+              - "*.example.com"
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should use auto-generated name when name is not set
+    set:
+      signingPolicies:
+        - any: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-signing-policy-0


### PR DESCRIPTION
## Summary
- Add [helm-unittest](https://github.com/helm-unittest/helm-unittest) tests for all three Helm charts (123 tests total)
- **openvox-db-postgres** (9 tests): default values, instances, storageClass, postInitSQL with pg_trgm
- **openvox-operator** (41 tests): webhook toggle, scope mode (cluster/namespace), image digest, RBAC rules, ServiceAccount
- **openvox-stack** (73 tests): Config, CertificateAuthority, Certificates, Servers, Pools, Database (incl. fail validations), NodeClassifier, SigningPolicy, ReportProcessor
- CI: add helm-unittest plugin install and test step to `_helm.yaml` workflow
- Makefile: add `helm-unittest` target and include in `ci` target

**Note:** The issue mentions MutatingWebhookConfiguration but the codebase only has ValidatingWebhookConfiguration. Tests match the actual code.

## Test plan
- [ ] CI passes helm-unittest for all three charts
- [ ] `make helm-unittest` runs locally

Closes #233