### PR TITLE
feat: add --enable-gateway-api flag for explicit opt-out

### DIFF
--- a/charts/openvox-operator/templates/deployment.yaml
+++ b/charts/openvox-operator/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             {{- if .Values.webhook.enabled }}
             - --enable-webhooks
             {{- end }}
+            {{- if not .Values.gatewayAPI.enabled }}
+            - --enable-gateway-api=false
+            {{- end }}
           ports:
             - name: health
               containerPort: 8081

--- a/charts/openvox-operator/tests/deployment_test.yaml
+++ b/charts/openvox-operator/tests/deployment_test.yaml
@@ -101,6 +101,21 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --watch-namespace=custom-ns
 
+  - it: should not have enable-gateway-api arg by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-gateway-api=false
+
+  - it: should have enable-gateway-api=false arg when gatewayAPI is disabled
+    set:
+      gatewayAPI:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-gateway-api=false
+
   - it: should propagate resources
     asserts:
       - equal:

--- a/charts/openvox-operator/values.yaml
+++ b/charts/openvox-operator/values.yaml
@@ -23,6 +23,9 @@ scope:
   # watchNamespace: defaults to .Release.Namespace when mode is "namespace"
   watchNamespace: ""
 
+gatewayAPI:
+  enabled: true  # set to false to disable TLSRoute support
+
 resources:
   limits:
     cpu: 500m

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ func main() {
 	var probeAddr string
 	var enableLeaderElection bool
 	var enableWebhooks bool
+	var enableGatewayAPI bool
 	var watchNamespace string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -45,6 +46,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", false, "Enable admission webhooks.")
+	flag.BoolVar(&enableGatewayAPI, "enable-gateway-api", true, "Enable Gateway API TLSRoute support. When enabled, the operator auto-detects Gateway API CRDs.")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
 		"Namespace to restrict the operator to. If empty, the operator watches all namespaces (cluster-wide).")
 
@@ -112,13 +114,17 @@ func main() {
 	}
 
 	gatewayAPIAvailable := false
-	if _, err := mgr.GetRESTMapper().RESTMapping(
-		schema.GroupKind{Group: "gateway.networking.k8s.io", Kind: "TLSRoute"},
-	); err == nil {
-		gatewayAPIAvailable = true
-		setupLog.Info("Gateway API detected, TLSRoute support enabled")
+	if enableGatewayAPI {
+		if _, err := mgr.GetRESTMapper().RESTMapping(
+			schema.GroupKind{Group: "gateway.networking.k8s.io", Kind: "TLSRoute"},
+		); err == nil {
+			gatewayAPIAvailable = true
+			setupLog.Info("Gateway API detected, TLSRoute support enabled")
+		} else {
+			setupLog.Info("Gateway API not detected, TLSRoute support disabled")
+		}
 	} else {
-		setupLog.Info("Gateway API not detected, TLSRoute support disabled")
+		setupLog.Info("Gateway API disabled via --enable-gateway-api=false")
 	}
 
 	if err = (&controller.PoolReconciler{


### PR DESCRIPTION
## Summary

- Add `--enable-gateway-api` flag (default `true`) to allow disabling Gateway API TLSRoute support even when CRDs are installed
- Add `gatewayAPI.enabled` Helm value to pass the flag through the chart
- Add helm-unittest tests for the new flag

This enables testing the no-Gateway-API code path in E2E tests when Gateway API CRDs are present.

Closes #230

## Test plan

- [x] `go build ./cmd/main.go` succeeds
- [x] `helm unittest charts/openvox-operator` passes (43 tests)
- [ ] E2E: deploy with `--enable-gateway-api=false` and verify TLSRoute reconciliation is skipped