### PR TITLE
fix: add RetryOnConflict to all Status().Update() calls

### DIFF
--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -51,8 +51,9 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Set initial phase
 	if cert.Status.Phase == "" {
-		cert.Status.Phase = openvoxv1alpha1.CertificatePhasePending
-		if err := r.Status().Update(ctx, cert); err != nil {
+		if err := updateStatusWithRetry(ctx, r.Client, cert, func() {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhasePending
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -70,8 +71,9 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Wait for CA to be ready (accept both Ready and External phases)
 	if ca.Status.Phase != openvoxv1alpha1.CertificateAuthorityPhaseReady && ca.Status.Phase != openvoxv1alpha1.CertificateAuthorityPhaseExternal {
 		logger.Info("waiting for CertificateAuthority to be ready", "ca", ca.Name, "phase", ca.Status.Phase)
-		cert.Status.Phase = openvoxv1alpha1.CertificatePhasePending
-		if statusErr := r.Status().Update(ctx, cert); statusErr != nil {
+		if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhasePending
+		}); statusErr != nil {
 			logger.Error(statusErr, "failed to update Certificate status", "name", cert.Name)
 		}
 		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
@@ -85,17 +87,19 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, fmt.Errorf("adopting TLS Secret: %w", err)
 		}
 
-		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseSigned
-		cert.Status.SecretName = tlsSecretName
-		cert.Status.NotAfter = r.extractNotAfter(ctx, tlsSecretName, cert.Namespace)
-		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionCertSigned,
-			Status:             metav1.ConditionTrue,
-			Reason:             "CertificateSigned",
-			Message:            "Certificate is signed and available",
-			LastTransitionTime: metav1.Now(),
-		})
-		if err := r.Status().Update(ctx, cert); err != nil {
+		notAfter := r.extractNotAfter(ctx, tlsSecretName, cert.Namespace)
+		if err := updateStatusWithRetry(ctx, r.Client, cert, func() {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhaseSigned
+			cert.Status.SecretName = tlsSecretName
+			cert.Status.NotAfter = notAfter
+			meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionCertSigned,
+				Status:             metav1.ConditionTrue,
+				Reason:             "CertificateSigned",
+				Message:            "Certificate is signed and available",
+				LastTransitionTime: metav1.Now(),
+			})
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 		r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateSigned, "Reconcile", "Certificate signed and available in Secret %s", tlsSecretName)
@@ -131,23 +135,26 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 		caBaseURL = fmt.Sprintf("https://%s.%s.svc:8140", caInternalServiceName(ca.Name), cert.Namespace)
 	}
 
-	cert.Status.Phase = openvoxv1alpha1.CertificatePhaseRequesting
-	if statusErr := r.Status().Update(ctx, cert); statusErr != nil {
+	if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
+		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseRequesting
+	}); statusErr != nil {
 		logger.Error(statusErr, "failed to update Certificate status", "name", cert.Name)
 	}
 
 	result, err := r.signCertificate(ctx, cert, ca, caBaseURL, cert.Namespace)
 	if err != nil {
 		logger.Error(err, "certificate signing failed, will retry")
-		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseError
-		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionCertSigned,
-			Status:             metav1.ConditionFalse,
-			Reason:             "SigningFailed",
-			Message:            err.Error(),
-			LastTransitionTime: metav1.Now(),
-		})
-		if statusErr := r.Status().Update(ctx, cert); statusErr != nil {
+		errMsg := err.Error()
+		if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhaseError
+			meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionCertSigned,
+				Status:             metav1.ConditionFalse,
+				Reason:             "SigningFailed",
+				Message:            errMsg,
+				LastTransitionTime: metav1.Now(),
+			})
+		}); statusErr != nil {
 			logger.Error(statusErr, "failed to update Certificate status", "name", cert.Name)
 		}
 		if result.RequeueAfter > 0 {
@@ -163,17 +170,19 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 
 	// Mark as signed
 	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
-	cert.Status.Phase = openvoxv1alpha1.CertificatePhaseSigned
-	cert.Status.SecretName = tlsSecretName
-	cert.Status.NotAfter = r.extractNotAfter(ctx, tlsSecretName, cert.Namespace)
-	meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
-		Type:               openvoxv1alpha1.ConditionCertSigned,
-		Status:             metav1.ConditionTrue,
-		Reason:             "CertificateSigned",
-		Message:            "Certificate is signed and available",
-		LastTransitionTime: metav1.Now(),
-	})
-	if err := r.Status().Update(ctx, cert); err != nil {
+	notAfter := r.extractNotAfter(ctx, tlsSecretName, cert.Namespace)
+	if err := updateStatusWithRetry(ctx, r.Client, cert, func() {
+		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseSigned
+		cert.Status.SecretName = tlsSecretName
+		cert.Status.NotAfter = notAfter
+		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionCertSigned,
+			Status:             metav1.ConditionTrue,
+			Reason:             "CertificateSigned",
+			Message:            "Certificate is signed and available",
+			LastTransitionTime: metav1.Now(),
+		})
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -353,15 +353,17 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 			if certname == "" {
 				certname = "puppet"
 			}
-			cert.Status.Phase = openvoxv1alpha1.CertificatePhaseWaitingForSigning
-			meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
-				Type:               openvoxv1alpha1.ConditionCertSigned,
-				Status:             metav1.ConditionFalse,
-				Reason:             "WaitingForManualSigning",
-				Message:            fmt.Sprintf("CSR submitted but not yet signed after %d attempts", attempts),
-				LastTransitionTime: metav1.Now(),
-			})
-			if statusErr := r.Status().Update(ctx, cert); statusErr != nil {
+			waitMsg := fmt.Sprintf("CSR submitted but not yet signed after %d attempts", attempts)
+			if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
+				cert.Status.Phase = openvoxv1alpha1.CertificatePhaseWaitingForSigning
+				meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+					Type:               openvoxv1alpha1.ConditionCertSigned,
+					Status:             metav1.ConditionFalse,
+					Reason:             "WaitingForManualSigning",
+					Message:            waitMsg,
+					LastTransitionTime: metav1.Now(),
+				})
+			}); statusErr != nil {
 				logger.Error(statusErr, "failed to update Certificate status to WaitingForSigning")
 			}
 			r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCSRWaitingForSigning, "Reconcile",

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -61,8 +61,9 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// Set initial phase
 	if ca.Status.Phase == "" {
-		ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhasePending
-		if err := r.Status().Update(ctx, ca); err != nil {
+		if err := updateStatusWithRetry(ctx, r.Client, ca, func() {
+			ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhasePending
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -121,24 +122,29 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// CA is ready
 	wasReady := ca.Status.Phase == openvoxv1alpha1.CertificateAuthorityPhaseReady
-	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseReady
-	ca.Status.CASecretName = caSecretName
-	ca.Status.ServiceName = caInternalServiceName(ca.Name)
-	ca.Status.NotAfter = r.extractCANotAfter(ctx, caSecretName, ca.Namespace)
-
-	// Find the CA server cert's TLS secret for signing credentials
+	notAfter := r.extractCANotAfter(ctx, caSecretName, ca.Namespace)
+	serviceName := caInternalServiceName(ca.Name)
+	var signingSecretName string
 	if caCert := r.findCAServerCert(ctx, ca, certs); caCert != nil {
-		ca.Status.SigningSecretName = fmt.Sprintf("%s-tls", caCert.Name)
+		signingSecretName = fmt.Sprintf("%s-tls", caCert.Name)
 	}
-	meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
-		Type:               openvoxv1alpha1.ConditionCAReady,
-		Status:             metav1.ConditionTrue,
-		Reason:             "CAInitialized",
-		Message:            "CA is initialized and ready",
-		LastTransitionTime: metav1.Now(),
-	})
 
-	if err := r.Status().Update(ctx, ca); err != nil {
+	if err := updateStatusWithRetry(ctx, r.Client, ca, func() {
+		ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseReady
+		ca.Status.CASecretName = caSecretName
+		ca.Status.ServiceName = serviceName
+		ca.Status.NotAfter = notAfter
+		if signingSecretName != "" {
+			ca.Status.SigningSecretName = signingSecretName
+		}
+		meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionCAReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             "CAInitialized",
+			Message:            "CA is initialized and ready",
+			LastTransitionTime: metav1.Now(),
+		})
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -235,19 +241,21 @@ func (r *CertificateAuthorityReconciler) reconcileExternalCA(ctx context.Context
 	}
 
 	wasExternal := ca.Status.Phase == openvoxv1alpha1.CertificateAuthorityPhaseExternal
-	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseExternal
-	ca.Status.CASecretName = caSecretName
-	ca.Status.NotAfter = r.extractCANotAfter(ctx, caSecretName, ca.Namespace)
+	notAfter := r.extractCANotAfter(ctx, caSecretName, ca.Namespace)
+	extMsg := fmt.Sprintf("External CA configured at %s", ext.URL)
 
-	meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
-		Type:               openvoxv1alpha1.ConditionCAReady,
-		Status:             metav1.ConditionTrue,
-		Reason:             "ExternalCA",
-		Message:            fmt.Sprintf("External CA configured at %s", ext.URL),
-		LastTransitionTime: metav1.Now(),
-	})
-
-	if err := r.Status().Update(ctx, ca); err != nil {
+	if err := updateStatusWithRetry(ctx, r.Client, ca, func() {
+		ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseExternal
+		ca.Status.CASecretName = caSecretName
+		ca.Status.NotAfter = notAfter
+		meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionCAReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             "ExternalCA",
+			Message:            extMsg,
+			LastTransitionTime: metav1.Now(),
+		})
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/certificateauthority_job.go
+++ b/internal/controller/certificateauthority_job.go
@@ -96,8 +96,9 @@ func (r *CertificateAuthorityReconciler) reconcileCASetupJob(ctx context.Context
 	}
 
 	// CA not ready -- run setup job
-	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseInitializing
-	if statusErr := r.Status().Update(ctx, ca); statusErr != nil {
+	if statusErr := updateStatusWithRetry(ctx, r.Client, ca, func() {
+		ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseInitializing
+	}); statusErr != nil {
 		logger.Error(statusErr, "failed to update CertificateAuthority status", "name", ca.Name)
 	}
 

--- a/internal/controller/config_autosign.go
+++ b/internal/controller/config_autosign.go
@@ -137,26 +137,31 @@ func (r *ConfigReconciler) renderAutosignPolicyConfig(ctx context.Context, names
 
 // updateSigningPolicyStatus sets the phase and condition on a SigningPolicy.
 func (r *ConfigReconciler) updateSigningPolicyStatus(ctx context.Context, sp *openvoxv1alpha1.SigningPolicy, err error) {
+	var errMsg string
 	if err != nil {
-		sp.Status.Phase = openvoxv1alpha1.SigningPolicyPhaseError
-		meta.SetStatusCondition(&sp.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionSigningPolicyReady,
-			Status:             metav1.ConditionFalse,
-			Reason:             "Error",
-			Message:            err.Error(),
-			LastTransitionTime: metav1.Now(),
-		})
-	} else {
-		sp.Status.Phase = openvoxv1alpha1.SigningPolicyPhaseActive
-		meta.SetStatusCondition(&sp.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionSigningPolicyReady,
-			Status:             metav1.ConditionTrue,
-			Reason:             "PolicyRendered",
-			Message:            "Signing policy is active",
-			LastTransitionTime: metav1.Now(),
-		})
+		errMsg = err.Error()
 	}
-	if statusErr := r.Status().Update(ctx, sp); statusErr != nil {
+	if statusErr := updateStatusWithRetry(ctx, r.Client, sp, func() {
+		if err != nil {
+			sp.Status.Phase = openvoxv1alpha1.SigningPolicyPhaseError
+			meta.SetStatusCondition(&sp.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionSigningPolicyReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "Error",
+				Message:            errMsg,
+				LastTransitionTime: metav1.Now(),
+			})
+		} else {
+			sp.Status.Phase = openvoxv1alpha1.SigningPolicyPhaseActive
+			meta.SetStatusCondition(&sp.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionSigningPolicyReady,
+				Status:             metav1.ConditionTrue,
+				Reason:             "PolicyRendered",
+				Message:            "Signing policy is active",
+				LastTransitionTime: metav1.Now(),
+			})
+		}
+	}); statusErr != nil {
 		log.FromContext(ctx).Error(statusErr, "failed to update SigningPolicy status", "name", sp.Name)
 	}
 }

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -53,8 +53,9 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Set initial phase
 	if cfg.Status.Phase == "" {
-		cfg.Status.Phase = openvoxv1alpha1.ConfigPhasePending
-		if err := r.Status().Update(ctx, cfg); err != nil {
+		if err := updateStatusWithRetry(ctx, r.Client, cfg, func() {
+			cfg.Status.Phase = openvoxv1alpha1.ConfigPhasePending
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -64,13 +65,6 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.reconcileConfigMap(ctx, cfg); err != nil {
 		return ctrl.Result{}, fmt.Errorf("reconciling ConfigMaps: %w", err)
 	}
-	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-		Type:               openvoxv1alpha1.ConditionConfigReady,
-		Status:             metav1.ConditionTrue,
-		Reason:             "ConfigMapsCreated",
-		Message:            "Configuration ConfigMaps are up to date",
-		LastTransitionTime: metav1.Now(),
-	})
 
 	// Step 2: Reconcile autosign policy Secrets for all CAs in this Config
 	if err := r.reconcileAutosignSecrets(ctx, cfg); err != nil {
@@ -93,9 +87,16 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Update status
-	cfg.Status.Phase = openvoxv1alpha1.ConfigPhaseRunning
-
-	if err := r.Status().Update(ctx, cfg); err != nil {
+	if err := updateStatusWithRetry(ctx, r.Client, cfg, func() {
+		cfg.Status.Phase = openvoxv1alpha1.ConfigPhaseRunning
+		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionConfigReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             "ConfigMapsCreated",
+			Message:            "Configuration ConfigMaps are up to date",
+			LastTransitionTime: metav1.Now(),
+		})
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/config_enc.go
+++ b/internal/controller/config_enc.go
@@ -162,26 +162,31 @@ func (r *ConfigReconciler) renderENCConfig(ctx context.Context, cfg *openvoxv1al
 
 // updateNodeClassifierStatus sets the phase and condition on a NodeClassifier.
 func (r *ConfigReconciler) updateNodeClassifierStatus(ctx context.Context, nc *openvoxv1alpha1.NodeClassifier, err error) {
+	var errMsg string
 	if err != nil {
-		nc.Status.Phase = openvoxv1alpha1.NodeClassifierPhaseError
-		meta.SetStatusCondition(&nc.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionNodeClassifierReady,
-			Status:             metav1.ConditionFalse,
-			Reason:             "Error",
-			Message:            err.Error(),
-			LastTransitionTime: metav1.Now(),
-		})
-	} else {
-		nc.Status.Phase = openvoxv1alpha1.NodeClassifierPhaseActive
-		meta.SetStatusCondition(&nc.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionNodeClassifierReady,
-			Status:             metav1.ConditionTrue,
-			Reason:             "ConfigRendered",
-			Message:            "Node classifier configuration is active",
-			LastTransitionTime: metav1.Now(),
-		})
+		errMsg = err.Error()
 	}
-	if statusErr := r.Status().Update(ctx, nc); statusErr != nil {
+	if statusErr := updateStatusWithRetry(ctx, r.Client, nc, func() {
+		if err != nil {
+			nc.Status.Phase = openvoxv1alpha1.NodeClassifierPhaseError
+			meta.SetStatusCondition(&nc.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionNodeClassifierReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "Error",
+				Message:            errMsg,
+				LastTransitionTime: metav1.Now(),
+			})
+		} else {
+			nc.Status.Phase = openvoxv1alpha1.NodeClassifierPhaseActive
+			meta.SetStatusCondition(&nc.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionNodeClassifierReady,
+				Status:             metav1.ConditionTrue,
+				Reason:             "ConfigRendered",
+				Message:            "Node classifier configuration is active",
+				LastTransitionTime: metav1.Now(),
+			})
+		}
+	}); statusErr != nil {
 		log.FromContext(ctx).Error(statusErr, "failed to update NodeClassifier status", "name", nc.Name)
 	}
 }

--- a/internal/controller/config_reports.go
+++ b/internal/controller/config_reports.go
@@ -221,26 +221,31 @@ func (r *ConfigReconciler) resolveConfigMapKey(ctx context.Context, namespace, c
 
 // updateReportProcessorStatus sets the phase and condition on a ReportProcessor.
 func (r *ConfigReconciler) updateReportProcessorStatus(ctx context.Context, rp *openvoxv1alpha1.ReportProcessor, err error) {
+	var errMsg string
 	if err != nil {
-		rp.Status.Phase = openvoxv1alpha1.ReportProcessorPhaseError
-		meta.SetStatusCondition(&rp.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionReportProcessorReady,
-			Status:             metav1.ConditionFalse,
-			Reason:             "Error",
-			Message:            err.Error(),
-			LastTransitionTime: metav1.Now(),
-		})
-	} else {
-		rp.Status.Phase = openvoxv1alpha1.ReportProcessorPhaseActive
-		meta.SetStatusCondition(&rp.Status.Conditions, metav1.Condition{
-			Type:               openvoxv1alpha1.ConditionReportProcessorReady,
-			Status:             metav1.ConditionTrue,
-			Reason:             "ConfigRendered",
-			Message:            "Report processor configuration is active",
-			LastTransitionTime: metav1.Now(),
-		})
+		errMsg = err.Error()
 	}
-	if statusErr := r.Status().Update(ctx, rp); statusErr != nil {
+	if statusErr := updateStatusWithRetry(ctx, r.Client, rp, func() {
+		if err != nil {
+			rp.Status.Phase = openvoxv1alpha1.ReportProcessorPhaseError
+			meta.SetStatusCondition(&rp.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionReportProcessorReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "Error",
+				Message:            errMsg,
+				LastTransitionTime: metav1.Now(),
+			})
+		} else {
+			rp.Status.Phase = openvoxv1alpha1.ReportProcessorPhaseActive
+			meta.SetStatusCondition(&rp.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionReportProcessorReady,
+				Status:             metav1.ConditionTrue,
+				Reason:             "ConfigRendered",
+				Message:            "Report processor configuration is active",
+				LastTransitionTime: metav1.Now(),
+			})
+		}
+	}); statusErr != nil {
 		log.FromContext(ctx).Error(statusErr, "failed to update ReportProcessor status", "name", rp.Name)
 	}
 }

--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -69,8 +69,9 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Set initial phase
 	if db.Status.Phase == "" {
-		db.Status.Phase = openvoxv1alpha1.DatabasePhasePending
-		if err := r.Status().Update(ctx, db); err != nil {
+		if err := updateStatusWithRetry(ctx, r.Client, db, func() {
+			db.Status.Phase = openvoxv1alpha1.DatabasePhasePending
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -87,8 +88,9 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if cert.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned || cert.Status.SecretName == "" {
 		logger.Info("waiting for Certificate to be signed", "certificate", cert.Name, "phase", cert.Status.Phase)
-		db.Status.Phase = openvoxv1alpha1.DatabasePhaseWaitingForCert
-		if statusErr := r.Status().Update(ctx, db); statusErr != nil {
+		if statusErr := updateStatusWithRetry(ctx, r.Client, db, func() {
+			db.Status.Phase = openvoxv1alpha1.DatabasePhaseWaitingForCert
+		}); statusErr != nil {
 			logger.Error(statusErr, "failed to update Database status", "name", db.Name)
 		}
 		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
@@ -150,33 +152,28 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("reconciling NetworkPolicy: %w", err)
 	}
 
-	// Re-fetch to avoid conflict errors from concurrent reconciliations
-	if err := r.Get(ctx, req.NamespacedName, db); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Update status
-	replicas := int32(1)
-	if db.Spec.Replicas != nil {
-		replicas = *db.Spec.Replicas
-	}
 	ready := r.getReadyReplicas(ctx, db)
-	db.Status.Desired = replicas
-	db.Status.Ready = ready
+	if err := updateStatusWithRetry(ctx, r.Client, db, func() {
+		replicas := int32(1)
+		if db.Spec.Replicas != nil {
+			replicas = *db.Spec.Replicas
+		}
+		db.Status.Desired = replicas
+		db.Status.Ready = ready
 
-	port := db.Spec.Service.Port
-	if port == 0 {
-		port = DatabaseHTTPSPort
-	}
-	db.Status.URL = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", db.Name, db.Namespace, port)
+		port := db.Spec.Service.Port
+		if port == 0 {
+			port = DatabaseHTTPSPort
+		}
+		db.Status.URL = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", db.Name, db.Namespace, port)
 
-	if ready > 0 {
-		db.Status.Phase = openvoxv1alpha1.DatabasePhaseRunning
-	} else {
-		db.Status.Phase = openvoxv1alpha1.DatabasePhasePending
-	}
-
-	if err := r.Status().Update(ctx, db); err != nil {
+		if ready > 0 {
+			db.Status.Phase = openvoxv1alpha1.DatabasePhaseRunning
+		} else {
+			db.Status.Phase = openvoxv1alpha1.DatabasePhasePending
+		}
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -14,12 +14,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
+
+// updateStatusWithRetry updates an object's status with automatic retry on conflict.
+// It re-fetches the object before each attempt so the latest resourceVersion is used.
+func updateStatusWithRetry(ctx context.Context, c client.Client, obj client.Object, mutate func()) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return err
+		}
+		mutate()
+		return c.Status().Update(ctx, obj)
+	})
+}
 
 // resolveSecretKey reads a specific key from a Secret.
 func resolveSecretKey(ctx context.Context, reader client.Reader, namespace, secretName, key string) (string, error) {

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -1,7 +1,17 @@
 package controller
 
 import (
+	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -175,6 +185,93 @@ func TestBoolPtr(t *testing.T) {
 	val = boolPtr(false)
 	if val == nil || *val {
 		t.Errorf("boolPtr(false) = %v, want pointer to false", val)
+	}
+}
+
+func TestUpdateStatusWithRetry(t *testing.T) {
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: testNamespace,
+		},
+	}
+	c := setupTestClient(cfg)
+
+	err := updateStatusWithRetry(testCtx(), c, cfg, func() {
+		cfg.Status.Phase = openvoxv1alpha1.ConfigPhaseRunning
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the mutation was applied
+	got := &openvoxv1alpha1.Config{}
+	if err := c.Get(testCtx(), client.ObjectKeyFromObject(cfg), got); err != nil {
+		t.Fatalf("failed to get config: %v", err)
+	}
+	if got.Status.Phase != openvoxv1alpha1.ConfigPhaseRunning {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.ConfigPhaseRunning, got.Status.Phase)
+	}
+}
+
+func TestUpdateStatusWithRetry_ConflictRetry(t *testing.T) {
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: testNamespace,
+		},
+	}
+
+	var calls atomic.Int32
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(cfg).
+		WithStatusSubresource(&openvoxv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if calls.Add(1) == 1 {
+					return errors.NewConflict(schema.GroupResource{Group: "openvox.voxpupuli.org", Resource: "configs"}, obj.GetName(), fmt.Errorf("conflict"))
+				}
+				return client.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	err := updateStatusWithRetry(testCtx(), c, cfg, func() {
+		cfg.Status.Phase = openvoxv1alpha1.ConfigPhaseRunning
+	})
+	if err != nil {
+		t.Fatalf("unexpected error after retry: %v", err)
+	}
+	if calls.Load() < 2 {
+		t.Errorf("expected at least 2 calls, got %d", calls.Load())
+	}
+}
+
+func TestUpdateStatusWithRetry_NonConflictError(t *testing.T) {
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: testNamespace,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(cfg).
+		WithStatusSubresource(&openvoxv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				return fmt.Errorf("internal server error")
+			},
+		}).
+		Build()
+
+	err := updateStatusWithRetry(testCtx(), c, cfg, func() {
+		cfg.Status.Phase = openvoxv1alpha1.ConfigPhaseRunning
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -123,9 +123,11 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// Update status
-	pool.Status.ServiceName = pool.Name
-	pool.Status.Endpoints = r.countEndpoints(ctx, pool)
-	if err := r.Status().Update(ctx, pool); err != nil {
+	endpoints := r.countEndpoints(ctx, pool)
+	if err := updateStatusWithRetry(ctx, r.Client, pool, func() {
+		pool.Status.ServiceName = pool.Name
+		pool.Status.Endpoints = endpoints
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -416,8 +418,9 @@ func (r *PoolReconciler) injectDNSAltNames(ctx context.Context, pool *openvoxv1a
 
 		// Reset certificate phase to trigger re-signing with the new alt name
 		if cert.Status.Phase == openvoxv1alpha1.CertificatePhaseSigned {
-			cert.Status.Phase = openvoxv1alpha1.CertificatePhasePending
-			if err := r.Status().Update(ctx, cert); err != nil {
+			if err := updateStatusWithRetry(ctx, r.Client, cert, func() {
+				cert.Status.Phase = openvoxv1alpha1.CertificatePhasePending
+			}); err != nil {
 				return fmt.Errorf("resetting Certificate %s phase: %w", cert.Name, err)
 			}
 			logger.Info("reset Certificate phase to Pending for re-signing",

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -72,8 +72,9 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Set initial phase
 	if server.Status.Phase == "" {
-		server.Status.Phase = openvoxv1alpha1.ServerPhasePending
-		if err := r.Status().Update(ctx, server); err != nil {
+		if err := updateStatusWithRetry(ctx, r.Client, server, func() {
+			server.Status.Phase = openvoxv1alpha1.ServerPhasePending
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -100,8 +101,9 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if cert.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned || cert.Status.SecretName == "" {
 		logger.Info("waiting for Certificate to be signed", "certificate", cert.Name, "phase", cert.Status.Phase)
-		server.Status.Phase = openvoxv1alpha1.ServerPhaseWaitingForCert
-		if statusErr := r.Status().Update(ctx, server); statusErr != nil {
+		if statusErr := updateStatusWithRetry(ctx, r.Client, server, func() {
+			server.Status.Phase = openvoxv1alpha1.ServerPhaseWaitingForCert
+		}); statusErr != nil {
 			logger.Error(statusErr, "failed to update Server status", "name", server.Name)
 		}
 		return ctrl.Result{RequeueAfter: RequeueIntervalMedium}, nil
@@ -138,27 +140,22 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("reconciling NetworkPolicy: %w", err)
 	}
 
-	// Re-fetch server to avoid conflict errors from concurrent reconciliations
-	if err := r.Get(ctx, req.NamespacedName, server); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Update status
-	replicas := int32(1)
-	if server.Spec.Replicas != nil {
-		replicas = *server.Spec.Replicas
-	}
 	ready := r.getReadyReplicas(ctx, server)
-	server.Status.Desired = replicas
-	server.Status.Ready = ready
+	if err := updateStatusWithRetry(ctx, r.Client, server, func() {
+		replicas := int32(1)
+		if server.Spec.Replicas != nil {
+			replicas = *server.Spec.Replicas
+		}
+		server.Status.Desired = replicas
+		server.Status.Ready = ready
 
-	if ready > 0 {
-		server.Status.Phase = openvoxv1alpha1.ServerPhaseRunning
-	} else {
-		server.Status.Phase = openvoxv1alpha1.ServerPhasePending
-	}
-
-	if err := r.Status().Update(ctx, server); err != nil {
+		if ready > 0 {
+			server.Status.Phase = openvoxv1alpha1.ServerPhaseRunning
+		} else {
+			server.Status.Phase = openvoxv1alpha1.ServerPhasePending
+		}
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
## Summary

- Add `updateStatusWithRetry()` helper to `helpers.go` that wraps `retry.RetryOnConflict` with a re-fetch + mutate + update cycle
- Wrap all 24 `Status().Update()` call sites across 12 controller files with the new helper
- Remove manual re-fetch blocks in `database_controller.go` and `server_controller.go` (now handled by the retry helper)
- Add 3 unit tests for the helper (success, conflict retry, non-conflict error)

Fixes #243

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/... -count=1` passes (all existing + 3 new tests)
- [x] `go vet ./...` passes
- [ ] E2E tests with concurrent reconciliations show reduced conflict error noise