### PR TITLE
ci: add concurrency group to E2E workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,9 @@
 name: E2E
 
+concurrency:
+  group: e2e
+  cancel-in-progress: false
+
 on:
   push:
     branches: [develop]


### PR DESCRIPTION
## Summary
- Add global `concurrency: group: e2e` to prevent parallel E2E runs against the shared cluster
- `cancel-in-progress: false` ensures running tests complete with cleanup before the next run starts