### PR TITLE
refactor: split E2E workflow into image builds and manual test trigger

### DIFF
--- a/.github/workflows/_e2e-run.yaml
+++ b/.github/workflows/_e2e-run.yaml
@@ -1,0 +1,59 @@
+name: E2E Run
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: 'Image tag to use for E2E tests'
+        required: true
+        type: string
+      group:
+        description: 'Test group to run (base, enc, gateway, webhooks-byo, webhooks-cm)'
+        required: true
+        type: string
+
+concurrency:
+  group: e2e
+  cancel-in-progress: false
+
+jobs:
+  e2e-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl version --short 2>/dev/null || kubectl version
+
+      - name: Cleanup previous run
+        run: make e2e-cleanup
+
+      - name: Verify cluster connectivity
+        run: kubectl get nodes
+
+  e2e-test:
+    needs: [e2e-setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl version --short 2>/dev/null || kubectl version
+
+      - name: Run ${{ inputs.group }} test group
+        run: make e2e-group-${{ inputs.group }} IMAGE_TAG=${{ inputs.image_tag }}

--- a/.github/workflows/e2e-images.yaml
+++ b/.github/workflows/e2e-images.yaml
@@ -1,0 +1,115 @@
+name: E2E Images
+
+on:
+  push:
+    branches: [develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CHANGELOG*'
+      - '.github/*.md'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Custom image tag (default: branch name)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  IMAGE_TAG: ${{ inputs.image_tag || github.ref_name }}
+
+jobs:
+  openvox-operator:
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      image_name: openvox-operator
+      dockerfile: images/openvox-operator/Containerfile
+      context: '.'
+      push: true
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
+
+  openvox-server:
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      image_name: openvox-server
+      dockerfile: images/openvox-server/Containerfile
+      context: '.'
+      push: true
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
+
+  openvox-e2e-code:
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      image_name: openvox-e2e-code
+      dockerfile: images/openvox-e2e-code/Containerfile
+      context: '.'
+      push: true
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
+      sign: false
+
+  openvox-agent:
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      image_name: openvox-agent
+      dockerfile: images/openvox-agent/Containerfile
+      context: 'images/openvox-agent'
+      push: true
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
+      sign: false
+
+  openvox-db:
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      image_name: openvox-db
+      dockerfile: images/openvox-db/Containerfile
+      context: '.'
+      push: true
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
+
+  openvox-mock:
+    uses: ./.github/workflows/_container-build.yaml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      image_name: openvox-mock
+      dockerfile: images/openvox-mock/Containerfile
+      context: '.'
+      push: true
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
+      sign: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,25 +1,13 @@
 name: E2E
 
-concurrency:
-  group: e2e
-  cancel-in-progress: false
-
 on:
-  push:
-    branches: [develop]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - 'CHANGELOG*'
-      - '.github/*.md'
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Custom image tag (default: short git SHA)'
+        description: 'Image tag for E2E images'
         required: false
         type: string
-        default: ''
+        default: 'develop'
       group:
         description: 'Test group to run'
         required: false
@@ -32,256 +20,48 @@ on:
           - gateway
           - webhooks-byo
           - webhooks-cm
-      cleanup_images:
-        description: 'Delete E2E images after test run'
-        required: false
-        type: boolean
-        default: true
-
-permissions:
-  contents: read
-  packages: write
-  id-token: write
-  attestations: write
-
-env:
-  IMAGE_TAG: ${{ inputs.image_tag || github.ref_name }}
 
 jobs:
-  # Phase 1: Build (parallel)
-
-  openvox-operator:
-    uses: ./.github/workflows/_container-build.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    with:
-      image_name: openvox-operator
-      dockerfile: images/openvox-operator/Containerfile
-      context: '.'
-      push: true
-      image_tag: ${{ inputs.image_tag || github.ref_name }}
-
-  openvox-server:
-    uses: ./.github/workflows/_container-build.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    with:
-      image_name: openvox-server
-      dockerfile: images/openvox-server/Containerfile
-      context: '.'
-      push: true
-      image_tag: ${{ inputs.image_tag || github.ref_name }}
-
-  openvox-e2e-code:
-    uses: ./.github/workflows/_container-build.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    with:
-      image_name: openvox-e2e-code
-      dockerfile: images/openvox-e2e-code/Containerfile
-      context: '.'
-      push: true
-      image_tag: ${{ inputs.image_tag || github.ref_name }}
-      sign: false
-
-  openvox-agent:
-    uses: ./.github/workflows/_container-build.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    with:
-      image_name: openvox-agent
-      dockerfile: images/openvox-agent/Containerfile
-      context: 'images/openvox-agent'
-      push: true
-      image_tag: ${{ inputs.image_tag || github.ref_name }}
-      sign: false
-
-  openvox-db:
-    uses: ./.github/workflows/_container-build.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    with:
-      image_name: openvox-db
-      dockerfile: images/openvox-db/Containerfile
-      context: '.'
-      push: true
-      image_tag: ${{ inputs.image_tag || github.ref_name }}
-
-  openvox-mock:
-    uses: ./.github/workflows/_container-build.yaml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    with:
-      image_name: openvox-mock
-      dockerfile: images/openvox-mock/Containerfile
-      context: '.'
-      push: true
-      image_tag: ${{ inputs.image_tag || github.ref_name }}
-      sign: false
-
-  # Phase 1b: Cluster setup (parallel to builds)
-
-  e2e-setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl version --short 2>/dev/null || kubectl version
-
-      - name: Cleanup previous run
-        run: make e2e-cleanup
-
-      - name: Verify cluster connectivity
-        run: kubectl get nodes
-
-  # Phase 2: Test (sequential)
-
   e2e-base:
-    if: inputs.group == 'all' || inputs.group == 'base' || inputs.group == ''
-    needs: [e2e-setup, openvox-operator, openvox-server, openvox-e2e-code, openvox-agent, openvox-db, openvox-mock]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl version --short 2>/dev/null || kubectl version
-
-      - name: Run base test group
-        run: make e2e-group-base IMAGE_TAG=${{ env.IMAGE_TAG }}
+    if: inputs.group == 'all' || inputs.group == 'base'
+    uses: ./.github/workflows/_e2e-run.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      group: base
+    secrets: inherit
 
   e2e-enc:
-    if: inputs.group == 'all' || inputs.group == 'enc' || inputs.group == ''
+    if: inputs.group == 'all' || inputs.group == 'enc'
     needs: [e2e-base]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl version --short 2>/dev/null || kubectl version
-
-      - name: Run enc test group
-        run: make e2e-group-enc IMAGE_TAG=${{ env.IMAGE_TAG }}
+    uses: ./.github/workflows/_e2e-run.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      group: enc
+    secrets: inherit
 
   e2e-gateway:
-    if: inputs.group == 'all' || inputs.group == 'gateway' || inputs.group == ''
+    if: inputs.group == 'all' || inputs.group == 'gateway'
     needs: [e2e-enc]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl version --short 2>/dev/null || kubectl version
-
-      - name: Run gateway test group
-        run: make e2e-group-gateway IMAGE_TAG=${{ env.IMAGE_TAG }}
+    uses: ./.github/workflows/_e2e-run.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      group: gateway
+    secrets: inherit
 
   e2e-webhooks-byo:
-    if: inputs.group == 'all' || inputs.group == 'webhooks-byo' || inputs.group == ''
+    if: inputs.group == 'all' || inputs.group == 'webhooks-byo'
     needs: [e2e-gateway]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl version --short 2>/dev/null || kubectl version
-
-      - name: Run webhooks-byo test group
-        run: make e2e-group-webhooks-byo IMAGE_TAG=${{ env.IMAGE_TAG }}
+    uses: ./.github/workflows/_e2e-run.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      group: webhooks-byo
+    secrets: inherit
 
   e2e-webhooks-cm:
-    if: inputs.group == 'all' || inputs.group == 'webhooks-cm' || inputs.group == ''
+    if: inputs.group == 'all' || inputs.group == 'webhooks-cm'
     needs: [e2e-webhooks-byo]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl version --short 2>/dev/null || kubectl version
-
-      - name: Run webhooks-cm test group
-        run: make e2e-group-webhooks-cm IMAGE_TAG=${{ env.IMAGE_TAG }}
-
-  # Phase 3: Cleanup E2E images
-
-  cleanup:
-    if: always() && inputs.cleanup_images != false
-    needs: [e2e-base, e2e-enc, e2e-gateway, e2e-webhooks-byo, e2e-webhooks-cm]
-    uses: ./.github/workflows/_cleanup-images.yaml
-    permissions:
-      packages: write
+    uses: ./.github/workflows/_e2e-run.yaml
     with:
-      image_tag: ${{ inputs.image_tag || github.ref_name }}
+      image_tag: ${{ inputs.image_tag }}
+      group: webhooks-cm
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -59,17 +59,17 @@ docker-push: ## Push container image.
 
 ##@ Local Development
 
-LOCAL_TAG ?= $(shell git describe --always)
+IMAGE_TAG ?= $(shell git describe --always)
 
 .PHONY: local-build
 local-build: ## Build all images for local development (Docker Desktop K8s).
-	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-operator:$(LOCAL_TAG) -f images/openvox-operator/Containerfile .
-	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-server:$(LOCAL_TAG) -f images/openvox-server/Containerfile .
+	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-operator:$(IMAGE_TAG) -f images/openvox-operator/Containerfile .
+	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-server:$(IMAGE_TAG) -f images/openvox-server/Containerfile .
 	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-e2e-code:latest -f images/openvox-e2e-code/Containerfile .
 	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-agent:latest -f images/openvox-agent/Containerfile images/openvox-agent/
 	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-mock:latest -f images/openvox-mock/Containerfile .
-	@echo "Built ghcr.io/slauger/openvox-operator:$(LOCAL_TAG)"
-	@echo "Built ghcr.io/slauger/openvox-server:$(LOCAL_TAG)"
+	@echo "Built ghcr.io/slauger/openvox-operator:$(IMAGE_TAG)"
+	@echo "Built ghcr.io/slauger/openvox-server:$(IMAGE_TAG)"
 	@echo "Built ghcr.io/slauger/openvox-e2e-code:latest"
 	@echo "Built ghcr.io/slauger/openvox-agent:latest"
 	@echo "Built ghcr.io/slauger/openvox-mock:latest"
@@ -77,16 +77,16 @@ local-build: ## Build all images for local development (Docker Desktop K8s).
 .PHONY: local-deploy
 local-deploy: local-build local-install ## Build images and deploy operator via Helm.
 	@echo ""
-	@echo "Operator deployed with openvox-operator:$(LOCAL_TAG)"
+	@echo "Operator deployed with openvox-operator:$(IMAGE_TAG)"
 
 STACK_NAMESPACE ?= openvox
 STACK_VALUES ?= charts/openvox-stack/values.yaml
 
 ##@ Deployment
 
-# When IMAGE_TAG is set (e.g. make install IMAGE_TAG=487ea36), configure
-# helm to pull that specific image from the registry.
-ifdef IMAGE_TAG
+# When IMAGE_TAG is explicitly passed (e.g. make install IMAGE_TAG=487ea36),
+# configure helm to pull that specific image from the registry.
+ifeq ($(origin IMAGE_TAG),command line)
 HELM_SET ?= --set image.repository=$(IMAGE_REGISTRY)/openvox-operator --set image.tag=$(IMAGE_TAG) --set image.pullPolicy=Always
 STACK_HELM_SET ?= --set config.image.repository=$(IMAGE_REGISTRY)/openvox-server --set config.image.tag=$(IMAGE_TAG) --set config.image.pullPolicy=Always
 endif
@@ -97,7 +97,7 @@ install: manifests ## Install operator via Helm (supports IMAGE_TAG=<tag>).
 		--namespace $(NAMESPACE) --create-namespace $(HELM_SET)
 
 .PHONY: local-install
-local-install: HELM_SET := --set image.tag=$(LOCAL_TAG) --set image.pullPolicy=Never
+local-install: HELM_SET := --set image.tag=$(IMAGE_TAG) --set image.pullPolicy=Never
 local-install: install ## Install operator via Helm with local images (no build).
 
 .PHONY: stack
@@ -107,7 +107,7 @@ stack: ## Deploy openvox-stack via Helm (supports IMAGE_TAG=<tag>).
 		--values $(STACK_VALUES) $(STACK_HELM_SET)
 
 .PHONY: local-stack
-local-stack: STACK_HELM_SET := --set config.image.tag=$(LOCAL_TAG) --set config.image.pullPolicy=Never
+local-stack: STACK_HELM_SET := --set config.image.tag=$(IMAGE_TAG) --set config.image.pullPolicy=Never
 local-stack: stack ## Deploy openvox-stack via Helm with local images.
 
 .PHONY: unstack
@@ -174,8 +174,6 @@ ci: lint vet test check-manifests vulncheck helm-lint helm-unittest ## Run all C
 	@echo "All CI checks passed."
 
 ##@ E2E
-
-IMAGE_TAG ?= $(LOCAL_TAG)
 
 .PHONY: chainsaw
 chainsaw: $(CHAINSAW) ## Download chainsaw binary.
@@ -250,6 +248,8 @@ e2e-operator-base: e2e-cleanup ## Install operator: webhooks=false, gatewayAPI=f
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
 		--set image.tag=$(IMAGE_TAG) \
 		--set image.pullPolicy=Always \
+		--set resources.limits.cpu=null \
+		--set resources.limits.memory=null \
 		--set webhook.enabled=false \
 		--set gatewayAPI.enabled=false
 	kubectl wait --for=condition=Available deployment/openvox-operator \
@@ -262,6 +262,8 @@ e2e-operator-gateway: e2e-cleanup ## Install operator: webhooks=false, gatewayAP
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
 		--set image.tag=$(IMAGE_TAG) \
 		--set image.pullPolicy=Always \
+		--set resources.limits.cpu=null \
+		--set resources.limits.memory=null \
 		--set webhook.enabled=false \
 		--set gatewayAPI.enabled=true
 	kubectl wait --for=condition=Available deployment/openvox-operator \
@@ -275,6 +277,8 @@ e2e-operator-webhooks-byo: e2e-cleanup e2e-webhook-byo-cert ## Install operator:
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
 		--set image.tag=$(IMAGE_TAG) \
 		--set image.pullPolicy=Always \
+		--set resources.limits.cpu=null \
+		--set resources.limits.memory=null \
 		--set webhook.enabled=true \
 		--set webhook.certManager.enabled=false \
 		--set webhook.tls.certSecret=$(WEBHOOK_CERT_SECRET) \
@@ -290,6 +294,8 @@ e2e-operator-webhooks-cm: e2e-cleanup ## Install operator: webhooks=true, cert-m
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
 		--set image.tag=$(IMAGE_TAG) \
 		--set image.pullPolicy=Always \
+		--set resources.limits.cpu=null \
+		--set resources.limits.memory=null \
 		--set webhook.enabled=true \
 		--set webhook.certManager.enabled=true \
 		--set gatewayAPI.enabled=false

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ A Kubernetes Operator that maps [OpenVox Server](https://github.com/OpenVoxProje
 - 🗄️ **Managed OpenVox DB** - Deploy OpenVox DB (PuppetDB) with external PostgreSQL - TLS, config, and credentials managed by the operator
 - 🔃 **Automatic Config Rollout** - Config and certificate changes trigger rolling restarts automatically
 - ☸️ **Kubernetes-Native** - All config via ConfigMaps/Secrets - no entrypoint scripts, no ENV translation
-
-> **⚠️ Status: Early Development** - This project is experimental and under active development. CRDs, APIs, and behavior may change at any time. Not ready for production use. Feedback is welcome - especially on the CRD data model, which is still evolving. Feel free to open an [issue](https://github.com/slauger/openvox-operator/issues).
-
 ## Architecture
 
 ```mermaid
@@ -215,11 +212,11 @@ make uninstall                    # Remove everything
 Override the image tag or use a different scenario:
 
 ```bash
-make local-deploy LOCAL_TAG=my-feature
-make local-stack LOCAL_TAG=my-feature STACK_VALUES=charts/openvox-stack/ci/multi-server-values.yaml
+make local-deploy IMAGE_TAG=my-feature
+make local-stack IMAGE_TAG=my-feature STACK_VALUES=charts/openvox-stack/ci/multi-server-values.yaml
 ```
 
-### Testing
+## Testing
 
 ```bash
 make ci           # Run all offline checks (lint, vet, test, vulncheck, helm-lint, helm-unittest)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -30,7 +30,8 @@ make ci
 | Workflow | File | Trigger | What it does |
 |----------|------|---------|-------------|
 | CI | `ci.yaml` | Push to main/develop, PRs | Linting + all 6 image builds; pushes `:develop` tag on develop branch |
-| E2E | `e2e.yaml` | Push to develop, manual | Builds + pushes all 6 images, runs E2E test groups, cleans up images |
+| E2E Images | `e2e-images.yaml` | Push to develop, manual | Builds + pushes all 6 E2E images to ghcr.io |
+| E2E | `e2e.yaml` | Manual only | Runs E2E test groups against pre-built images (sequential, with group selection) |
 | Release | `release.yaml` | Manual (main only) | semantic-release, builds operator/server/db with version tag + `:latest`, publishes Helm charts |
 
 ### Reusable Workflows
@@ -38,11 +39,11 @@ make ci
 | Workflow | File | Purpose |
 |----------|------|---------|
 | Container Build | `_container-build.yaml` | Multi-arch image build, optional push, signing, SBOM |
+| E2E Run | `_e2e-run.yaml` | Run a single E2E test group (cluster cleanup + test execution) |
 | Go | `_go.yaml` | Go build, test, vet, vulncheck, lint |
 | Helm | `_helm.yaml` | Helm lint + unittest |
 | Shellcheck | `_shellcheck.yaml` | Shell script linting |
 | Unicode Lint | `_unicode-lint.yaml` | Detect suspicious Unicode characters |
-| Cleanup Images | `_cleanup-images.yaml` | Delete E2E images from ghcr.io |
 
 ### Image Tagging Strategy
 
@@ -51,16 +52,15 @@ make ci
 | CI - PR | all 6 | No | - | - |
 | CI - push develop | all 6 | Yes | `:develop` | No |
 | CI - push main | all 6 | No | - | - |
-| E2E - push develop | all 6 | Yes | `:develop` (or custom) | No |
-| E2E - manual | all 6 | Yes | custom `image_tag` | No |
+| E2E Images - push develop | all 6 | Yes | `:develop` | No |
+| E2E Images - manual | all 6 | Yes | custom `image_tag` or branch name | No |
 | Release | operator, server, db | Yes | `:x.y.z` | Yes |
 
 **Key points:**
 
-- `:develop` images are unstable, rebuilt on every push to develop
+- `:develop` images are unstable, rebuilt on every push to develop (by both CI and E2E Images workflows)
 - `:latest` is only set by `release.yaml` and always points to the latest release
-- E2E images tagged with short SHAs are automatically cleaned up after tests
-- Cleanup can be disabled via `cleanup_images: false` in `workflow_dispatch`
+- E2E tests run against pre-built images; no images are built or cleaned up during test runs
 
 ### Which Images Are Released?
 
@@ -206,21 +206,24 @@ make e2e-group-base IMAGE_TAG=develop
 
 # Run all groups
 make e2e-all IMAGE_TAG=develop
-
-# For feature branches: trigger E2E workflow first to build images
-gh workflow run e2e.yaml --ref $(git branch --show-current)
-make e2e-all IMAGE_TAG=$(git branch --show-current)
 ```
+
+> **Feature branches:** E2E images are only pushed for the `develop` branch. To run E2E
+> tests for a feature branch, you need to build and push images manually (e.g. via
+> `gh workflow run e2e-images.yaml --ref <branch>`). A future in-cluster registry feature
+> will make this easier -- see the tracking issue for details.
 
 ### Running in CI
 
 The E2E workflow connects to a persistent K3S cluster via `E2E_KUBECONFIG` secret. External dependencies (CNPG, Envoy Gateway, cert-manager) are managed by ArgoCD on the cluster -- the workflow only verifies they are available before starting tests. Test groups run sequentially: base, enc, gateway, webhooks-byo, webhooks-cm.
 
+Images are built by the separate `e2e-images.yaml` workflow (triggered on push to develop). The `e2e.yaml` workflow only runs tests against already-pushed images.
+
 Manual trigger with group selection:
 
 ```bash
-gh workflow run e2e.yaml -f group=webhooks-byo
-gh workflow run e2e.yaml -f group=all -f cleanup_images=false  # keep images
+gh workflow run e2e.yaml -f group=webhooks-byo -f image_tag=develop
+gh workflow run e2e.yaml -f group=all -f image_tag=develop
 ```
 
 ### Chainsaw Configuration


### PR DESCRIPTION
## Summary

- **`e2e-images.yaml`** (new): builds and pushes all 6 E2E images on push to `develop` + `workflow_dispatch`
- **`_e2e-run.yaml`** (new): reusable workflow for a single E2E test group (cluster cleanup + test execution)
- **`e2e.yaml`** (refactored): `workflow_dispatch` only, calls `_e2e-run.yaml` for each group with sequential chaining and group selection
- **`Makefile`**: remove operator CPU/memory limits in all 4 `e2e-operator-*` targets to avoid throttling
- **`README.md`**: remove early-development warning, fix `LOCAL_TAG`/`IMAGE_TAG` references
- **`docs/development/testing.md`**: update workflow tables, reusable workflows, image tagging strategy, and CI running instructions

Tracking issue for feature-branch E2E with in-cluster registry: #279

## Test plan

- [ ] Verify YAML syntax passes CI
- [ ] `e2e-images.yaml`: push to develop builds 6 images with tag `develop`
- [ ] `e2e.yaml`: manual trigger `image_tag=develop, group=base` runs only base
- [ ] `e2e.yaml`: manual trigger `group=all` runs all 5 groups sequentially
- [ ] Concurrency: second manual trigger gets queued (not cancelled)
- [ ] `helm template` confirms no CPU/memory limits with the new Makefile flags