### PR TITLE
fix: update renovate datasource for openvox-agent to correct repo

### DIFF
--- a/images/openvox-agent/Containerfile
+++ b/images/openvox-agent/Containerfile
@@ -6,7 +6,7 @@
 # Run:
 #   podman run --rm openvox-agent:latest agent --test --server puppet
 
-# renovate: datasource=github-releases depName=OpenVoxProject/openvox-agent versioning=loose
+# renovate: datasource=github-releases depName=OpenVoxProject/openvox versioning=loose
 ARG OPENVOX_AGENT_VERSION=8.25.0
 
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1776315208


### PR DESCRIPTION
## Summary

- The `OpenVoxProject/openvox-agent` repository has been archived and is no longer receiving releases (last release: 8.22.1)
- The agent is now released from `OpenVoxProject/openvox` (current release: 8.26.1)
- Updates the Renovate datasource comment in the agent Containerfile to point to the correct repository so that Renovate can propose version bumps again

## Test plan

- [ ] Verify Renovate picks up new releases from `OpenVoxProject/openvox` for the agent image
- [ ] Confirm the Renovate "OpenVox versions" group PR includes the agent version bump