### PR TITLE
fix: work around syslog native C extension build failure on JRuby

### DIFF
--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -148,7 +148,9 @@ RUN printf '%s\n' \
         'INSTALL_DIR="/opt/puppetlabs/server/apps/puppetserver"' \
         'CONFIG="/etc/puppetlabs/puppetserver/conf.d"' \
         > /etc/sysconfig/puppetserver \
+    && ln -s /bin/true /usr/local/bin/make \
     && puppetserver gem install --no-document openvox -v "${OPENVOX_VERSION}" \
+    && rm /usr/local/bin/make \
     && puppetserver gem install --no-document jruby-openssl -v 0.15.7
 
 # Patch openvoxserver-ca to skip cadir symlink and chown (fails rootless)

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -13,7 +13,7 @@ ARG OPENVOXSERVER_VERSION=8.12.1
 # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
 ARG OPENVOXDB_TERMINI_VERSION=8.12.1
 # renovate: datasource=github-releases depName=OpenVoxProject/openvox
-ARG OPENVOX_VERSION=8.25.0
+ARG OPENVOX_VERSION=8.26.1
 ################################################################################
 # Stage: base — JRE + minimal runtime deps (no Ruby)
 ################################################################################


### PR DESCRIPTION
## Summary

- Work around syslog gem native C extension build failure on JRuby
- Symlink `make` to `/bin/true` during `puppetserver gem install` so the extension build succeeds as a no-op
- JRuby 9.4.x already includes syslog as a built-in Java extension, so the C extension is never loaded at runtime

## Context

OpenVox 8.26.x added `syslog ~> 0.1` as a runtime dependency (OpenVoxProject/openvox#400) for Ruby 4 compatibility. The syslog gem (0.4.0) ships a native C extension that cannot be compiled on JRuby, breaking `puppetserver gem install openvox`.

This workaround is needed before the Renovate version bump in #293 can be merged.

Ref: #306

## Test plan

- [x] Verified locally: image builds successfully with openvox 8.26.1
- [x] Verified `require 'syslog'` works on JRuby 9.4.12.1 in the container
- [x] Verified `require 'puppet'` loads correctly and reports version 8.26.1