### PR TITLE
feat(helm): expose missing CRD fields in openvox-stack chart

### DIFF
--- a/charts/openvox-stack/templates/certificateauthority.yaml
+++ b/charts/openvox-stack/templates/certificateauthority.yaml
@@ -4,8 +4,38 @@ metadata:
   name: {{ include "openvox-stack.caName" . }}
 spec:
   ttl: {{ .Values.ca.ttl }}
+  {{- if hasKey .Values.ca "allowSubjectAltNames" }}
+  allowSubjectAltNames: {{ .Values.ca.allowSubjectAltNames }}
+  {{- end }}
+  {{- if hasKey .Values.ca "allowAuthorizationExtensions" }}
+  allowAuthorizationExtensions: {{ .Values.ca.allowAuthorizationExtensions }}
+  {{- end }}
+  {{- if hasKey .Values.ca "enableInfraCRL" }}
+  enableInfraCRL: {{ .Values.ca.enableInfraCRL }}
+  {{- end }}
+  {{- if hasKey .Values.ca "allowAutoRenewal" }}
+  allowAutoRenewal: {{ .Values.ca.allowAutoRenewal }}
+  {{- end }}
+  {{- with .Values.ca.autoRenewalCertTTL }}
+  autoRenewalCertTTL: {{ . }}
+  {{- end }}
+  {{- with .Values.ca.crlRefreshInterval }}
+  crlRefreshInterval: {{ . }}
+  {{- end }}
   storage:
     size: {{ .Values.ca.storage.size }}
     {{- if .Values.ca.storage.storageClass }}
     storageClass: {{ .Values.ca.storage.storageClass }}
     {{- end }}
+  {{- with .Values.ca.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ca.intermediateCA }}
+  intermediateCA:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ca.external }}
+  external:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -11,6 +11,10 @@ spec:
     repository: {{ .Values.config.image.repository }}
     tag: {{ .Values.config.image.tag | quote }}
     pullPolicy: {{ .Values.config.image.pullPolicy }}
+    {{- with .Values.config.image.pullSecrets }}
+    pullSecrets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- if .Values.config.puppetdb.serverUrls }}
   puppetdb:
     serverUrls:
@@ -25,8 +29,21 @@ spec:
     {{- with .Values.config.puppet.environmentTimeout }}
     environmentTimeout: {{ . }}
     {{- end }}
+    {{- with .Values.config.puppet.environmentPath }}
+    environmentPath: {{ . }}
+    {{- end }}
+    {{- with .Values.config.puppet.hieraConfig }}
+    hieraConfig: {{ . }}
+    {{- end }}
     storeconfigs: {{ ternary true .Values.config.puppet.storeconfigs .Values.database.enabled }}
+    {{- with .Values.config.puppet.storeBackend }}
+    storeBackend: {{ . }}
+    {{- end }}
     reports: {{ .Values.config.puppet.reports }}
+    {{- with .Values.config.puppet.extraConfig }}
+    extraConfig:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- with .Values.config.code }}
   {{- if or .image .claimName }}
   code:
@@ -43,4 +60,16 @@ spec:
     claimName: {{ . }}
     {{- end }}
   {{- end }}
+  {{- end }}
+  {{- with .Values.config.puppetserver }}
+  puppetserver:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.config.logging }}
+  logging:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.config.metrics }}
+  metrics:
+    {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/openvox-stack/templates/database.yaml
+++ b/charts/openvox-stack/templates/database.yaml
@@ -48,4 +48,16 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.database.pdb }}
+  pdb:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.database.networkPolicy }}
+  networkPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.database.service }}
+  service:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/openvox-stack/templates/servers.yaml
+++ b/charts/openvox-stack/templates/servers.yaml
@@ -24,4 +24,38 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with $entry.javaArgs }}
+  javaArgs: {{ . | quote }}
+  {{- end }}
+  {{- with $entry.maxActiveInstances }}
+  maxActiveInstances: {{ . }}
+  {{- end }}
+  {{- with $entry.image }}
+  image:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $entry.code }}
+  code:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $entry.autoscaling }}
+  autoscaling:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $entry.pdb }}
+  pdb:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $entry.networkPolicy }}
+  networkPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $entry.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $entry.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/openvox-stack/tests/certificateauthority_test.yaml
+++ b/charts/openvox-stack/tests/certificateauthority_test.yaml
@@ -51,3 +51,128 @@ tests:
       - equal:
           path: metadata.name
           value: my-custom-ca
+
+  - it: should not render optional fields by default
+    asserts:
+      - isNull:
+          path: spec.allowSubjectAltNames
+      - isNull:
+          path: spec.allowAuthorizationExtensions
+      - isNull:
+          path: spec.enableInfraCRL
+      - isNull:
+          path: spec.allowAutoRenewal
+      - isNull:
+          path: spec.autoRenewalCertTTL
+      - isNull:
+          path: spec.crlRefreshInterval
+      - isNull:
+          path: spec.resources
+      - isNull:
+          path: spec.intermediateCA
+      - isNull:
+          path: spec.external
+
+  - it: should set allowSubjectAltNames to false
+    set:
+      ca:
+        allowSubjectAltNames: false
+    asserts:
+      - equal:
+          path: spec.allowSubjectAltNames
+          value: false
+
+  - it: should set allowSubjectAltNames to true
+    set:
+      ca:
+        allowSubjectAltNames: true
+    asserts:
+      - equal:
+          path: spec.allowSubjectAltNames
+          value: true
+
+  - it: should set allowAuthorizationExtensions to false
+    set:
+      ca:
+        allowAuthorizationExtensions: false
+    asserts:
+      - equal:
+          path: spec.allowAuthorizationExtensions
+          value: false
+
+  - it: should set enableInfraCRL to false
+    set:
+      ca:
+        enableInfraCRL: false
+    asserts:
+      - equal:
+          path: spec.enableInfraCRL
+          value: false
+
+  - it: should set allowAutoRenewal to false
+    set:
+      ca:
+        allowAutoRenewal: false
+    asserts:
+      - equal:
+          path: spec.allowAutoRenewal
+          value: false
+
+  - it: should propagate autoRenewalCertTTL
+    set:
+      ca:
+        autoRenewalCertTTL: 30d
+    asserts:
+      - equal:
+          path: spec.autoRenewalCertTTL
+          value: 30d
+
+  - it: should propagate crlRefreshInterval
+    set:
+      ca:
+        crlRefreshInterval: 10m
+    asserts:
+      - equal:
+          path: spec.crlRefreshInterval
+          value: 10m
+
+  - it: should propagate resources
+    set:
+      ca:
+        resources:
+          requests:
+            cpu: 200m
+            memory: 768Mi
+          limits:
+            memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.cpu
+          value: 200m
+      - equal:
+          path: spec.resources.limits.memory
+          value: 1Gi
+
+  - it: should propagate intermediateCA
+    set:
+      ca:
+        intermediateCA:
+          enabled: true
+          secretName: my-intermediate-ca
+    asserts:
+      - equal:
+          path: spec.intermediateCA.enabled
+          value: true
+      - equal:
+          path: spec.intermediateCA.secretName
+          value: my-intermediate-ca
+
+  - it: should propagate external
+    set:
+      ca:
+        external:
+          url: https://ca.example.com
+    asserts:
+      - equal:
+          path: spec.external.url
+          value: https://ca.example.com

--- a/charts/openvox-stack/tests/config_test.yaml
+++ b/charts/openvox-stack/tests/config_test.yaml
@@ -119,3 +119,122 @@ tests:
     asserts:
       - isNull:
           path: spec.code
+
+  - it: should not render optional fields by default
+    asserts:
+      - isNull:
+          path: spec.image.pullSecrets
+      - isNull:
+          path: spec.puppet.environmentPath
+      - isNull:
+          path: spec.puppet.hieraConfig
+      - isNull:
+          path: spec.puppet.storeBackend
+      - isNull:
+          path: spec.puppet.extraConfig
+      - isNull:
+          path: spec.puppetserver
+      - isNull:
+          path: spec.logging
+      - isNull:
+          path: spec.metrics
+
+  - it: should propagate image pullSecrets
+    set:
+      config:
+        image:
+          pullSecrets:
+            - name: my-secret
+    asserts:
+      - equal:
+          path: spec.image.pullSecrets[0].name
+          value: my-secret
+
+  - it: should propagate puppet environmentPath
+    set:
+      config:
+        puppet:
+          environmentPath: /custom/environments
+    asserts:
+      - equal:
+          path: spec.puppet.environmentPath
+          value: /custom/environments
+
+  - it: should propagate puppet hieraConfig
+    set:
+      config:
+        puppet:
+          hieraConfig: /etc/puppetlabs/puppet/hiera.yaml
+    asserts:
+      - equal:
+          path: spec.puppet.hieraConfig
+          value: /etc/puppetlabs/puppet/hiera.yaml
+
+  - it: should propagate puppet storeBackend
+    set:
+      config:
+        puppet:
+          storeBackend: puppetdb
+    asserts:
+      - equal:
+          path: spec.puppet.storeBackend
+          value: puppetdb
+
+  - it: should propagate puppet extraConfig
+    set:
+      config:
+        puppet:
+          extraConfig:
+            strict_variables: "true"
+            parser: future
+    asserts:
+      - equal:
+          path: spec.puppet.extraConfig.strict_variables
+          value: "true"
+      - equal:
+          path: spec.puppet.extraConfig.parser
+          value: future
+
+  - it: should propagate puppetserver settings
+    set:
+      config:
+        puppetserver:
+          maxRequestsPerInstance: 1000
+          compileMode: jit
+    asserts:
+      - equal:
+          path: spec.puppetserver.maxRequestsPerInstance
+          value: 1000
+      - equal:
+          path: spec.puppetserver.compileMode
+          value: jit
+
+  - it: should propagate logging settings
+    set:
+      config:
+        logging:
+          level: DEBUG
+          loggers:
+            mylogger: TRACE
+    asserts:
+      - equal:
+          path: spec.logging.level
+          value: DEBUG
+      - equal:
+          path: spec.logging.loggers.mylogger
+          value: TRACE
+
+  - it: should propagate metrics settings
+    set:
+      config:
+        metrics:
+          enabled: true
+          jmx:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.metrics.enabled
+          value: true
+      - equal:
+          path: spec.metrics.jmx.enabled
+          value: true

--- a/charts/openvox-stack/tests/database_test.yaml
+++ b/charts/openvox-stack/tests/database_test.yaml
@@ -162,6 +162,83 @@ tests:
           path: spec.resources.requests.memory
           value: 1Gi
 
+  - it: should not render optional fields by default
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+    documentIndex: 1
+    asserts:
+      - isNull:
+          path: spec.pdb
+      - isNull:
+          path: spec.networkPolicy
+      - isNull:
+          path: spec.service
+
+  - it: should propagate pdb
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+        pdb:
+          minAvailable: 1
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.pdb.minAvailable
+          value: 1
+
+  - it: should propagate networkPolicy
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+        networkPolicy:
+          enabled: true
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.networkPolicy.enabled
+          value: true
+
+  - it: should propagate service
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+        service:
+          type: ClusterIP
+          port: 8081
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.service.type
+          value: ClusterIP
+      - equal:
+          path: spec.service.port
+          value: 8081
+
   - it: should render dnsAltNames on Certificate when set
     set:
       database:

--- a/charts/openvox-stack/tests/servers_test.yaml
+++ b/charts/openvox-stack/tests/servers_test.yaml
@@ -85,3 +85,158 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
+
+  - it: should not render optional fields by default
+    documentIndex: 0
+    asserts:
+      - isNull:
+          path: spec.javaArgs
+      - isNull:
+          path: spec.maxActiveInstances
+      - isNull:
+          path: spec.image
+      - isNull:
+          path: spec.code
+      - isNull:
+          path: spec.autoscaling
+      - isNull:
+          path: spec.pdb
+      - isNull:
+          path: spec.networkPolicy
+      - isNull:
+          path: spec.topologySpreadConstraints
+      - isNull:
+          path: spec.affinity
+
+  - it: should propagate javaArgs
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          javaArgs: "-Xms512m -Xmx1024m"
+    asserts:
+      - equal:
+          path: spec.javaArgs
+          value: "-Xms512m -Xmx1024m"
+
+  - it: should propagate maxActiveInstances
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          maxActiveInstances: 4
+    asserts:
+      - equal:
+          path: spec.maxActiveInstances
+          value: 4
+
+  - it: should propagate image override
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          image:
+            repository: custom/image
+            tag: v1.0
+    asserts:
+      - equal:
+          path: spec.image.repository
+          value: custom/image
+      - equal:
+          path: spec.image.tag
+          value: v1.0
+
+  - it: should propagate code override
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          code:
+            image: ghcr.io/example/code:latest
+    asserts:
+      - equal:
+          path: spec.code.image
+          value: ghcr.io/example/code:latest
+
+  - it: should propagate autoscaling
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          autoscaling:
+            minReplicas: 2
+            maxReplicas: 5
+            targetCPUUtilizationPercentage: 80
+    asserts:
+      - equal:
+          path: spec.autoscaling.minReplicas
+          value: 2
+      - equal:
+          path: spec.autoscaling.maxReplicas
+          value: 5
+
+  - it: should propagate pdb
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          pdb:
+            minAvailable: 1
+    asserts:
+      - equal:
+          path: spec.pdb.minAvailable
+          value: 1
+
+  - it: should propagate networkPolicy
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          networkPolicy:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.networkPolicy.enabled
+          value: true
+
+  - it: should propagate topologySpreadConstraints
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+    asserts:
+      - equal:
+          path: spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: should propagate affinity
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -8,24 +8,72 @@ config:
     repository: ghcr.io/slauger/openvox-server
     tag: latest
     pullPolicy: Always
+    pullSecrets: []
+    # pullSecrets:
+    #   - name: my-registry-secret
   puppetdb:
     serverUrls: []
   puppet:
     environmentTimeout: ""
+    environmentPath: ""
+    hieraConfig: ""
     storeconfigs: false
+    storeBackend: ""
     reports: store
+    extraConfig: {}
+    # extraConfig:
+    #   strict_variables: "true"
+    #   parser: future
   code:
     image: ""
     imagePullPolicy: IfNotPresent
     imagePullSecret: ""
     claimName: ""
+  # puppetserver:
+  #   maxRequestsPerInstance: 0
+  #   borrowTimeout: 1200000
+  #   compileMode: "off"
+  #   clientAuth: want
+  #   httpClient:
+  #     connectTimeoutMs: 120000
+  #     idleTimeoutMs: 120000
+  #   authorizationRules: []
+  # logging:
+  #   level: INFO
+  #   loggers:
+  #     puppetlabs.puppetserver: DEBUG
+  # metrics:
+  #   enabled: true
+  #   jmx:
+  #     enabled: true
+  #   graphite:
+  #     enabled: true
+  #     host: graphite.example.com
+  #     port: 2003
 
 ca:
   name: ""             # default: {fullname}-ca
   ttl: 5y
+  # allowSubjectAltNames: true
+  # allowAuthorizationExtensions: true
+  # enableInfraCRL: true
+  # allowAutoRenewal: true
+  # autoRenewalCertTTL: 90d
+  # crlRefreshInterval: 5m
   storage:
     size: 1Gi
     storageClass: ""
+  # resources:
+  #   requests:
+  #     cpu: 200m
+  #     memory: 768Mi
+  #   limits:
+  #     memory: 1Gi
+  # intermediateCA:
+  #   enabled: true
+  #   secretName: my-intermediate-ca
+  # external:
+  #   url: https://ca.example.com
 
 reportProcessors: []
 # reportProcessors:
@@ -85,6 +133,13 @@ database:
       memory: 512Mi
     limits:
       memory: 1Gi
+  # pdb:
+  #   minAvailable: 1
+  # networkPolicy:
+  #   enabled: true
+  # service:
+  #   type: ClusterIP
+  #   port: 8081
 
 servers:
   - name: ca
@@ -115,6 +170,31 @@ servers:
         memory: 1Gi
       limits:
         memory: 2Gi
+    # javaArgs: "-Xms512m -Xmx1024m"
+    # maxActiveInstances: 2
+    # image:
+    #   repository: ghcr.io/slauger/openvox-server
+    #   tag: custom
+    # code:
+    #   image: ghcr.io/slauger/openvox-code:latest
+    # autoscaling:
+    #   minReplicas: 2
+    #   maxReplicas: 5
+    #   targetCPUUtilizationPercentage: 80
+    # pdb:
+    #   minAvailable: 1
+    # networkPolicy:
+    #   enabled: true
+    # topologySpreadConstraints:
+    #   - maxSkew: 1
+    #     topologyKey: kubernetes.io/hostname
+    #     whenUnsatisfiable: DoNotSchedule
+    # affinity:
+    #   podAntiAffinity:
+    #     preferredDuringSchedulingIgnoredDuringExecution:
+    #       - weight: 100
+    #         podAffinityTerm:
+    #           topologyKey: kubernetes.io/hostname
 
 gateway:
   name: ""              # shared Gateway resource name


### PR DESCRIPTION
## Summary

Closes #261

- Expose all missing CRD fields in the `openvox-stack` Helm chart templates so users can configure them via `values.yaml` instead of creating CRs manually
- **servers.yaml**: 9 new fields — `javaArgs`, `maxActiveInstances`, `image`, `code`, `autoscaling`, `pdb`, `networkPolicy`, `topologySpreadConstraints`, `affinity`
- **config.yaml**: 8 new fields — `image.pullSecrets`, `puppet.environmentPath`, `puppet.hieraConfig`, `puppet.storeBackend`, `puppet.extraConfig`, `puppetserver`, `logging`, `metrics`
- **certificateauthority.yaml**: 9 new fields — `allowSubjectAltNames`, `allowAuthorizationExtensions`, `enableInfraCRL`, `allowAutoRenewal` (using `hasKey` for booleans defaulting to `true`), `autoRenewalCertTTL`, `crlRefreshInterval`, `resources`, `intermediateCA`, `external`
- **database.yaml**: 3 new fields — `pdb`, `networkPolicy`, `service`
- All fields are optional and only rendered when set (no change to default behavior)
- Adds 40 new helm unit tests (107 total, all passing)

## Test plan

- [x] `helm lint charts/openvox-stack` passes
- [x] `helm unittest charts/openvox-stack` — 107 tests passing
- [x] `helm template test charts/openvox-stack` — default rendering unchanged
- [x] Spot-checked rendering with optional fields set (booleans, objects, arrays)
- [ ] CI passes