### PR TITLE
docs: fix remaining documentation gaps from CRD-to-docs audit

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@
 
 ## Prerequisites
 
-- Kubernetes 1.28+ or OpenShift 4.15+ cluster
+- Kubernetes or OpenShift cluster
 - Helm 3.x
 
 ### Optional Components

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,8 +5,17 @@
 
 ## Prerequisites
 
-- Kubernetes or OpenShift cluster
+- Kubernetes 1.28+ or OpenShift 4.15+ cluster
 - Helm 3.x
+
+### Optional Components
+
+| Component | When needed |
+|---|---|
+| Kubernetes 1.35+ | OCI Image Volumes for [code deployment](../concepts/code-deployment.md) (1.31+ with `ImageVolume` feature gate) |
+| cert-manager | Webhook TLS certificate automation |
+| Gateway API CRDs | [TLSRoute](../concepts/gateway-api.md) support in Pool |
+| CloudNativePG (CNPG) | Managed PostgreSQL for [Database](../reference/database.md) |
 
 ## Install via Helm (OCI)
 

--- a/docs/reference/certificate.md
+++ b/docs/reference/certificate.md
@@ -31,16 +31,35 @@ spec:
 |---|---|---|
 | `phase` | string | Current lifecycle phase |
 | `secretName` | string | Name of the Secret containing `cert.pem` and `key.pem` |
+| `notAfter` | time | Expiry time of the signed certificate |
 | `conditions` | []Condition | `CertSigned` |
 
 ## Phases
 
 | Phase | Description |
 |---|---|
-| `Pending` | Waiting for CertificateAuthority to reach `Ready` |
+| `Pending` | Waiting for CertificateAuthority to reach `Ready` or `External` |
 | `Requesting` | Certificate signing in progress |
+| `WaitingForSigning` | CSR submitted, waiting for CA to sign (backoff polling in progress) |
 | `Signed` | TLS Secret created, Servers can mount it |
 | `Error` | Certificate signing failed |
+
+### CSR Poll Backoff
+
+When the CA does not immediately sign the CSR (e.g. autosigning is disabled), the controller enters `WaitingForSigning` after 10 unsuccessful poll attempts and retries with exponential backoff:
+
+| Attempts | Interval |
+|---|---|
+| 0--2 | 5s |
+| 3--5 | 30s |
+| 6--9 | 2m |
+| 10+ | 5m |
+
+The poll attempt count is tracked via the annotation `openvox.voxpupuli.org/csr-poll-attempts` on the pending Secret `{name}-tls-pending`. To resolve manually, sign the CSR on the CA and the controller will pick it up on the next poll:
+
+```bash
+puppetserver ca sign --certname <certname>
+```
 
 ## Signing Strategy
 


### PR DESCRIPTION
## Summary
- Add `notAfter` field to Certificate status table (was in CRD but undocumented)
- Add `WaitingForSigning` phase to Certificate phases table with CSR poll backoff schedule (5s/30s/2m/5m)
- Add optional component prerequisites to installation guide (K8s 1.35+ for OCI volumes, cert-manager, Gateway API CRDs, CNPG)

Items 3 and 5 from the audit (ExternalCASpec docs and guide navigation) were already resolved in #249.

Closes #248