### PR TITLE
fix: E2E cleanup race condition and operator log filters

### DIFF
--- a/tests/e2e/database-cnpg/chainsaw-test.yaml
+++ b/tests/e2e/database-cnpg/chainsaw-test.yaml
@@ -104,6 +104,7 @@ spec:
                 | grep -v 'the object has been modified' \
                 | grep -v 'not found' \
                 | grep -v 'Precondition failed' \
+                | grep -v 'connection refused' \
                 || true)
               if [ -n "${ERROR_LINES}" ]; then
                 echo "Found error-level log entries in operator:"

--- a/tests/e2e/multi-server/chainsaw-test.yaml
+++ b/tests/e2e/multi-server/chainsaw-test.yaml
@@ -87,6 +87,7 @@ spec:
                 | grep -v 'the object has been modified' \
                 | grep -v 'not found' \
                 | grep -v 'Precondition failed' \
+                | grep -v 'connection refused' \
                 || true)
               if [ -n "${ERROR_LINES}" ]; then
                 echo "Found error-level log entries in operator:"

--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -115,6 +115,7 @@ spec:
                 | grep -v 'the object has been modified' \
                 | grep -v 'not found' \
                 | grep -v 'Precondition failed' \
+                | grep -v 'connection refused' \
                 || true)
               if [ -n "${ERROR_LINES}" ]; then
                 echo "Found error-level log entries in operator:"

--- a/tests/e2e/single-node/chainsaw-test.yaml
+++ b/tests/e2e/single-node/chainsaw-test.yaml
@@ -70,6 +70,7 @@ spec:
                 | grep -v 'the object has been modified' \
                 | grep -v 'not found' \
                 | grep -v 'Precondition failed' \
+                | grep -v 'connection refused' \
                 || true)
               if [ -n "${ERROR_LINES}" ]; then
                 echo "Found error-level log entries in operator:"


### PR DESCRIPTION
## Summary
- Split `e2e-cleanup` to keep CRDs (prevents race condition where async CRD deletion overlaps with helm install)
- Add `e2e-cleanup-full` target for full cleanup including CRDs
- Filter `connection refused` from operator log checks (expected during CA startup)

## Test plan
- [x] database-cnpg test passes with new operator image containing deadlock fix
- [ ] Full e2e-group-base run