### PR TITLE
fix: update Go toolchain to 1.26.2 and pin builder images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slauger/openvox-operator
 
-go 1.26.1
+go 1.26.2
 
 require (
 	gopkg.in/yaml.v3 v3.0.1

--- a/images/openvox-mock/Containerfile
+++ b/images/openvox-mock/Containerfile
@@ -3,7 +3,7 @@
 # Build (from repo root):
 #   podman build -t openvox-mock:latest -f images/openvox-mock/Containerfile .
 
-FROM docker.io/library/golang:1.26 AS builder
+FROM docker.io/library/golang:1.26.2 AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/images/openvox-operator/Containerfile
+++ b/images/openvox-operator/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.26 AS builder
+FROM docker.io/library/golang:1.26.2 AS builder
 
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -161,7 +161,7 @@ RUN find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/action/setup.rb' \
 ################################################################################
 # Stage: autosign — compile the openvox-autosign Go binary
 ################################################################################
-FROM docker.io/library/golang:1.26 AS autosign
+FROM docker.io/library/golang:1.26.2 AS autosign
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -173,7 +173,7 @@ RUN CGO_ENABLED=0 go build -o /openvox-autosign ./cmd/autosign/
 ################################################################################
 # Stage: enc — compile the openvox-enc Go binary
 ################################################################################
-FROM docker.io/library/golang:1.26 AS enc
+FROM docker.io/library/golang:1.26.2 AS enc
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,14 @@
   ],
   "packageRules": [
     {
+      "matchDepNames": [
+        "go",
+        "golang",
+        "docker.io/library/golang"
+      ],
+      "groupName": "Go version"
+    },
+    {
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
## Summary
- Update Go toolchain from 1.26.1 to 1.26.2 to fix govulncheck failures (GO-2026-4947, GO-2026-4946, GO-2026-4870, GO-2026-4866)
- Pin golang builder images to exact patch version so Renovate can track updates
- Add Renovate packageRule to group Go toolchain and golang Docker images into a single PR

## Changed files
- `go.mod` / `go.sum`: go 1.26.1 → 1.26.2
- `images/openvox-operator/Containerfile`: golang:1.26 → golang:1.26.2
- `images/openvox-server/Containerfile`: golang:1.26 → golang:1.26.2 (2x)
- `images/openvox-mock/Containerfile`: golang:1.26 → golang:1.26.2
- `renovate.json`: new "Go version" group rule