### PR TITLE
fix: replace Unicode em dash with ASCII in code comment

### DIFF
--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -244,7 +244,7 @@ func (r *CertificateAuthorityReconciler) reconcileExternalCA(ctx context.Context
 	notAfter := r.extractCANotAfter(ctx, caSecretName, ca.Namespace)
 	extMsg := fmt.Sprintf("External CA configured at %s", ext.URL)
 
-	// Note: ServiceName is intentionally not set for external CAs —
+	// Note: ServiceName is intentionally not set for external CAs -
 	// no internal ClusterIP Service is created.
 	if err := updateStatusWithRetry(ctx, r.Client, ca, func() {
 		ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseExternal


### PR DESCRIPTION
## Summary
- Replace Unicode em dash (U+2014) with ASCII hyphen in code comment to pass Unicode lint check