### PR TITLE
test: add missing test for Database JavaArgs env var propagation

### DIFF
--- a/internal/controller/database_controller_test.go
+++ b/internal/controller/database_controller_test.go
@@ -246,6 +246,60 @@ func TestDatabaseReconcile_AnnotationHashes(t *testing.T) {
 	}
 }
 
+func TestDatabaseReconcile_JavaArgs(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		objs := append(databasePrereqs(), newDatabase("test-db", withDatabaseJavaArgs("-Xmx2g -Xms1g")))
+		c := setupTestClient(objs...)
+		r := newDatabaseReconciler(c)
+
+		if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+			t.Fatalf("reconcile error: %v", err)
+		}
+
+		deploy := &appsv1.Deployment{}
+		if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, deploy); err != nil {
+			t.Fatalf("Deployment not found: %v", err)
+		}
+
+		container := deploy.Spec.Template.Spec.Containers[0]
+		found := false
+		for _, env := range container.Env {
+			if env.Name == "JAVA_ARGS" {
+				found = true
+				if env.Value != "-Xmx2g -Xms1g" {
+					t.Errorf("expected JAVA_ARGS %q, got %q", "-Xmx2g -Xms1g", env.Value)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Error("JAVA_ARGS env var not found on container")
+		}
+	})
+
+	t.Run("empty by default", func(t *testing.T) {
+		objs := append(databasePrereqs(), newDatabase("test-db"))
+		c := setupTestClient(objs...)
+		r := newDatabaseReconciler(c)
+
+		if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+			t.Fatalf("reconcile error: %v", err)
+		}
+
+		deploy := &appsv1.Deployment{}
+		if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, deploy); err != nil {
+			t.Fatalf("Deployment not found: %v", err)
+		}
+
+		container := deploy.Spec.Template.Spec.Containers[0]
+		for _, env := range container.Env {
+			if env.Name == "JAVA_ARGS" {
+				t.Error("JAVA_ARGS should not be set when javaArgs is empty")
+			}
+		}
+	})
+}
+
 func TestDatabaseReconcile_ExecProbes(t *testing.T) {
 	objs := append(databasePrereqs(), newDatabase("test-db"))
 	c := setupTestClient(objs...)

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -514,6 +514,12 @@ func withDatabaseReplicas(r int32) databaseOption {
 	}
 }
 
+func withDatabaseJavaArgs(args string) databaseOption {
+	return func(db *openvoxv1alpha1.Database) {
+		db.Spec.JavaArgs = args
+	}
+}
+
 func withDatabaseNetworkPolicy(enabled bool) databaseOption {
 	return func(db *openvoxv1alpha1.Database) {
 		db.Spec.NetworkPolicy = &openvoxv1alpha1.NetworkPolicySpec{Enabled: enabled}


### PR DESCRIPTION
## Summary
- The controller already reconciles `Database.Spec.JavaArgs` into a `JAVA_ARGS` env var correctly (see `database_deployment.go:176-179`), but no test existed to verify this behavior
- Add `TestDatabaseReconcile_JavaArgs` covering both the set and empty-by-default cases
- Add `withDatabaseJavaArgs` test helper

The issue #295 reported this as a bug, but the code is already working correctly. This PR adds the missing test coverage as proof.

Closes #295