### PR TITLE
refactor: deduplicate CA HTTP client helpers + docs for external CA

### DIFF
--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -82,7 +82,7 @@ spec:
 |---|---|---|
 | `phase` | string | Current lifecycle phase |
 | `caSecretName` | string | Name of the Secret containing `ca_crt.pem` (public CA certificate) |
-| `serviceName` | string | Name of the internal ClusterIP Service for operator communication |
+| `serviceName` | string | Name of the internal ClusterIP Service for operator communication. Empty when `spec.external` is set. |
 | `signingSecretName` | string | Name of the TLS Secret used for mTLS authentication when signing certificates via the CA HTTP API |
 | `notAfter` | time | Expiry time of the CA certificate |
 | `conditions` | []Condition | `CAReady` |

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -32,12 +32,12 @@ import (
 // caHTTPClientForCA returns an HTTP client configured for the CA.
 // For external CAs, it builds an mTLS client from the referenced Secrets.
 // For internal CAs, it uses the CA public certificate.
-func (r *CertificateReconciler) caHTTPClientForCA(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, namespace string) (*http.Client, error) {
+func caHTTPClientForCA(ctx context.Context, reader client.Reader, ca *openvoxv1alpha1.CertificateAuthority, namespace string) (*http.Client, error) {
 	if ca.Spec.External != nil {
-		return buildExternalCAHTTPClient(ctx, r.Client, ca.Spec.External, namespace)
+		return buildExternalCAHTTPClient(ctx, reader, ca.Spec.External, namespace)
 	}
 
-	caCertPEM, err := r.getCAPublicCert(ctx, ca, namespace)
+	caCertPEM, err := getCAPublicCert(ctx, reader, ca, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("loading CA certificate: %w", err)
 	}
@@ -127,19 +127,6 @@ func caHTTPClient(caCertPEM []byte) (*http.Client, error) {
 	}, nil
 }
 
-// getCAPublicCert reads the CA public certificate from the CA Secret.
-func (r *CertificateReconciler) getCAPublicCert(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, namespace string) ([]byte, error) {
-	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: caSecretName, Namespace: namespace}, secret); err != nil {
-		return nil, fmt.Errorf("getting CA Secret %s: %w", caSecretName, err)
-	}
-	certPEM := secret.Data["ca_crt.pem"]
-	if len(certPEM) == 0 {
-		return nil, fmt.Errorf("CA Secret %s has no ca_crt.pem data", caSecretName)
-	}
-	return certPEM, nil
-}
 
 // submitCSR generates an RSA key (or reuses an existing one from a pending Secret),
 // submits the CSR to the Puppet CA, and stores the private key in a pending Secret.
@@ -213,7 +200,7 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 	}
 	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 
-	httpClient, err := r.caHTTPClientForCA(ctx, ca, namespace)
+	httpClient, err := caHTTPClientForCA(ctx, r.Client, ca, namespace)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, fmt.Errorf("creating CA HTTP client: %w", err)
 	}
@@ -255,7 +242,7 @@ func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openv
 		certname = "puppet"
 	}
 
-	httpClient, err := r.caHTTPClientForCA(ctx, ca, namespace)
+	httpClient, err := caHTTPClientForCA(ctx, r.Client, ca, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("creating CA HTTP client: %w", err)
 	}
@@ -405,7 +392,7 @@ func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvox
 	}
 
 	// Load CA public cert for TLS server verification
-	caCertPEM, err := r.getCAPublicCert(ctx, ca, namespace)
+	caCertPEM, err := getCAPublicCert(ctx, r.Client, ca, namespace)
 	if err != nil {
 		return fmt.Errorf("loading CA certificate: %w", err)
 	}

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -244,6 +244,8 @@ func (r *CertificateAuthorityReconciler) reconcileExternalCA(ctx context.Context
 	notAfter := r.extractCANotAfter(ctx, caSecretName, ca.Namespace)
 	extMsg := fmt.Sprintf("External CA configured at %s", ext.URL)
 
+	// Note: ServiceName is intentionally not set for external CAs —
+	// no internal ClusterIP Service is created.
 	if err := updateStatusWithRetry(ctx, r.Client, ca, func() {
 		ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseExternal
 		ca.Status.CASecretName = caSecretName

--- a/internal/controller/certificateauthority_crl.go
+++ b/internal/controller/certificateauthority_crl.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -52,23 +51,10 @@ func (r *CertificateAuthorityReconciler) reconcileCRLRefresh(ctx context.Context
 	return ctrl.Result{RequeueAfter: interval}, nil
 }
 
-// getCAPublicCert reads the CA public certificate from the CA Secret.
-func (r *CertificateAuthorityReconciler) getCAPublicCert(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, namespace string) ([]byte, error) {
-	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: caSecretName, Namespace: namespace}, secret); err != nil {
-		return nil, fmt.Errorf("getting CA Secret %s: %w", caSecretName, err)
-	}
-	certPEM := secret.Data["ca_crt.pem"]
-	if len(certPEM) == 0 {
-		return nil, fmt.Errorf("CA Secret %s has no ca_crt.pem data", caSecretName)
-	}
-	return certPEM, nil
-}
 
 // fetchCRL retrieves the CRL from the CA HTTP API.
 func (r *CertificateAuthorityReconciler) fetchCRL(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) ([]byte, error) {
-	httpClient, err := r.caHTTPClientForCA(ctx, ca, namespace)
+	httpClient, err := caHTTPClientForCA(ctx, r.Client, ca, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("creating CA HTTP client: %w", err)
 	}
@@ -98,20 +84,6 @@ func (r *CertificateAuthorityReconciler) fetchCRL(ctx context.Context, ca *openv
 	return body, nil
 }
 
-// caHTTPClientForCA returns an HTTP client configured for the CA.
-// For external CAs, it builds an mTLS client from the referenced Secrets.
-// For internal CAs, it uses the CA public certificate.
-func (r *CertificateAuthorityReconciler) caHTTPClientForCA(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, namespace string) (*http.Client, error) {
-	if ca.Spec.External != nil {
-		return buildExternalCAHTTPClient(ctx, r.Client, ca.Spec.External, namespace)
-	}
-
-	caCertPEM, err := r.getCAPublicCert(ctx, ca, namespace)
-	if err != nil {
-		return nil, fmt.Errorf("loading CA certificate: %w", err)
-	}
-	return caHTTPClient(caCertPEM)
-}
 
 // updateCRLSecret creates or updates the CRL secret with fresh CRL data.
 func (r *CertificateAuthorityReconciler) updateCRLSecret(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, name string, crlPEM []byte) error {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -149,6 +149,20 @@ func createOrUpdateSecret(ctx context.Context, c client.Client, scheme *runtime.
 	return c.Update(ctx, secret)
 }
 
+// getCAPublicCert reads the CA public certificate from the CA Secret.
+func getCAPublicCert(ctx context.Context, reader client.Reader, ca *openvoxv1alpha1.CertificateAuthority, namespace string) ([]byte, error) {
+	caSecretName := fmt.Sprintf("%s-ca", ca.Name)
+	secret := &corev1.Secret{}
+	if err := reader.Get(ctx, types.NamespacedName{Name: caSecretName, Namespace: namespace}, secret); err != nil {
+		return nil, fmt.Errorf("getting CA Secret %s: %w", caSecretName, err)
+	}
+	certPEM := secret.Data["ca_crt.pem"]
+	if len(certPEM) == 0 {
+		return nil, fmt.Errorf("CA Secret %s has no ca_crt.pem data", caSecretName)
+	}
+	return certPEM, nil
+}
+
 // caInternalServiceName returns the name of the internal ClusterIP Service
 // created by the CA controller for operator communication (CSR signing, CRL refresh).
 func caInternalServiceName(caName string) string {


### PR DESCRIPTION
## Summary
- Extract duplicated `caHTTPClientForCA` and `getCAPublicCert` receiver methods into free functions with `client.Reader` parameter (Closes #255)
- Add code comment and update docs clarifying that `status.serviceName` is intentionally empty for external CAs (Closes #257)

## Test plan
- [x] `go build ./...` passes
- [ ] Existing unit tests pass (CI)