### PR TITLE
test: add unit tests for rendering functions and CA helpers

### DIFF
--- a/internal/controller/certificateauthority_job_test.go
+++ b/internal/controller/certificateauthority_job_test.go
@@ -1,0 +1,237 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestFindCAServerCert(t *testing.T) {
+	t.Run("finds cert from server with ca:true", func(t *testing.T) {
+		ca := newCertificateAuthority("myca")
+		cfg := newConfig("production", withAuthorityRef("myca"))
+		server := newServer("ca-server", withCA(true), withServerRole(true))
+		server.Spec.ConfigRef = "production"
+		server.Spec.CertificateRef = "ca-cert"
+
+		cert1 := newCertificate("other-cert", "myca", openvoxv1alpha1.CertificatePhasePending)
+		cert2 := newCertificate("ca-cert", "myca", openvoxv1alpha1.CertificatePhasePending)
+		cert2.Spec.Certname = "ca.example.com"
+
+		c := setupTestClient(ca, cfg, server, cert1, cert2)
+		r := newCertificateAuthorityReconciler(c)
+
+		certs := []openvoxv1alpha1.Certificate{*cert1, *cert2}
+		found := r.findCAServerCert(testCtx(), ca, certs)
+
+		if found == nil {
+			t.Fatal("expected to find a certificate, got nil")
+		}
+		if found.Name != "ca-cert" {
+			t.Errorf("expected cert 'ca-cert', got %q", found.Name)
+		}
+	})
+
+	t.Run("fallback to first cert when no CA server", func(t *testing.T) {
+		ca := newCertificateAuthority("myca")
+		cfg := newConfig("production", withAuthorityRef("myca"))
+		// No server with ca:true
+		server := newServer("server1")
+		server.Spec.ConfigRef = "production"
+		server.Spec.CA = false
+
+		cert1 := newCertificate("first-cert", "myca", openvoxv1alpha1.CertificatePhasePending)
+		cert2 := newCertificate("second-cert", "myca", openvoxv1alpha1.CertificatePhasePending)
+
+		c := setupTestClient(ca, cfg, server, cert1, cert2)
+		r := newCertificateAuthorityReconciler(c)
+
+		certs := []openvoxv1alpha1.Certificate{*cert1, *cert2}
+		found := r.findCAServerCert(testCtx(), ca, certs)
+
+		if found == nil {
+			t.Fatal("expected fallback to first cert, got nil")
+		}
+		if found.Name != "first-cert" {
+			t.Errorf("expected 'first-cert', got %q", found.Name)
+		}
+	})
+
+	t.Run("returns nil with no certs", func(t *testing.T) {
+		ca := newCertificateAuthority("myca")
+		c := setupTestClient(ca)
+		r := newCertificateAuthorityReconciler(c)
+
+		found := r.findCAServerCert(testCtx(), ca, nil)
+		if found != nil {
+			t.Errorf("expected nil with empty certs, got %v", found)
+		}
+	})
+}
+
+func TestBuildCASetupJob(t *testing.T) {
+	t.Run("certname from CA server cert", func(t *testing.T) {
+		ca := newCertificateAuthority("myca")
+		cfg := newConfig("production", withAuthorityRef("myca"))
+		server := newServer("ca-server", withCA(true), withServerRole(true))
+		server.Spec.ConfigRef = "production"
+		server.Spec.CertificateRef = "ca-cert"
+
+		cert := newCertificate("ca-cert", "myca", openvoxv1alpha1.CertificatePhasePending)
+		cert.Spec.Certname = "puppet-ca.example.com"
+		cert.Spec.DNSAltNames = []string{"puppet.example.com"}
+
+		c := setupTestClient(ca, cfg, server, cert)
+		r := newCertificateAuthorityReconciler(c)
+
+		certs := []openvoxv1alpha1.Certificate{*cert}
+		job := r.buildCASetupJob(testCtx(), ca, cfg, "myca-ca-setup", certs)
+
+		// Check env vars for certname
+		container := job.Spec.Template.Spec.Containers[0]
+		certnameFound := false
+		dnsFound := false
+		for _, env := range container.Env {
+			if env.Name == "CERTNAME" && env.Value == "puppet-ca.example.com" {
+				certnameFound = true
+			}
+			if env.Name == "DNS_ALT_NAMES" {
+				dnsFound = true
+				// Should contain the original DNS alt name and the service FQDN
+				if !strings.Contains(env.Value, "puppet.example.com") {
+					t.Errorf("expected DNS alt name 'puppet.example.com' in %q", env.Value)
+				}
+				serviceFQDN := "myca-internal.default.svc"
+				if !strings.Contains(env.Value, serviceFQDN) {
+					t.Errorf("expected service FQDN %q in DNS_ALT_NAMES %q", serviceFQDN, env.Value)
+				}
+			}
+		}
+		if !certnameFound {
+			t.Error("CERTNAME env var not found or incorrect")
+		}
+		if !dnsFound {
+			t.Error("DNS_ALT_NAMES env var not found")
+		}
+	})
+
+	t.Run("default certname puppet when no cert found", func(t *testing.T) {
+		ca := newCertificateAuthority("myca")
+		cfg := newConfig("production", withAuthorityRef("myca"))
+
+		c := setupTestClient(ca, cfg)
+		r := newCertificateAuthorityReconciler(c)
+
+		job := r.buildCASetupJob(testCtx(), ca, cfg, "myca-ca-setup", nil)
+
+		container := job.Spec.Template.Spec.Containers[0]
+		for _, env := range container.Env {
+			if env.Name == "CERTNAME" {
+				if env.Value != "puppet" {
+					t.Errorf("expected default certname 'puppet', got %q", env.Value)
+				}
+				return
+			}
+		}
+		t.Error("CERTNAME env var not found")
+	})
+
+	t.Run("job metadata and spec", func(t *testing.T) {
+		ca := newCertificateAuthority("myca")
+		cfg := newConfig("production", withAuthorityRef("myca"))
+
+		c := setupTestClient(ca, cfg)
+		r := newCertificateAuthorityReconciler(c)
+
+		job := r.buildCASetupJob(testCtx(), ca, cfg, "myca-ca-setup", nil)
+
+		if job.Name != "myca-ca-setup" {
+			t.Errorf("expected job name 'myca-ca-setup', got %q", job.Name)
+		}
+		if job.Namespace != testNamespace {
+			t.Errorf("expected namespace %q, got %q", testNamespace, job.Namespace)
+		}
+
+		spec := job.Spec.Template.Spec
+		if spec.ServiceAccountName != "myca-ca-setup" {
+			t.Errorf("expected SA name 'myca-ca-setup', got %q", spec.ServiceAccountName)
+		}
+		if spec.RestartPolicy != corev1.RestartPolicyNever {
+			t.Errorf("expected RestartPolicyNever, got %v", spec.RestartPolicy)
+		}
+
+		container := spec.Containers[0]
+		expectedImage := "ghcr.io/slauger/openvox-server:latest"
+		if container.Image != expectedImage {
+			t.Errorf("expected image %q, got %q", expectedImage, container.Image)
+		}
+
+		// Security context checks
+		if spec.SecurityContext == nil {
+			t.Fatal("expected pod security context")
+		}
+		if *spec.SecurityContext.RunAsUser != CASetupRunAsUser {
+			t.Errorf("expected RunAsUser %d, got %d", CASetupRunAsUser, *spec.SecurityContext.RunAsUser)
+		}
+	})
+}
+
+func TestResolveCAJobResources(t *testing.T) {
+	t.Run("default resources", func(t *testing.T) {
+		ca := newCertificateAuthority("myca")
+		res := resolveCAJobResources(ca)
+
+		expectedCPUReq := resource.MustParse(DefaultCAJobCPURequest)
+		expectedMemReq := resource.MustParse(DefaultCAJobMemoryRequest)
+		expectedCPULim := resource.MustParse(DefaultCAJobCPULimit)
+		expectedMemLim := resource.MustParse(DefaultCAJobMemoryLimit)
+
+		if !res.Requests.Cpu().Equal(expectedCPUReq) {
+			t.Errorf("expected CPU request %s, got %s", expectedCPUReq.String(), res.Requests.Cpu().String())
+		}
+		if !res.Requests.Memory().Equal(expectedMemReq) {
+			t.Errorf("expected memory request %s, got %s", expectedMemReq.String(), res.Requests.Memory().String())
+		}
+		if !res.Limits.Cpu().Equal(expectedCPULim) {
+			t.Errorf("expected CPU limit %s, got %s", expectedCPULim.String(), res.Limits.Cpu().String())
+		}
+		if !res.Limits.Memory().Equal(expectedMemLim) {
+			t.Errorf("expected memory limit %s, got %s", expectedMemLim.String(), res.Limits.Memory().String())
+		}
+	})
+
+	t.Run("user-specified resources", func(t *testing.T) {
+		ca := &openvoxv1alpha1.CertificateAuthority{
+			ObjectMeta: metav1.ObjectMeta{Name: "myca", Namespace: testNamespace},
+			Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+		}
+
+		res := resolveCAJobResources(ca)
+
+		expectedCPU := resource.MustParse("500m")
+		if !res.Requests.Cpu().Equal(expectedCPU) {
+			t.Errorf("expected CPU request 500m, got %s", res.Requests.Cpu().String())
+		}
+
+		expectedMem := resource.MustParse("4Gi")
+		if !res.Limits.Memory().Equal(expectedMem) {
+			t.Errorf("expected memory limit 4Gi, got %s", res.Limits.Memory().String())
+		}
+	})
+}

--- a/internal/controller/config_autosign_test.go
+++ b/internal/controller/config_autosign_test.go
@@ -1,0 +1,215 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestRenderAutosignPolicyConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		policies []openvoxv1alpha1.SigningPolicy
+		objs     []client.Object
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "empty policies",
+			policies: nil,
+			contains: []string{"policies:\n"},
+		},
+		{
+			name: "any: true",
+			policies: []openvoxv1alpha1.SigningPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-all", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						Any:                     true,
+					},
+				},
+			},
+			contains: []string{
+				"- name: allow-all",
+				"any: true",
+			},
+		},
+		{
+			name: "CSR attribute with inline value",
+			policies: []openvoxv1alpha1.SigningPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "psk-policy", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						CSRAttributes: []openvoxv1alpha1.CSRAttributeMatch{
+							{Name: "pp_preshared_key", Value: "my-key-value"},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"- name: psk-policy",
+				"csrAttributes:",
+				"- name: pp_preshared_key",
+				`value: "my-key-value"`,
+			},
+		},
+		{
+			name: "CSR attribute with secretKeyRef",
+			policies: []openvoxv1alpha1.SigningPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-policy", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						CSRAttributes: []openvoxv1alpha1.CSRAttributeMatch{
+							{
+								Name: "pp_preshared_key",
+								ValueFrom: &openvoxv1alpha1.SecretKeySelector{
+									SecretKeyRef: openvoxv1alpha1.SecretKeyRef{
+										Name: "psk-secret",
+										Key:  "key",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			objs: []client.Object{
+				newSecret("psk-secret", map[string][]byte{"key": []byte("secret-value")}),
+			},
+			contains: []string{
+				"- name: pp_preshared_key",
+				`value: "secret-value"`,
+			},
+		},
+		{
+			name: "multiple policies sorted by name",
+			policies: []openvoxv1alpha1.SigningPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "zebra", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						Any:                     true,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						Any:                     true,
+					},
+				},
+			},
+			contains: []string{
+				"- name: alpha",
+				"- name: zebra",
+			},
+		},
+		{
+			name: "pattern spec",
+			policies: []openvoxv1alpha1.SigningPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pattern-policy", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						Pattern: &openvoxv1alpha1.PatternSpec{
+							Allow: []string{"*.example.com", "web-*"},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"pattern:",
+				"allow:",
+				`"*.example.com"`,
+				`"web-*"`,
+			},
+		},
+		{
+			name: "dnsAltNames spec",
+			policies: []openvoxv1alpha1.SigningPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "dns-policy", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						DNSAltNames: &openvoxv1alpha1.PatternSpec{
+							Allow: []string{"puppet", "puppet.local"},
+						},
+					},
+				},
+			},
+			contains: []string{
+				"dnsAltNames:",
+				"allow:",
+				`"puppet"`,
+				`"puppet.local"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := setupTestClient(tt.objs...)
+			r := newConfigReconciler(c)
+
+			out, err := r.renderAutosignPolicyConfig(testCtx(), testNamespace, tt.policies)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, s := range tt.contains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected %q in output:\n%s", s, out)
+				}
+			}
+			for _, s := range tt.excludes {
+				if strings.Contains(out, s) {
+					t.Errorf("unexpected %q in output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderAutosignPolicyConfig_SortOrder(t *testing.T) {
+	c := setupTestClient()
+	r := newConfigReconciler(c)
+
+	policies := []openvoxv1alpha1.SigningPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "charlie", Namespace: testNamespace},
+			Spec:       openvoxv1alpha1.SigningPolicySpec{CertificateAuthorityRef: "ca", Any: true},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: testNamespace},
+			Spec:       openvoxv1alpha1.SigningPolicySpec{CertificateAuthorityRef: "ca", Any: true},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "bravo", Namespace: testNamespace},
+			Spec:       openvoxv1alpha1.SigningPolicySpec{CertificateAuthorityRef: "ca", Any: true},
+		},
+	}
+
+	out, err := r.renderAutosignPolicyConfig(testCtx(), testNamespace, policies)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	alphaIdx := strings.Index(out, "- name: alpha")
+	bravoIdx := strings.Index(out, "- name: bravo")
+	charlieIdx := strings.Index(out, "- name: charlie")
+
+	if alphaIdx < 0 || bravoIdx < 0 || charlieIdx < 0 {
+		t.Fatalf("not all policies found in output:\n%s", out)
+	}
+
+	if alphaIdx >= bravoIdx || bravoIdx >= charlieIdx {
+		t.Errorf("policies not sorted by name; alpha=%d, bravo=%d, charlie=%d", alphaIdx, bravoIdx, charlieIdx)
+	}
+}

--- a/internal/controller/config_enc_test.go
+++ b/internal/controller/config_enc_test.go
@@ -69,9 +69,9 @@ func TestRenderENCConfig(t *testing.T) {
 
 			// Use the provided NC or default
 			nc := tt.nc
-			if nc.ObjectMeta.Name == "" {
-				nc.ObjectMeta.Name = "enc"
-				nc.ObjectMeta.Namespace = testNamespace
+			if nc.Name == "" {
+				nc.Name = "enc"
+				nc.Namespace = testNamespace
 			}
 
 			out, err := r.renderENCConfig(testCtx(), cfg, nc)

--- a/internal/controller/config_enc_test.go
+++ b/internal/controller/config_enc_test.go
@@ -1,0 +1,266 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestRenderENCConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		nc       *openvoxv1alpha1.NodeClassifier
+		contains []string
+		excludes []string
+	}{
+		{
+			name: "no auth",
+			nc: &openvoxv1alpha1.NodeClassifier{
+				Spec: openvoxv1alpha1.NodeClassifierSpec{
+					URL:     "https://enc.example.com",
+					Request: openvoxv1alpha1.NodeClassifierRequest{Method: "GET", Path: "/node/{certname}"},
+					Response: openvoxv1alpha1.NodeClassifierResponse{Format: "yaml"},
+					TimeoutSeconds: 15,
+				},
+			},
+			contains: []string{
+				"url: https://enc.example.com",
+				"method: GET",
+				"path: /node/{certname}",
+				"responseFormat: yaml",
+				"timeoutSeconds: 15",
+				"certFile:",
+				"keyFile:",
+				"caFile:",
+			},
+			excludes: []string{"auth:"},
+		},
+		{
+			name: "default timeout",
+			nc: &openvoxv1alpha1.NodeClassifier{
+				Spec: openvoxv1alpha1.NodeClassifierSpec{
+					URL:      "https://enc.example.com",
+					Request:  openvoxv1alpha1.NodeClassifierRequest{Method: "GET", Path: "/node/{certname}"},
+					Response: openvoxv1alpha1.NodeClassifierResponse{Format: "yaml"},
+				},
+			},
+			contains: []string{"timeoutSeconds: 10"},
+		},
+		{
+			name: "mTLS auth",
+			nc: func() *openvoxv1alpha1.NodeClassifier {
+				nc := newNodeClassifier("enc", "https://enc.example.com")
+				nc.Spec.Auth = &openvoxv1alpha1.NodeClassifierAuth{MTLS: true}
+				return nc
+			}(),
+			contains: []string{
+				"auth:",
+				"type: mtls",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := setupTestClient()
+			r := newConfigReconciler(c)
+			cfg := newConfig("test")
+
+			// Use the provided NC or default
+			nc := tt.nc
+			if nc.ObjectMeta.Name == "" {
+				nc.ObjectMeta.Name = "enc"
+				nc.ObjectMeta.Namespace = testNamespace
+			}
+
+			out, err := r.renderENCConfig(testCtx(), cfg, nc)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, s := range tt.contains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected %q in output:\n%s", s, out)
+				}
+			}
+			for _, s := range tt.excludes {
+				if strings.Contains(out, s) {
+					t.Errorf("unexpected %q in output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderENCConfig_TokenAuth(t *testing.T) {
+	tokenSecret := newSecret("enc-token", map[string][]byte{
+		"token": []byte("my-secret-token"),
+	})
+
+	c := setupTestClient(tokenSecret)
+	r := newConfigReconciler(c)
+	cfg := newConfig("test")
+
+	nc := newNodeClassifier("enc", "https://enc.example.com")
+	nc.Spec.Auth = &openvoxv1alpha1.NodeClassifierAuth{
+		Token: &openvoxv1alpha1.TokenAuth{
+			Header: "X-Auth-Token",
+			SecretKeyRef: openvoxv1alpha1.SecretKeyRef{
+				Name: "enc-token",
+				Key:  "token",
+			},
+		},
+	}
+
+	out, err := r.renderENCConfig(testCtx(), cfg, nc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"type: token",
+		"header: X-Auth-Token",
+		"token: my-secret-token",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderENCConfig_BearerAuth(t *testing.T) {
+	bearerSecret := newSecret("bearer-secret", map[string][]byte{
+		"token": []byte("bearer-value"),
+	})
+
+	c := setupTestClient(bearerSecret)
+	r := newConfigReconciler(c)
+	cfg := newConfig("test")
+
+	nc := newNodeClassifier("enc", "https://enc.example.com")
+	nc.Spec.Auth = &openvoxv1alpha1.NodeClassifierAuth{
+		Bearer: &openvoxv1alpha1.SecretKeySelector{
+			SecretKeyRef: openvoxv1alpha1.SecretKeyRef{
+				Name: "bearer-secret",
+				Key:  "token",
+			},
+		},
+	}
+
+	out, err := r.renderENCConfig(testCtx(), cfg, nc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"type: bearer",
+		"token: bearer-value",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderENCConfig_BasicAuth(t *testing.T) {
+	basicSecret := newSecret("basic-creds", map[string][]byte{
+		"user": []byte("admin"),
+		"pass": []byte("s3cret"),
+	})
+
+	c := setupTestClient(basicSecret)
+	r := newConfigReconciler(c)
+	cfg := newConfig("test")
+
+	nc := newNodeClassifier("enc", "https://enc.example.com")
+	nc.Spec.Auth = &openvoxv1alpha1.NodeClassifierAuth{
+		Basic: &openvoxv1alpha1.BasicAuth{
+			SecretRef: openvoxv1alpha1.BasicAuthSecretRef{
+				Name:        "basic-creds",
+				UsernameKey: "user",
+				PasswordKey: "pass",
+			},
+		},
+	}
+
+	out, err := r.renderENCConfig(testCtx(), cfg, nc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"type: basic",
+		"username: admin",
+		"password: s3cret",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderENCConfig_CacheEnabled(t *testing.T) {
+	c := setupTestClient()
+	r := newConfigReconciler(c)
+	cfg := newConfig("test")
+
+	nc := newNodeClassifier("enc", "https://enc.example.com")
+	nc.Spec.Cache = &openvoxv1alpha1.NodeClassifierCache{
+		Enabled: true,
+	}
+
+	out, err := r.renderENCConfig(testCtx(), cfg, nc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"cache:",
+		"enabled: true",
+		"directory: /var/cache/openvox-enc",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderENCConfig_CacheDisabled(t *testing.T) {
+	c := setupTestClient()
+	r := newConfigReconciler(c)
+	cfg := newConfig("test")
+
+	nc := newNodeClassifier("enc", "https://enc.example.com")
+	// Cache nil = no cache section
+
+	out, err := r.renderENCConfig(testCtx(), cfg, nc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(out, "cache:") {
+		t.Errorf("unexpected cache section in output:\n%s", out)
+	}
+}
+
+func TestRenderENCConfig_CacheCustomDirectory(t *testing.T) {
+	c := setupTestClient()
+	r := newConfigReconciler(c)
+	cfg := newConfig("test")
+
+	nc := newNodeClassifier("enc", "https://enc.example.com")
+	nc.Spec.Cache = &openvoxv1alpha1.NodeClassifierCache{
+		Enabled:   true,
+		Directory: "/custom/cache/dir",
+	}
+
+	out, err := r.renderENCConfig(testCtx(), cfg, nc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "directory: /custom/cache/dir") {
+		t.Errorf("expected custom cache directory in output:\n%s", out)
+	}
+}

--- a/internal/controller/config_rendering_test.go
+++ b/internal/controller/config_rendering_test.go
@@ -1,0 +1,210 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestRenderMetricsConf(t *testing.T) {
+	r := newConfigReconciler(setupTestClient())
+
+	tests := []struct {
+		name     string
+		metrics  *openvoxv1alpha1.MetricsSpec
+		contains []string
+		excludes []string
+	}{
+		{
+			name:    "nil metrics (disabled)",
+			metrics: nil,
+			contains: []string{
+				"metrics: {",
+				"server-id: localhost",
+			},
+			excludes: []string{"registries", "jmx", "graphite"},
+		},
+		{
+			name:    "JMX enabled",
+			metrics: &openvoxv1alpha1.MetricsSpec{Enabled: true, JMX: &openvoxv1alpha1.JMXSpec{Enabled: true}},
+			contains: []string{
+				"registries:",
+				"reporters:",
+				"jmx:",
+				"enabled: true",
+			},
+			excludes: []string{"graphite"},
+		},
+		{
+			name: "Graphite with custom host and port",
+			metrics: &openvoxv1alpha1.MetricsSpec{
+				Enabled: true,
+				Graphite: &openvoxv1alpha1.GraphiteSpec{
+					Enabled:               true,
+					Host:                  "graphite.example.com",
+					Port:                  9090,
+					UpdateIntervalSeconds: 30,
+				},
+			},
+			contains: []string{
+				"graphite:",
+				`host: "graphite.example.com"`,
+				"port: 9090",
+				"update-interval-seconds: 30",
+			},
+			excludes: []string{"jmx"},
+		},
+		{
+			name: "Graphite with default port and interval",
+			metrics: &openvoxv1alpha1.MetricsSpec{
+				Enabled: true,
+				Graphite: &openvoxv1alpha1.GraphiteSpec{
+					Enabled: true,
+					Host:    "graphite.local",
+				},
+			},
+			contains: []string{
+				"port: 2003",
+				"update-interval-seconds: 60",
+			},
+		},
+		{
+			name: "both JMX and Graphite enabled",
+			metrics: &openvoxv1alpha1.MetricsSpec{
+				Enabled:  true,
+				JMX:      &openvoxv1alpha1.JMXSpec{Enabled: true},
+				Graphite: &openvoxv1alpha1.GraphiteSpec{Enabled: true, Host: "g.local"},
+			},
+			contains: []string{"jmx:", "graphite:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newConfig("test")
+			cfg.Spec.Metrics = tt.metrics
+
+			out := r.renderMetricsConf(cfg)
+
+			for _, s := range tt.contains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected %q in output:\n%s", s, out)
+				}
+			}
+			for _, s := range tt.excludes {
+				if strings.Contains(out, s) {
+					t.Errorf("unexpected %q in output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderWebserverConf(t *testing.T) {
+	r := newConfigReconciler(setupTestClient())
+
+	t.Run("default client-auth", func(t *testing.T) {
+		cfg := newConfig("test")
+		out := r.renderWebserverConf(cfg)
+
+		if !strings.Contains(out, "client-auth: want") {
+			t.Errorf("expected default client-auth 'want' in output:\n%s", out)
+		}
+		if !strings.Contains(out, "ssl-crl-path: /etc/puppetlabs/puppet/crl/ca_crl.pem") {
+			t.Errorf("expected non-CA CRL path in output:\n%s", out)
+		}
+	})
+
+	t.Run("custom client-auth", func(t *testing.T) {
+		cfg := newConfig("test", withPuppetServerSpec(openvoxv1alpha1.PuppetServerSpec{
+			ClientAuth: "need",
+		}))
+		out := r.renderWebserverConf(cfg)
+
+		if !strings.Contains(out, "client-auth: need") {
+			t.Errorf("expected client-auth 'need' in output:\n%s", out)
+		}
+	})
+}
+
+func TestRenderWebserverConfCA(t *testing.T) {
+	r := newConfigReconciler(setupTestClient())
+	cfg := newConfig("test")
+
+	out := r.renderWebserverConfCA(cfg)
+
+	if !strings.Contains(out, "ssl-crl-path: /etc/puppetlabs/puppet/ssl/crl.pem") {
+		t.Errorf("expected CA CRL path in output:\n%s", out)
+	}
+	if !strings.Contains(out, "ssl-port: 8140") {
+		t.Errorf("expected ssl-port 8140 in output:\n%s", out)
+	}
+}
+
+func TestRenderCAConf(t *testing.T) {
+	r := newConfigReconciler(setupTestClient())
+
+	tests := []struct {
+		name     string
+		ca       *openvoxv1alpha1.CertificateAuthority
+		contains []string
+	}{
+		{
+			name: "nil CA (all defaults true)",
+			ca:   nil,
+			contains: []string{
+				"allow-subject-alt-names: true",
+				"allow-authorization-extensions: true",
+				"enable-infra-crl: true",
+				"allow-auto-renewal: true",
+				"auto-renewal-cert-ttl: 90d",
+			},
+		},
+		{
+			name: "custom values",
+			ca: &openvoxv1alpha1.CertificateAuthority{
+				Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+					AllowSubjectAltNames:         false,
+					AllowAuthorizationExtensions: false,
+					EnableInfraCRL:               false,
+					AllowAutoRenewal:             false,
+					AutoRenewalCertTTL:           "30d",
+				},
+			},
+			contains: []string{
+				"allow-subject-alt-names: false",
+				"allow-authorization-extensions: false",
+				"enable-infra-crl: false",
+				"allow-auto-renewal: false",
+				"auto-renewal-cert-ttl: 30d",
+			},
+		},
+		{
+			name: "empty autoRenewalCertTTL uses default",
+			ca: &openvoxv1alpha1.CertificateAuthority{
+				Spec: openvoxv1alpha1.CertificateAuthoritySpec{
+					AllowSubjectAltNames:         true,
+					AllowAuthorizationExtensions: true,
+					EnableInfraCRL:               true,
+					AllowAutoRenewal:             true,
+					AutoRenewalCertTTL:           "",
+				},
+			},
+			contains: []string{
+				"auto-renewal-cert-ttl: 90d",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := r.renderCAConf(tt.ca)
+			for _, s := range tt.contains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected %q in output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/config_reports_test.go
+++ b/internal/controller/config_reports_test.go
@@ -1,0 +1,303 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+func TestRenderReportWebhookConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		processors []openvoxv1alpha1.ReportProcessor
+		objs       []client.Object
+		contains   []string
+		excludes   []string
+	}{
+		{
+			name: "single endpoint no auth",
+			processors: []openvoxv1alpha1.ReportProcessor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "webhook1", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.ReportProcessorSpec{
+						ConfigRef:      "production",
+						URL:            "https://reports.example.com/webhook",
+						TimeoutSeconds: 15,
+					},
+				},
+			},
+			contains: []string{
+				"endpoints:",
+				"name: webhook1",
+				"url: https://reports.example.com/webhook",
+				"timeoutSeconds: 15",
+				"certFile:",
+				"keyFile:",
+				"caFile:",
+			},
+			excludes: []string{"auth:"},
+		},
+		{
+			name: "default timeout",
+			processors: []openvoxv1alpha1.ReportProcessor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "webhook1", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.ReportProcessorSpec{
+						ConfigRef: "production",
+						URL:       "https://reports.example.com/webhook",
+					},
+				},
+			},
+			contains: []string{"timeoutSeconds: 30"},
+		},
+		{
+			name: "mTLS auth",
+			processors: []openvoxv1alpha1.ReportProcessor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mtls-ep", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.ReportProcessorSpec{
+						ConfigRef: "production",
+						URL:       "https://reports.example.com",
+						Auth:      &openvoxv1alpha1.ReportProcessorAuth{MTLS: true},
+					},
+				},
+			},
+			contains: []string{
+				"auth:",
+				"type: mtls",
+			},
+		},
+		{
+			name: "bearer auth",
+			processors: []openvoxv1alpha1.ReportProcessor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "bearer-ep", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.ReportProcessorSpec{
+						ConfigRef: "production",
+						URL:       "https://reports.example.com",
+						Auth: &openvoxv1alpha1.ReportProcessorAuth{
+							Bearer: &openvoxv1alpha1.SecretKeySelector{
+								SecretKeyRef: openvoxv1alpha1.SecretKeyRef{
+									Name: "bearer-secret",
+									Key:  "token",
+								},
+							},
+						},
+					},
+				},
+			},
+			objs: []client.Object{
+				newSecret("bearer-secret", map[string][]byte{"token": []byte("bearer-xyz")}),
+			},
+			contains: []string{
+				"type: bearer",
+				"token: bearer-xyz",
+			},
+		},
+		{
+			name: "processor field set",
+			processors: []openvoxv1alpha1.ReportProcessor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pdb-ep", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.ReportProcessorSpec{
+						ConfigRef: "production",
+						Processor: "puppetdb",
+						URL:       "https://pdb.example.com",
+					},
+				},
+			},
+			contains: []string{"processor: puppetdb"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := setupTestClient(tt.objs...)
+			r := newConfigReconciler(c)
+
+			out, err := r.renderReportWebhookConfig(testCtx(), testNamespace, tt.processors)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, s := range tt.contains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected %q in output:\n%s", s, out)
+				}
+			}
+			for _, s := range tt.excludes {
+				if strings.Contains(out, s) {
+					t.Errorf("unexpected %q in output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderReportWebhookConfig_HeaderStaticValue(t *testing.T) {
+	c := setupTestClient()
+	r := newConfigReconciler(c)
+
+	processors := []openvoxv1alpha1.ReportProcessor{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "hdr-ep", Namespace: testNamespace},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "production",
+				URL:       "https://reports.example.com",
+				Headers: []openvoxv1alpha1.HTTPHeader{
+					{Name: "X-Custom", Value: "static-val"},
+				},
+			},
+		},
+	}
+
+	out, err := r.renderReportWebhookConfig(testCtx(), testNamespace, processors)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"headers:",
+		"name: X-Custom",
+		"value: static-val",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderReportWebhookConfig_HeaderFromSecret(t *testing.T) {
+	secret := newSecret("header-secret", map[string][]byte{"api-key": []byte("secret-key-val")})
+	c := setupTestClient(secret)
+	r := newConfigReconciler(c)
+
+	processors := []openvoxv1alpha1.ReportProcessor{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "hdr-ep", Namespace: testNamespace},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "production",
+				URL:       "https://reports.example.com",
+				Headers: []openvoxv1alpha1.HTTPHeader{
+					{
+						Name: "X-API-Key",
+						ValueFrom: &openvoxv1alpha1.HTTPHeaderValueFrom{
+							SecretKeyRef: &openvoxv1alpha1.SecretKeyRef{
+								Name: "header-secret",
+								Key:  "api-key",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := r.renderReportWebhookConfig(testCtx(), testNamespace, processors)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"name: X-API-Key",
+		"value: secret-key-val",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderReportWebhookConfig_HeaderFromConfigMap(t *testing.T) {
+	cm := newConfigMap("header-cm", map[string]string{"env": "production"})
+	c := setupTestClient(cm)
+	r := newConfigReconciler(c)
+
+	processors := []openvoxv1alpha1.ReportProcessor{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "hdr-ep", Namespace: testNamespace},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "production",
+				URL:       "https://reports.example.com",
+				Headers: []openvoxv1alpha1.HTTPHeader{
+					{
+						Name: "X-Environment",
+						ValueFrom: &openvoxv1alpha1.HTTPHeaderValueFrom{
+							ConfigMapKeyRef: &openvoxv1alpha1.ConfigMapKeyRef{
+								Name: "header-cm",
+								Key:  "env",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := r.renderReportWebhookConfig(testCtx(), testNamespace, processors)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"name: X-Environment",
+		"value: production",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderReportWebhookConfig_MultipleEndpoints(t *testing.T) {
+	bearerSecret := newSecret("bearer-secret", map[string][]byte{"token": []byte("tok123")})
+	c := setupTestClient(bearerSecret)
+	r := newConfigReconciler(c)
+
+	processors := []openvoxv1alpha1.ReportProcessor{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ep-mtls", Namespace: testNamespace},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "production",
+				URL:       "https://mtls.example.com",
+				Auth:      &openvoxv1alpha1.ReportProcessorAuth{MTLS: true},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ep-bearer", Namespace: testNamespace},
+			Spec: openvoxv1alpha1.ReportProcessorSpec{
+				ConfigRef: "production",
+				URL:       "https://bearer.example.com",
+				Auth: &openvoxv1alpha1.ReportProcessorAuth{
+					Bearer: &openvoxv1alpha1.SecretKeySelector{
+						SecretKeyRef: openvoxv1alpha1.SecretKeyRef{
+							Name: "bearer-secret",
+							Key:  "token",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := r.renderReportWebhookConfig(testCtx(), testNamespace, processors)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range []string{
+		"name: ep-mtls",
+		"type: mtls",
+		"name: ep-bearer",
+		"type: bearer",
+		"token: tok123",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}

--- a/internal/controller/config_serviceaccount_test.go
+++ b/internal/controller/config_serviceaccount_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestReconcileServerServiceAccount(t *testing.T) {
+	t.Run("creates SA when not found", func(t *testing.T) {
+		cfg := newConfig("production")
+		c := setupTestClient(cfg)
+		r := newConfigReconciler(c)
+
+		if err := r.reconcileServerServiceAccount(testCtx(), cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sa := &corev1.ServiceAccount{}
+		if err := c.Get(testCtx(), types.NamespacedName{Name: "production-server", Namespace: testNamespace}, sa); err != nil {
+			t.Fatalf("ServiceAccount not created: %v", err)
+		}
+
+		if sa.AutomountServiceAccountToken == nil || *sa.AutomountServiceAccountToken {
+			t.Error("expected AutomountServiceAccountToken to be false")
+		}
+
+		// Verify labels
+		if sa.Labels["app.kubernetes.io/name"] != "openvox" {
+			t.Errorf("expected label app.kubernetes.io/name=openvox, got %q", sa.Labels["app.kubernetes.io/name"])
+		}
+	})
+
+	t.Run("no-op when SA already exists", func(t *testing.T) {
+		cfg := newConfig("production")
+		automount := false
+		existingSA := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "production-server",
+				Namespace: testNamespace,
+			},
+			AutomountServiceAccountToken: &automount,
+		}
+		c := setupTestClient(cfg, existingSA)
+		r := newConfigReconciler(c)
+
+		if err := r.reconcileServerServiceAccount(testCtx(), cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should still exist and be the same
+		sa := &corev1.ServiceAccount{}
+		if err := c.Get(testCtx(), types.NamespacedName{Name: "production-server", Namespace: testNamespace}, sa); err != nil {
+			t.Fatalf("ServiceAccount should still exist: %v", err)
+		}
+	})
+}

--- a/internal/controller/database_rendering_test.go
+++ b/internal/controller/database_rendering_test.go
@@ -4,24 +4,173 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
 func TestRenderJettyIni(t *testing.T) {
 	ini := renderJettyIni("puppetdb.example.com")
 
 	checks := map[string]string{
-		"cleartext host":  "host = 127.0.0.1",
-		"cleartext port":  fmt.Sprintf("port = %d", DatabaseHTTPPort),
-		"ssl host":        "ssl-host = 0.0.0.0",
-		"ssl port":        fmt.Sprintf("ssl-port = %d", DatabaseHTTPSPort),
-		"client-auth":     "client-auth = need",
-		"ssl-key path":    "ssl-key = /etc/puppetlabs/puppetdb/ssl/private_keys/puppetdb.example.com.pem",
-		"ssl-cert path":   "ssl-cert = /etc/puppetlabs/puppetdb/ssl/certs/puppetdb.example.com.pem",
+		"cleartext host":   "host = 127.0.0.1",
+		"cleartext port":   fmt.Sprintf("port = %d", DatabaseHTTPPort),
+		"ssl host":         "ssl-host = 0.0.0.0",
+		"ssl port":         fmt.Sprintf("ssl-port = %d", DatabaseHTTPSPort),
+		"client-auth":      "client-auth = need",
+		"ssl-key path":     "ssl-key = /etc/puppetlabs/puppetdb/ssl/private_keys/puppetdb.example.com.pem",
+		"ssl-cert path":    "ssl-cert = /etc/puppetlabs/puppetdb/ssl/certs/puppetdb.example.com.pem",
 		"ssl-ca-cert path": "ssl-ca-cert = /etc/puppetlabs/puppetdb/ssl/certs/ca.pem",
 	}
 	for name, expected := range checks {
 		if !strings.Contains(ini, expected) {
 			t.Errorf("jetty.ini missing %s: expected %q in output:\n%s", name, expected, ini)
+		}
+	}
+}
+
+func TestRenderDatabaseIni(t *testing.T) {
+	tests := []struct {
+		name     string
+		db       *openvoxv1alpha1.Database
+		contains []string
+	}{
+		{
+			name: "default port 5432",
+			db: func() *openvoxv1alpha1.Database {
+				db := newDatabase("db")
+				db.Spec.Postgres.Port = 0
+				return db
+			}(),
+			contains: []string{
+				"subname = //pg-rw.openvox.svc:5432/openvoxdb?sslmode=require",
+			},
+		},
+		{
+			name: "custom port",
+			db: func() *openvoxv1alpha1.Database {
+				db := newDatabase("db")
+				db.Spec.Postgres.Port = 5433
+				return db
+			}(),
+			contains: []string{
+				":5433/",
+			},
+		},
+		{
+			name: "sslMode verify-full",
+			db: func() *openvoxv1alpha1.Database {
+				db := newDatabase("db")
+				db.Spec.Postgres.SSLMode = "verify-full"
+				return db
+			}(),
+			contains: []string{
+				"sslmode=verify-full",
+			},
+		},
+		{
+			name: "sslMode disable",
+			db: func() *openvoxv1alpha1.Database {
+				db := newDatabase("db")
+				db.Spec.Postgres.SSLMode = "disable"
+				return db
+			}(),
+			contains: []string{
+				"sslmode=disable",
+			},
+		},
+		{
+			name: "default sslMode require",
+			db: func() *openvoxv1alpha1.Database {
+				db := newDatabase("db")
+				db.Spec.Postgres.SSLMode = ""
+				return db
+			}(),
+			contains: []string{
+				"sslmode=require",
+			},
+		},
+		{
+			name: "custom database name",
+			db: func() *openvoxv1alpha1.Database {
+				db := newDatabase("db")
+				db.Spec.Postgres.Database = "customdb"
+				return db
+			}(),
+			contains: []string{
+				"/customdb?",
+			},
+		},
+		{
+			name: "default database name openvoxdb",
+			db: func() *openvoxv1alpha1.Database {
+				db := newDatabase("db")
+				db.Spec.Postgres.Database = ""
+				return db
+			}(),
+			contains: []string{
+				"/openvoxdb?",
+			},
+		},
+		{
+			name: "credentials from secret",
+			db:   newDatabase("db"),
+			contains: []string{
+				"username = dbuser",
+				"password = dbpass",
+			},
+		},
+	}
+
+	pgSecret := newSecret("pg-credentials", map[string][]byte{
+		"username": []byte("dbuser"),
+		"password": []byte("dbpass"),
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := setupTestClient(pgSecret)
+			r := newDatabaseReconciler(c)
+
+			out, err := r.renderDatabaseIni(testCtx(), tt.db)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, s := range tt.contains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected %q in output:\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderConfigIni(t *testing.T) {
+	out := renderConfigIni()
+
+	for _, s := range []string{
+		"vardir = /opt/puppetlabs/server/data/puppetdb",
+		"logging-config = /etc/puppetlabs/puppetdb/logback.xml",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
+		}
+	}
+}
+
+func TestRenderAuthConfDatabase(t *testing.T) {
+	out := renderAuthConf()
+
+	for _, s := range []string{
+		"path: \"/status/v1/services\"",
+		"path: \"/status/v1/simple\"",
+		"path: \"/metrics\"",
+		"name: \"puppetlabs puppetdb metrics\"",
+		"deny: \"*\"",
+		"name: \"puppetlabs deny all\"",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected %q in output:\n%s", s, out)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #234.

- Add 38 new unit tests covering previously untested rendering functions and CA helper components
- New test files: `config_rendering_test.go`, `config_enc_test.go`, `config_autosign_test.go`, `config_reports_test.go`, `certificateauthority_job_test.go`, `config_serviceaccount_test.go`
- Extended `database_rendering_test.go` with tests for `renderDatabaseIni`, `renderConfigIni`, and `renderAuthConf`

### Functions now covered

| Function | Test file |
|----------|-----------|
| `renderMetricsConf` | `config_rendering_test.go` |
| `renderWebserverConf` / `renderWebserverConfCA` | `config_rendering_test.go` |
| `renderCAConf` | `config_rendering_test.go` |
| `renderENCConfig` (all auth types, cache) | `config_enc_test.go` |
| `renderAutosignPolicyConfig` (CSR attrs, patterns, sort) | `config_autosign_test.go` |
| `renderReportWebhookConfig` (headers, auth, multi-endpoint) | `config_reports_test.go` |
| `renderDatabaseIni` (port, sslMode, credentials) | `database_rendering_test.go` |
| `renderConfigIni` / `renderAuthConf` (database) | `database_rendering_test.go` |
| `buildCASetupJob` / `findCAServerCert` / `resolveCAJobResources` | `certificateauthority_job_test.go` |
| `reconcileServerServiceAccount` | `config_serviceaccount_test.go` |

## Test plan

- [x] `go test ./internal/controller/... -count=1` passes
- [x] `go test ./internal/webhook/... -count=1` passes
- [x] No existing tests broken