### PR TITLE
docs: fix terminology, use agent Ruby instead of system Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Kubernetes Operator that maps [OpenVox Server](https://github.com/OpenVoxProje
 - ⚡ **Scalable Servers** - Scale catalog compilation horizontally - multiple server pools with HPA
 - 🔄 **Multi-Version Deployments** - Run different server versions side by side - canary deployments, rolling upgrades
 - 🔒 **Rootless & OpenShift Ready** - Random UID compatible, no root, no ezbake, no privilege escalation
-- 🪶 **Minimal Image** - UBI9-based, no system Ruby, no ezbake packaging - smaller footprint, fewer updates
+- 🪶 **Minimal Image** - UBI9-based, no agent Ruby, no ezbake packaging - smaller footprint, fewer updates
 - 🧠 **Auto-tuned JVM** - Heap size calculated from memory limits (90%) - no manual `-Xmx` tuning needed
 - 📦 **OCI Image Volumes** - Package Puppet code as OCI images, deploy immutably with automatic rollout (K8s 1.35+)
 - 🌐 **Gateway API** - SNI-based TLSRoute support - share a single LoadBalancer across environments via TLS passthrough
@@ -132,13 +132,13 @@ All resources use the API group `openvox.voxpupuli.org/v1alpha1`.
 
 ## Differences to VM-based Installations
 
-Traditional Puppet/OpenVox Server installations on VMs use OS packages that install both a system Ruby (CRuby) and the server JAR with its embedded JRuby. The system Ruby is used by CLI tools like `puppet config set` and `puppetserver ca`. The server process requires root privileges.
+Traditional Puppet/OpenVox Server installations on VMs use OS packages that install both the agent Ruby (a dedicated CRuby shipped with the agent packages) and the server JAR with its embedded JRuby. The agent Ruby is used by CLI tools like `puppet config set` and `puppetserver ca`. The server process requires root privileges.
 
 This operator takes a **Kubernetes-native approach** that differs in several key areas:
 
 | | VM-based | openvox-operator |
 |---|---|---|
-| **Ruby** | System Ruby (CRuby) installed alongside JRuby for CLI tooling | **No system Ruby** - only JRuby embedded in the server JAR |
+| **Ruby** | Agent Ruby (CRuby) installed alongside JRuby for CLI tooling | **No agent Ruby** - only JRuby embedded in the server JAR |
 | **Configuration** | `puppet.conf` managed via `puppet config set`, Puppet modules, or config management | Declarative CRDs, operator renders ConfigMaps and Secrets |
 | **Privileges** | Requires root | Fully rootless, random UID compatible |
 | **CA Management** | `puppetserver ca` CLI with CRuby shebang | Custom JRuby wrapper that routes through `clojure.main` |
@@ -151,7 +151,7 @@ This operator takes a **Kubernetes-native approach** that differs in several key
 | **Traffic Routing** | DNS round-robin or hardware load balancer per environment | Gateway API TLSRoute with SNI-based routing - share a single LoadBalancer across environments |
 | **Multi-Version** | Separate VMs or manual package pinning | Multiple `Server` CRDs in the same `Pool` with different image tags |
 
-By eliminating system Ruby from the runtime image, the container has a smaller footprint and a reduced attack surface, avoiding the duplicate Ruby installation (CRuby + JRuby) that the OS packages carry.
+By eliminating the agent Ruby from the runtime image, the container has a smaller footprint and a reduced attack surface, avoiding the duplicate Ruby installation (CRuby + JRuby) that the OS packages carry.
 
 ## Quick Start
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -43,7 +43,7 @@ graph TD
 
 ## Why Separate CRDs for CA and Certificates?
 
-Traditional Puppet/OpenVox Server bundles CA management, certificate signing, and server runtime into a single process. This works on VMs where `puppetserver ca` (a CRuby CLI) manages everything locally. This operator deliberately ships **no system Ruby** - only JRuby embedded in the server JAR - to keep the image small and reduce the update surface. CA operations are handled through a custom JRuby wrapper that calls `clojure.main` instead.
+Traditional Puppet/OpenVox Server bundles CA management, certificate signing, and server runtime into a single process. This works on VMs where `puppetserver ca` (a CRuby CLI) manages everything locally. This operator deliberately ships **no agent Ruby** - only JRuby embedded in the server JAR - to keep the image small and reduce the update surface. CA operations are handled through a custom JRuby wrapper that calls `clojure.main` instead.
 
 By separating the CA lifecycle (`CertificateAuthority`) from certificate signing (`Certificate`) and from the server runtime (`Server`), each concern becomes independently manageable. Certificates can be issued before a server is running, revoked without restarting pods, and the CA can be initialized once while multiple servers share the same signed certificate for horizontal scaling.
 
@@ -193,7 +193,7 @@ See [Code Deployment](code-deployment.md) for the full guide.
 
 ## Why a New Approach?
 
-Traditional Puppet/OpenVox Server installations on VMs use OS packages that install both a system Ruby (CRuby) and the server JAR with its embedded JRuby. Existing container images carry this VM-centric approach into containers, leading to several problems in a Kubernetes context.
+Traditional Puppet/OpenVox Server installations on VMs use OS packages that install both the agent Ruby (a dedicated CRuby shipped with the agent packages) and the server JAR with its embedded JRuby. Existing container images carry this VM-centric approach into containers, leading to several problems in a Kubernetes context.
 
 ### ezbake Legacy
 
@@ -201,7 +201,7 @@ Upstream OpenVox Server uses ezbake for packaging. It generates init scripts tha
 
 ### Duplicate Ruby Installation
 
-The server needs JRuby (embedded in the JAR) for runtime. Existing containers additionally install system Ruby + the openvox gem just so entrypoint scripts can call `puppet config set/print`. This is unnecessary when configuration comes via ConfigMaps.
+The server needs JRuby (embedded in the JAR) for runtime. Existing containers additionally install the agent Ruby + the openvox gem just so entrypoint scripts can call `puppet config set/print`. This is unnecessary when configuration comes via ConfigMaps.
 
 ### Docker Logic in Kubernetes
 
@@ -215,7 +215,7 @@ Existing containers decide at startup whether to run as CA or server based on en
 
 | | VM-based / Docker | openvox-operator |
 |---|---|---|
-| **Ruby** | System Ruby (CRuby) alongside JRuby | No system Ruby - only JRuby in the server JAR |
+| **Ruby** | Agent Ruby (CRuby) alongside JRuby | No agent Ruby - only JRuby in the server JAR |
 | **Configuration** | `puppet config set`, entrypoint scripts, ENV vars | Declarative CRDs, operator renders ConfigMaps |
 | **Privileges** | Requires root | Fully rootless, random UID compatible |
 | **CA Management** | `puppetserver ca` CLI (CRuby) | Custom JRuby wrapper via `clojure.main` |
@@ -242,7 +242,7 @@ The operator uses a minimal container image:
 **Removed (compared to upstream images):**
 
 - All entrypoint.d scripts
-- System Ruby and openvox gem
+- Agent Ruby and openvox gem
 - Gemfile / bundle install / ruby-devel / gcc / make
 - ENV var to config translation logic
 - Docker-Compose support

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ A Kubernetes Operator that maps [OpenVox Server](https://github.com/OpenVoxProje
 - ⚡ **Scalable Servers** - Scale catalog compilation horizontally with multiple server pools and HPA
 - 🔄 **Multi-Version Deployments** - Run different server versions side by side for canary deployments and rolling upgrades
 - 🔒 **Rootless & OpenShift Ready** - Random UID compatible, no root, no ezbake, no privilege escalation
-- 🪶 **Minimal Image** - UBI9-based, no system Ruby, no ezbake packaging - smaller footprint, fewer updates
+- 🪶 **Minimal Image** - UBI9-based, no agent Ruby, no ezbake packaging - smaller footprint, fewer updates
 - 🧠 **Auto-tuned JVM** - Heap size calculated from memory limits (90%) - no manual `-Xmx` tuning needed
 - 📦 **OCI Image Volumes** - Package Puppet code as OCI images, deploy immutably with automatic rollout (K8s 1.35+)
 - 🌐 **Gateway API** - SNI-based TLSRoute support - share a single LoadBalancer across environments via TLS passthrough

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -1,5 +1,5 @@
 # Rootless OpenVox Server on UBI9 for Kubernetes/OpenShift
-# K8s-first: no entrypoint.d scripts, no System Ruby, no Docker ENV config.
+# K8s-first: no entrypoint.d scripts, no agent Ruby, no Docker ENV config.
 # The operator manages all configuration via ConfigMaps and Secrets.
 #
 # Build (from repo root):


### PR DESCRIPTION
## Summary
- Replace "system Ruby" with "agent Ruby" across all docs, README, and Containerfile
- The CRuby shipped with Puppet/OpenVox packages is the agent Ruby (bundled with the agent packages), not the system Ruby (which would imply the OS-provided interpreter)