### PR TITLE
feat: emit WaitingForConfig event when CA has no matching Config

### DIFF
--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -31,10 +31,11 @@ type CertificateAuthorityReconciler struct {
 
 // Event reasons for CertificateAuthority.
 const (
-	EventReasonCAInitialized    = "CAInitialized"
-	EventReasonCAExternal       = "CAExternal"
-	EventReasonCRLRefreshed     = "CRLRefreshed"
-	EventReasonCRLRefreshFailed = "CRLRefreshFailed"
+	EventReasonCAInitialized      = "CAInitialized"
+	EventReasonCAExternal         = "CAExternal"
+	EventReasonCAWaitingForConfig = "WaitingForConfig"
+	EventReasonCRLRefreshed       = "CRLRefreshed"
+	EventReasonCRLRefreshFailed   = "CRLRefreshFailed"
 )
 
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=certificateauthorities,verbs=get;list;watch;create;update;patch;delete
@@ -77,6 +78,8 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 	cfg := r.findConfigForCA(ctx, ca)
 	if cfg == nil {
 		logger.Info("waiting for a Config with authorityRef pointing to this CA", "ca", ca.Name)
+		r.Recorder.Eventf(ca, nil, corev1.EventTypeNormal, EventReasonCAWaitingForConfig, "Reconcile",
+			"Waiting for a Config with authorityRef: %s", ca.Name)
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
 

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -10,6 +10,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -44,6 +45,34 @@ func TestCAReconcile_NoConfig(t *testing.T) {
 	}
 	if res.RequeueAfter != 5*time.Second {
 		t.Errorf("expected requeue after 5s, got %v", res.RequeueAfter)
+	}
+}
+
+func TestCAReconcile_NoConfig_EmitsEvent(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.Phase = ""
+	c := setupTestClient(ca)
+	rec := events.NewFakeRecorder(10)
+	r := &CertificateAuthorityReconciler{
+		Client:   c,
+		Scheme:   testScheme(),
+		Recorder: rec,
+	}
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-ca")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case evt := <-rec.Events:
+		if !strings.Contains(evt, EventReasonCAWaitingForConfig) {
+			t.Errorf("expected event reason %q, got %q", EventReasonCAWaitingForConfig, evt)
+		}
+		if !strings.Contains(evt, "Waiting for a Config with authorityRef") {
+			t.Errorf("expected event message about waiting for Config, got %q", evt)
+		}
+	default:
+		t.Error("expected WaitingForConfig event, but none was emitted")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Emits a `WaitingForConfig` event when a `CertificateAuthority` reconciles but no `Config` with a matching `authorityRef` exists yet
- Users can now see via `kubectl describe certificateauthority` why their CA is stuck in `Pending`
- Adds test asserting the event is emitted

Closes #256

## Test plan
- [x] `make test` passes (controller tests)
- [ ] Deploy a CA without a Config, verify `WaitingForConfig` event appears in `kubectl describe`