### PR TITLE
fix: assert ReportProcessors are Active before Server check in agent-report E2E

### DIFF
--- a/tests/e2e/agent-report/chainsaw-test.yaml
+++ b/tests/e2e/agent-report/chainsaw-test.yaml
@@ -77,6 +77,25 @@ spec:
       catch:
         - events: {}
 
+    - name: Assert ReportProcessors are Active
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: ReportProcessor
+              metadata:
+                name: e2e-report-webhook
+              status:
+                phase: Active
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: ReportProcessor
+              metadata:
+                name: e2e-report-puppetdb
+              status:
+                phase: Active
+
     - name: Assert Server is Running
       try:
         - assert:


### PR DESCRIPTION
## Summary
- Fixes intermittent `agent-report` E2E failure where `Reports: null`
- Root cause: race condition where Config reconciles before ReportProcessors are in the informer cache, so the `report-webhook` Secret is not created when the Server pod starts
- Adds assertion step that waits for both ReportProcessors (`e2e-report-webhook`, `e2e-report-puppetdb`) to reach `Active` phase before checking Server readiness

## Test plan
- [ ] Re-run `make e2e-group-base` and verify `agent-report` passes reliably