### PR TITLE
fix: drop full curl install from mock image

### DIFF
--- a/images/openvox-mock/Containerfile
+++ b/images/openvox-mock/Containerfile
@@ -20,8 +20,6 @@ LABEL org.opencontainers.image.title="OpenVox Mock" \
       org.opencontainers.image.source="https://github.com/slauger/openvox-operator" \
       org.opencontainers.image.licenses="Apache-2.0"
 
-RUN microdnf install -y curl && microdnf clean all
-
 COPY --from=builder /openvox-mock /openvox-mock
 
 USER 1001:0


### PR DESCRIPTION
The UBI9-minimal base image already ships `curl-minimal` which conflicts with the full `curl` package. Since the E2E tests only need basic HTTP requests (`curl -sf`), `curl-minimal` is sufficient.

Fixes the build failure: https://github.com/slauger/openvox-operator/actions/runs/24005925186