### PR TITLE
feat: add priorityClassName support for Server and Database pods

### DIFF
--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -65,6 +65,10 @@ type DatabaseSpec struct {
 	// +optional
 	NetworkPolicy *NetworkPolicySpec `json:"networkPolicy,omitempty"`
 
+	// PriorityClassName is the name of the PriorityClass for the Database pods.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// Service defines the Service configuration for the Database.
 	// +optional
 	Service DatabaseServiceSpec `json:"service,omitempty"`

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -100,6 +100,10 @@ type ServerSpec struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// PriorityClassName is the name of the PriorityClass for the Server pods.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// PDB defines PodDisruptionBudget settings.
 	// +optional
 	PDB *PDBSpec `json:"pdb,omitempty"`

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
@@ -361,6 +361,10 @@ spec:
                 - credentialsSecretRef
                 - host
                 type: object
+              priorityClassName:
+                description: PriorityClassName is the name of the PriorityClass for
+                  the Database pods.
+                type: string
               replicas:
                 default: 1
                 description: Replicas is the number of Database instances.

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -1319,6 +1319,10 @@ spec:
                 items:
                   type: string
                 type: array
+              priorityClassName:
+                description: PriorityClassName is the name of the PriorityClass for
+                  the Server pods.
+                type: string
               replicas:
                 default: 1
                 description: Replicas is the number of Server instances.

--- a/charts/openvox-stack/templates/database.yaml
+++ b/charts/openvox-stack/templates/database.yaml
@@ -56,6 +56,9 @@ spec:
   networkPolicy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.database.priorityClassName }}
+  priorityClassName: {{ . }}
+  {{- end }}
   {{- with .Values.database.service }}
   service:
     {{- toYaml . | nindent 4 }}

--- a/charts/openvox-stack/templates/servers.yaml
+++ b/charts/openvox-stack/templates/servers.yaml
@@ -58,4 +58,7 @@ spec:
   affinity:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with $entry.priorityClassName }}
+  priorityClassName: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/openvox-stack/tests/database_test.yaml
+++ b/charts/openvox-stack/tests/database_test.yaml
@@ -179,7 +179,26 @@ tests:
       - isNull:
           path: spec.networkPolicy
       - isNull:
+          path: spec.priorityClassName
+      - isNull:
           path: spec.service
+
+  - it: should propagate priorityClassName
+    set:
+      database:
+        enabled: true
+        name: my-puppetdb
+        certificate:
+          certname: puppetdb
+        postgres:
+          host: pg-cluster-rw.postgres.svc
+          credentialsSecretRef: pg-credentials
+        priorityClassName: high-priority
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.priorityClassName
+          value: high-priority
 
   - it: should propagate pdb
     set:

--- a/charts/openvox-stack/tests/servers_test.yaml
+++ b/charts/openvox-stack/tests/servers_test.yaml
@@ -107,6 +107,8 @@ tests:
           path: spec.topologySpreadConstraints
       - isNull:
           path: spec.affinity
+      - isNull:
+          path: spec.priorityClassName
 
   - it: should propagate javaArgs
     set:
@@ -223,6 +225,18 @@ tests:
       - equal:
           path: spec.topologySpreadConstraints[0].topologyKey
           value: kubernetes.io/hostname
+
+  - it: should propagate priorityClassName
+    set:
+      servers:
+        - name: test
+          certificate:
+            certname: puppet
+          priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.priorityClassName
+          value: high-priority
 
   - it: should propagate affinity
     set:

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -138,6 +138,7 @@ database:
   #   minAvailable: 1
   # networkPolicy:
   #   enabled: true
+  # priorityClassName: ""
   # service:
   #   type: ClusterIP
   #   port: 8081
@@ -196,6 +197,7 @@ servers:
     #       - weight: 100
     #         podAffinityTerm:
     #           topologyKey: kubernetes.io/hostname
+    # priorityClassName: ""
 
 gateway:
   name: ""              # shared Gateway resource name

--- a/config/crd/bases/openvox.voxpupuli.org_databases.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_databases.yaml
@@ -361,6 +361,10 @@ spec:
                 - credentialsSecretRef
                 - host
                 type: object
+              priorityClassName:
+                description: PriorityClassName is the name of the PriorityClass for
+                  the Database pods.
+                type: string
               replicas:
                 default: 1
                 description: Replicas is the number of Database instances.

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -1319,6 +1319,10 @@ spec:
                 items:
                   type: string
                 type: array
+              priorityClassName:
+                description: PriorityClassName is the name of the PriorityClass for
+                  the Server pods.
+                type: string
               replicas:
                 default: 1
                 description: Replicas is the number of Server instances.

--- a/internal/controller/database_controller_test.go
+++ b/internal/controller/database_controller_test.go
@@ -344,6 +344,44 @@ func TestDatabaseReconcile_StatusPhase(t *testing.T) {
 	}
 }
 
+func TestDatabaseReconcile_PriorityClassName(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		objs := append(databasePrereqs(), newDatabase("test-db", withDatabasePriorityClassName("high-priority")))
+		c := setupTestClient(objs...)
+		r := newDatabaseReconciler(c)
+
+		if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+			t.Fatalf("reconcile error: %v", err)
+		}
+
+		deploy := &appsv1.Deployment{}
+		if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, deploy); err != nil {
+			t.Fatalf("Deployment not found: %v", err)
+		}
+		if deploy.Spec.Template.Spec.PriorityClassName != "high-priority" {
+			t.Errorf("expected PriorityClassName %q, got %q", "high-priority", deploy.Spec.Template.Spec.PriorityClassName)
+		}
+	})
+
+	t.Run("empty by default", func(t *testing.T) {
+		objs := append(databasePrereqs(), newDatabase("test-db"))
+		c := setupTestClient(objs...)
+		r := newDatabaseReconciler(c)
+
+		if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+			t.Fatalf("reconcile error: %v", err)
+		}
+
+		deploy := &appsv1.Deployment{}
+		if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, deploy); err != nil {
+			t.Fatalf("Deployment not found: %v", err)
+		}
+		if deploy.Spec.Template.Spec.PriorityClassName != "" {
+			t.Errorf("expected empty PriorityClassName, got %q", deploy.Spec.Template.Spec.PriorityClassName)
+		}
+	})
+}
+
 func TestDatabaseReconcile_NetworkPolicyCreation(t *testing.T) {
 	objs := append(databasePrereqs(), newDatabase("test-db", withDatabaseNetworkPolicy(true)))
 	c := setupTestClient(objs...)

--- a/internal/controller/database_deployment.go
+++ b/internal/controller/database_deployment.go
@@ -255,9 +255,10 @@ chmod 640 /ssl/private_keys/%s.pem`, certname, certname, certname)
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		},
-		InitContainers: []corev1.Container{initContainer},
-		Containers:     []corev1.Container{container},
-		Volumes:        volumes,
+		PriorityClassName: db.Spec.PriorityClassName,
+		InitContainers:    []corev1.Container{initContainer},
+		Containers:        []corev1.Container{container},
+		Volumes:           volumes,
 	}
 
 	return podSpec

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -465,6 +465,7 @@ chmod 640 /ssl/private_keys/puppet.pem`
 		},
 		TopologySpreadConstraints: server.Spec.TopologySpreadConstraints,
 		Affinity:                  server.Spec.Affinity,
+		PriorityClassName:         server.Spec.PriorityClassName,
 		InitContainers:            []corev1.Container{initContainer},
 		Containers:                []corev1.Container{container},
 		Volumes:                   volumes,

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -359,6 +359,26 @@ func TestBuildPodSpec_Probes(t *testing.T) {
 	}
 }
 
+func TestBuildPodSpec_PriorityClassName(t *testing.T) {
+	cfg := newConfig("production")
+
+	t.Run("set", func(t *testing.T) {
+		server := newServer("test-server", withPriorityClassName("high-priority"))
+		podSpec := testBuildPodSpec(server, cfg)
+		if podSpec.PriorityClassName != "high-priority" {
+			t.Errorf("expected PriorityClassName %q, got %q", "high-priority", podSpec.PriorityClassName)
+		}
+	})
+
+	t.Run("empty by default", func(t *testing.T) {
+		server := newServer("test-server")
+		podSpec := testBuildPodSpec(server, cfg)
+		if podSpec.PriorityClassName != "" {
+			t.Errorf("expected empty PriorityClassName, got %q", podSpec.PriorityClassName)
+		}
+	})
+}
+
 func TestResolveJavaArgs_Default(t *testing.T) {
 	server := &openvoxv1alpha1.Server{
 		Spec: openvoxv1alpha1.ServerSpec{},

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -230,6 +230,12 @@ func withAutoscaling(enabled bool) serverOption {
 	}
 }
 
+func withPriorityClassName(name string) serverOption {
+	return func(s *openvoxv1alpha1.Server) {
+		s.Spec.PriorityClassName = name
+	}
+}
+
 type poolOption func(*openvoxv1alpha1.Pool)
 
 func newPool(name string, opts ...poolOption) *openvoxv1alpha1.Pool {
@@ -526,6 +532,12 @@ func withDatabaseNetworkPolicyAdditionalIngress(rules []networkingv1.NetworkPoli
 			db.Spec.NetworkPolicy = &openvoxv1alpha1.NetworkPolicySpec{Enabled: true}
 		}
 		db.Spec.NetworkPolicy.AdditionalIngress = rules
+	}
+}
+
+func withDatabasePriorityClassName(name string) databaseOption {
+	return func(db *openvoxv1alpha1.Database) {
+		db.Spec.PriorityClassName = name
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add optional `priorityClassName` field to `ServerSpec` and `DatabaseSpec` CRD types
- Propagate the field to PodSpec in both server and database controllers
- Expose `priorityClassName` in the openvox-stack Helm chart templates and values
- Add Go unit tests and Helm unit tests for the new field

Closes #298