### PR TITLE
docs: unify feature list between README.md and docs/index.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -99,3 +99,14 @@ docs/                      Documentation
 - `CONTRIBUTING.md` covers developer setup and workflow
 - `docs/` contains design docs and architecture diagrams
 - No CHANGELOG - release notes are auto-generated from commit messages by semantic-release
+
+### Feature List Synchronization
+
+The canonical feature list lives in `docs/_snippets/features.md`.
+
+- **`docs/index.md`** includes it automatically via `pymdownx.snippets` (`--8<-- "docs/_snippets/features.md"`)
+- **`README.md`** contains a copy between `<!-- features -->` and `<!-- /features -->` HTML comment markers
+
+When updating features:
+1. Edit `docs/_snippets/features.md` (single source of truth)
+2. Copy the same content into the `<!-- features -->` block in `README.md`

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 A Kubernetes Operator that maps [OpenVox Server](https://github.com/OpenVoxProject) infrastructure onto native building blocks - CRDs, Secrets, OCI image volumes, and Gateway API - for running Puppet on **Kubernetes** and **OpenShift**.
 
+<!-- features: keep in sync with docs/_snippets/features.md -->
 - 🔐 **Automated CA Lifecycle** - CA initialization, certificate signing, distribution, and periodic CRL refresh - fully managed
 - 📜 **Declarative Signing Policies** - CSR approval via patterns, DNS SANs, CSR attributes, or open signing - no autosign scripts
-- 🏷️ **External Node Classification** - Declarative ENC support for custom HTTP classifiers (Foreman: see [#26](https://github.com/slauger/openvox-operator/issues/26))
+- 🏷️ **External Node Classification** - Declarative ENC support for custom HTTP classifiers
 - 📦 **One Image, Two Roles** - Same rootless image runs as CA or server, configured by the operator
 - ⚡ **Scalable Servers** - Scale catalog compilation horizontally - multiple server pools with HPA
 - 🔄 **Multi-Version Deployments** - Run different server versions side by side - canary deployments, rolling upgrades
@@ -19,8 +20,10 @@ A Kubernetes Operator that maps [OpenVox Server](https://github.com/OpenVoxProje
 - 📦 **OCI Image Volumes** - Package Puppet code as OCI images, deploy immutably with automatic rollout (K8s 1.35+)
 - 🌐 **Gateway API** - SNI-based TLSRoute support - share a single LoadBalancer across environments via TLS passthrough
 - 🗄️ **Managed OpenVox DB** - Deploy OpenVox DB (PuppetDB) with external PostgreSQL - TLS, config, and credentials managed by the operator
+- 📊 **Report Processing** - Forward Puppet reports to OpenVox DB or custom HTTP endpoints via declarative webhook configuration
 - 🔃 **Automatic Config Rollout** - Config and certificate changes trigger rolling restarts automatically
 - ☸️ **Kubernetes-Native** - All config via ConfigMaps/Secrets - no entrypoint scripts, no ENV translation
+<!-- /features -->
 ## Architecture
 
 ```mermaid

--- a/docs/_snippets/features.md
+++ b/docs/_snippets/features.md
@@ -1,0 +1,15 @@
+- 🔐 **Automated CA Lifecycle** - CA initialization, certificate signing, distribution, and periodic CRL refresh - fully managed
+- 📜 **Declarative Signing Policies** - CSR approval via patterns, DNS SANs, CSR attributes, or open signing - no autosign scripts
+- 🏷️ **External Node Classification** - Declarative ENC support for custom HTTP classifiers
+- 📦 **One Image, Two Roles** - Same rootless image runs as CA or server, configured by the operator
+- ⚡ **Scalable Servers** - Scale catalog compilation horizontally - multiple server pools with HPA
+- 🔄 **Multi-Version Deployments** - Run different server versions side by side - canary deployments, rolling upgrades
+- 🔒 **Rootless & OpenShift Ready** - Random UID compatible, no root, no ezbake, no privilege escalation
+- 🪶 **Minimal Image** - UBI9-based, no agent Ruby, no ezbake packaging - smaller footprint, fewer updates
+- 🧠 **Auto-tuned JVM** - Heap size calculated from memory limits (90%) - no manual `-Xmx` tuning needed
+- 📦 **OCI Image Volumes** - Package Puppet code as OCI images, deploy immutably with automatic rollout (K8s 1.35+)
+- 🌐 **Gateway API** - SNI-based TLSRoute support - share a single LoadBalancer across environments via TLS passthrough
+- 🗄️ **Managed OpenVox DB** - Deploy OpenVox DB (PuppetDB) with external PostgreSQL - TLS, config, and credentials managed by the operator
+- 📊 **Report Processing** - Forward Puppet reports to OpenVox DB or custom HTTP endpoints via declarative webhook configuration
+- 🔃 **Automatic Config Rollout** - Config and certificate changes trigger rolling restarts automatically
+- ☸️ **Kubernetes-Native** - All config via ConfigMaps/Secrets - no entrypoint scripts, no ENV translation

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,20 +4,7 @@ A Kubernetes Operator that maps [OpenVox Server](https://github.com/OpenVoxProje
 
 ## Features
 
-- 🔐 **Automated CA Lifecycle** - CA initialization, certificate signing, distribution, and periodic CRL refresh - fully managed
-- 📜 **Declarative Signing Policies** - CSR approval via patterns, CSR attributes, or open signing - no autosign scripts
-- 🏷️ **External Node Classification** - Declarative ENC support for Foreman, Puppet Enterprise, or custom HTTP classifiers
-- 📦 **One Image, Two Roles** - Same rootless image runs as CA or server, configured by the operator
-- ⚡ **Scalable Servers** - Scale catalog compilation horizontally with multiple server pools and HPA
-- 🔄 **Multi-Version Deployments** - Run different server versions side by side for canary deployments and rolling upgrades
-- 🔒 **Rootless & OpenShift Ready** - Random UID compatible, no root, no ezbake, no privilege escalation
-- 🪶 **Minimal Image** - UBI9-based, no agent Ruby, no ezbake packaging - smaller footprint, fewer updates
-- 🧠 **Auto-tuned JVM** - Heap size calculated from memory limits (90%) - no manual `-Xmx` tuning needed
-- 📦 **OCI Image Volumes** - Package Puppet code as OCI images, deploy immutably with automatic rollout (K8s 1.35+)
-- 🌐 **Gateway API** - SNI-based TLSRoute support - share a single LoadBalancer across environments via TLS passthrough
-- 📊 **Report Processing** - Forward Puppet reports to OpenVox DB or custom HTTP endpoints via declarative webhook configuration
-- 🔃 **Automatic Config Rollout** - Config and certificate changes trigger rolling restarts automatically
-- ☸️ **Kubernetes-Native** - All config via ConfigMaps/Secrets, no entrypoint scripts, no ENV translation
+--8<-- "docs/_snippets/features.md"
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- Extract canonical feature list into `docs/_snippets/features.md` as single source of truth
- `docs/index.md` now includes it via `pymdownx.snippets` (already enabled in mkdocs.yml)
- `README.md` uses `<!-- features -->` / `<!-- /features -->` HTML comment markers for sync guidance
- Add missing **OpenVox DB** to docs feature list
- Add missing **Report Processing** to README feature list
- Remove incorrect Foreman/Puppet Enterprise references from ENC line
- Add sync instructions to `AGENT.md`

## Test plan

- [ ] Verify `mkdocs serve` renders the snippet correctly in docs/index.md
- [ ] Verify README.md renders correctly on GitHub (HTML comments are invisible)
- [ ] Confirm feature lists are now identical