### PR TITLE
ci: add path filters to skip docs-only workflow runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CHANGELOG*'
+      - '.github/*.md'
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CHANGELOG*'
+      - '.github/*.md'
 
 jobs:
   unicode:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,6 +7,12 @@ concurrency:
 on:
   push:
     branches: [develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CHANGELOG*'
+      - '.github/*.md'
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` filters to E2E and CI workflows
- Skips runs for docs-only commits (markdown, LICENSE, CHANGELOG)
- `workflow_dispatch` and `schedule` triggers are unaffected

Closes #258