### PR TITLE
feat: add certificate renewal before expiry

### DIFF
--- a/api/v1alpha1/certificate_types.go
+++ b/api/v1alpha1/certificate_types.go
@@ -73,7 +73,7 @@ type CertificateSpec struct {
 	// RenewBefore is the duration before expiration when the certificate should be renewed.
 	// Uses duration format: "60d", "30d", "720h".
 	// +kubebuilder:default="60d"
-	// +kubebuilder:validation:Pattern=`^\d+[smhdy]?$`
+	// +kubebuilder:validation:Pattern=`^\d+[smhdy]$`
 	// +optional
 	RenewBefore string `json:"renewBefore,omitempty"`
 }

--- a/api/v1alpha1/certificate_types.go
+++ b/api/v1alpha1/certificate_types.go
@@ -73,6 +73,7 @@ type CertificateSpec struct {
 	// RenewBefore is the duration before expiration when the certificate should be renewed.
 	// Uses duration format: "60d", "30d", "720h".
 	// +kubebuilder:default="60d"
+	// +kubebuilder:validation:Pattern=`^\d+[smhdy]?$`
 	// +optional
 	RenewBefore string `json:"renewBefore,omitempty"`
 }

--- a/api/v1alpha1/certificate_types.go
+++ b/api/v1alpha1/certificate_types.go
@@ -69,10 +69,16 @@ type CertificateSpec struct {
 	// CSRExtensions defines Puppet CSR extension attributes to embed in the CSR.
 	// +optional
 	CSRExtensions *CSRExtensionsSpec `json:"csrExtensions,omitempty"`
+
+	// RenewBefore is the duration before expiration when the certificate should be renewed.
+	// Uses duration format: "60d", "30d", "720h".
+	// +kubebuilder:default="60d"
+	// +optional
+	RenewBefore string `json:"renewBefore,omitempty"`
 }
 
 // CertificatePhase represents the current lifecycle phase of a Certificate.
-// +kubebuilder:validation:Enum=Pending;Requesting;WaitingForSigning;Signed;Error
+// +kubebuilder:validation:Enum=Pending;Requesting;WaitingForSigning;Signed;Renewing;Error
 type CertificatePhase string
 
 const (
@@ -80,6 +86,7 @@ const (
 	CertificatePhaseRequesting        CertificatePhase = "Requesting"
 	CertificatePhaseWaitingForSigning CertificatePhase = "WaitingForSigning"
 	CertificatePhaseSigned            CertificatePhase = "Signed"
+	CertificatePhaseRenewing          CertificatePhase = "Renewing"
 	CertificatePhaseError             CertificatePhase = "Error"
 )
 

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
@@ -100,7 +100,7 @@ spec:
                 description: |-
                   RenewBefore is the duration before expiration when the certificate should be renewed.
                   Uses duration format: "60d", "30d", "720h".
-                pattern: ^\d+[smhdy]?$
+                pattern: ^\d+[smhdy]$
                 type: string
             required:
             - authorityRef

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
@@ -95,6 +95,12 @@ spec:
                 items:
                   type: string
                 type: array
+              renewBefore:
+                default: 60d
+                description: |-
+                  RenewBefore is the duration before expiration when the certificate should be renewed.
+                  Uses duration format: "60d", "30d", "720h".
+                type: string
             required:
             - authorityRef
             type: object
@@ -169,6 +175,7 @@ spec:
                 - Requesting
                 - WaitingForSigning
                 - Signed
+                - Renewing
                 - Error
                 type: string
               secretName:

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
@@ -100,6 +100,7 @@ spec:
                 description: |-
                   RenewBefore is the duration before expiration when the certificate should be renewed.
                   Uses duration format: "60d", "30d", "720h".
+                pattern: ^\d+[smhdy]?$
                 type: string
             required:
             - authorityRef

--- a/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
@@ -100,7 +100,7 @@ spec:
                 description: |-
                   RenewBefore is the duration before expiration when the certificate should be renewed.
                   Uses duration format: "60d", "30d", "720h".
-                pattern: ^\d+[smhdy]?$
+                pattern: ^\d+[smhdy]$
                 type: string
             required:
             - authorityRef

--- a/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
@@ -95,6 +95,12 @@ spec:
                 items:
                   type: string
                 type: array
+              renewBefore:
+                default: 60d
+                description: |-
+                  RenewBefore is the duration before expiration when the certificate should be renewed.
+                  Uses duration format: "60d", "30d", "720h".
+                type: string
             required:
             - authorityRef
             type: object
@@ -169,6 +175,7 @@ spec:
                 - Requesting
                 - WaitingForSigning
                 - Signed
+                - Renewing
                 - Error
                 type: string
               secretName:

--- a/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
@@ -100,6 +100,7 @@ spec:
                 description: |-
                   RenewBefore is the duration before expiration when the certificate should be renewed.
                   Uses duration format: "60d", "30d", "720h".
+                pattern: ^\d+[smhdy]?$
                 type: string
             required:
             - authorityRef

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/gateway-api v1.5.1
 )
@@ -96,7 +97,6 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260304202019-5b3e3fdb0acf // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/controller-tools v0.20.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -412,39 +412,44 @@ func (r *CertificateReconciler) isWithinRenewalCooldown(cert *openvoxv1alpha1.Ce
 	return r.Clock.Since(t) < minRenewalCooldown
 }
 
-// emitExpiryWarnings emits warning events when the certificate is approaching expiry.
-// Each threshold is emitted only once, tracked via an annotation on the Certificate.
-func (r *CertificateReconciler) emitExpiryWarnings(ctx context.Context, cert *openvoxv1alpha1.Certificate, timeUntilExpiry time.Duration) {
-	var threshold string
-	switch {
-	case timeUntilExpiry <= 24*time.Hour:
-		threshold = "1d"
-	case timeUntilExpiry <= 7*24*time.Hour:
-		threshold = "7d"
-	case timeUntilExpiry <= 30*24*time.Hour:
-		threshold = "30d"
-	default:
-		return
-	}
+// expiryThresholds defines the warning thresholds for certificate expiry.
+var expiryThresholds = []struct {
+	dur   time.Duration
+	label string
+}{
+	{24 * time.Hour, "1d"},
+	{7 * 24 * time.Hour, "7d"},
+	{30 * 24 * time.Hour, "30d"},
+}
 
-	// Check if this threshold was already warned
+// emitExpiryWarnings emits warning events when the certificate is approaching expiry.
+// All crossed thresholds are emitted at once, tracked via an annotation on the Certificate.
+func (r *CertificateReconciler) emitExpiryWarnings(ctx context.Context, cert *openvoxv1alpha1.Certificate, timeUntilExpiry time.Duration) {
 	warned := ""
 	if cert.Annotations != nil {
 		warned = cert.Annotations[AnnotationExpiryWarned]
 	}
-	if strings.Contains(warned, threshold) {
+
+	var newWarnings []string
+	for _, th := range expiryThresholds {
+		if timeUntilExpiry <= th.dur && !strings.Contains(warned, th.label) {
+			r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
+				"Certificate expires in less than %s", th.label)
+			newWarnings = append(newWarnings, th.label)
+		}
+	}
+
+	if len(newWarnings) == 0 {
 		return
 	}
 
-	// Emit the warning
-	r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
-		"Certificate expires in less than %s", threshold)
-
-	// Track the threshold in an annotation
-	if warned != "" {
-		warned += "," + threshold
-	} else {
-		warned = threshold
+	// Track the thresholds in an annotation
+	for _, w := range newWarnings {
+		if warned != "" {
+			warned += "," + w
+		} else {
+			warned = w
+		}
 	}
 	patch := client.MergeFrom(cert.DeepCopy())
 	if cert.Annotations == nil {

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -419,9 +419,9 @@ var expiryThresholds = []struct {
 	dur   time.Duration
 	label string
 }{
-	{24 * time.Hour, "1d"},
-	{7 * 24 * time.Hour, "7d"},
 	{30 * 24 * time.Hour, "30d"},
+	{7 * 24 * time.Hour, "7d"},
+	{24 * time.Hour, "1d"},
 }
 
 // emitExpiryWarnings emits warning events when the certificate is approaching expiry.

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -114,8 +114,9 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
 				}
 			}
+			patch := client.MergeFrom(cert.DeepCopy())
 			controllerutil.RemoveFinalizer(cert, certificateFinalizer)
-			if err := r.Update(ctx, cert); err != nil {
+			if err := r.Patch(ctx, cert, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -124,8 +125,9 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Ensure finalizer is set
 	if !controllerutil.ContainsFinalizer(cert, certificateFinalizer) {
+		patch := client.MergeFrom(cert.DeepCopy())
 		controllerutil.AddFinalizer(cert, certificateFinalizer)
-		if err := r.Update(ctx, cert); err != nil {
+		if err := r.Patch(ctx, cert, patch); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -52,6 +53,10 @@ const defaultRenewBeforeSeconds = 60 * 24 * 3600
 // minRenewalCooldown prevents renewal loops when renewBefore exceeds the cert lifetime.
 const minRenewalCooldown = 1 * time.Hour
 
+// maxCleanupAttempts is the number of times the controller retries CA cleanup
+// before removing the finalizer anyway (to avoid blocking deletion indefinitely).
+const maxCleanupAttempts = 5
+
 // Annotation keys for renewal tracking.
 const (
 	// AnnotationLastRenewalTime records when the cert was last renewed (RFC3339).
@@ -59,6 +64,9 @@ const (
 
 	// AnnotationExpiryWarned records which expiry warning thresholds have been emitted.
 	AnnotationExpiryWarned = "openvox.voxpupuli.org/expiry-warned"
+
+	// AnnotationCleanupAttempts tracks how many times cleanup was attempted during deletion.
+	AnnotationCleanupAttempts = "openvox.voxpupuli.org/cleanup-attempts"
 )
 
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=certificates,verbs=get;list;watch;create;update;patch;delete
@@ -82,8 +90,29 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if !cert.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(cert, certificateFinalizer) {
 			if err := r.handleCertificateCleanup(ctx, cert); err != nil {
-				logger.Error(err, "certificate cleanup failed, will retry")
-				return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
+				attempts := 0
+				if cert.Annotations != nil {
+					if v, ok := cert.Annotations[AnnotationCleanupAttempts]; ok {
+						attempts, _ = strconv.Atoi(v)
+					}
+				}
+				attempts++
+				if attempts >= maxCleanupAttempts {
+					logger.Info("cleanup failed after max attempts, removing finalizer anyway",
+						"attempts", attempts, "error", err)
+				} else {
+					logger.Error(err, "certificate cleanup failed, will retry",
+						"attempt", attempts, "maxAttempts", maxCleanupAttempts)
+					patch := client.MergeFrom(cert.DeepCopy())
+					if cert.Annotations == nil {
+						cert.Annotations = make(map[string]string)
+					}
+					cert.Annotations[AnnotationCleanupAttempts] = strconv.Itoa(attempts)
+					if patchErr := r.Patch(ctx, cert, patch); patchErr != nil {
+						logger.Error(patchErr, "failed to update cleanup attempt annotation")
+					}
+					return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
+				}
 			}
 			controllerutil.RemoveFinalizer(cert, certificateFinalizer)
 			if err := r.Update(ctx, cert); err != nil {

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,9 +29,18 @@ type CertificateReconciler struct {
 
 // Event reasons for Certificate.
 const (
-	EventReasonCertificateSigned    = "CertificateSigned"
-	EventReasonCSRWaitingForSigning = "CSRWaitingForSigning"
+	EventReasonCertificateSigned           = "CertificateSigned"
+	EventReasonCSRWaitingForSigning        = "CSRWaitingForSigning"
+	EventReasonCertificateRenewalTriggered = "CertificateRenewalTriggered"
+	EventReasonCertificateRenewed          = "CertificateRenewed"
+	EventReasonCertificateExpiringSoon     = "CertificateExpiringSoon"
 )
+
+// Maximum requeue interval for renewal checks (caps the time-based backoff).
+const maxRenewalCheckInterval = 12 * time.Hour
+
+// defaultRenewBeforeSeconds is the fallback renewBefore value (60 days).
+const defaultRenewBeforeSeconds = 60 * 24 * 3600
 
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=certificates/status,verbs=get;update;patch
@@ -106,7 +116,12 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if cert.Status.NotAfter == nil {
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
-		return ctrl.Result{}, nil
+		return r.scheduleRenewalCheck(ctx, cert)
+	}
+
+	// Handle renewal phase
+	if cert.Status.Phase == openvoxv1alpha1.CertificatePhaseRenewing {
+		return r.reconcileCertRenewal(ctx, cert, ca)
 	}
 
 	// Sign certificate via CA HTTP API
@@ -189,7 +204,7 @@ func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *
 	if cert.Status.NotAfter == nil {
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
-	return ctrl.Result{}, nil
+	return r.scheduleRenewalCheck(ctx, cert)
 }
 
 // createOrUpdateTLSSecret creates or updates a Secret containing cert.pem and key.pem.
@@ -232,4 +247,78 @@ func (r *CertificateReconciler) extractNotAfter(ctx context.Context, secretName,
 		return nil
 	}
 	return parseCertNotAfter(ctx, secret.Data["cert.pem"])
+}
+
+// parseCertRenewBefore parses the RenewBefore spec field and returns the duration.
+// Falls back to 60 days if the field is empty or unparseable.
+func parseCertRenewBefore(cert *openvoxv1alpha1.Certificate) time.Duration {
+	if cert.Spec.RenewBefore == "" {
+		return time.Duration(defaultRenewBeforeSeconds) * time.Second
+	}
+	secs, err := openvoxv1alpha1.ParseDurationToSeconds(cert.Spec.RenewBefore)
+	if err != nil || secs <= 0 {
+		return time.Duration(defaultRenewBeforeSeconds) * time.Second
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// scheduleRenewalCheck computes when to next check for renewal and emits warning
+// events at 30d/7d/1d thresholds. If the certificate is within the renewal window,
+// it transitions to the Renewing phase and requeues immediately.
+func (r *CertificateReconciler) scheduleRenewalCheck(ctx context.Context, cert *openvoxv1alpha1.Certificate) (ctrl.Result, error) {
+	if cert.Status.NotAfter == nil {
+		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
+	}
+
+	now := time.Now()
+	notAfter := cert.Status.NotAfter.Time
+	timeUntilExpiry := notAfter.Sub(now)
+
+	renewBefore := parseCertRenewBefore(cert)
+	renewalTime := notAfter.Add(-renewBefore)
+	timeUntilRenewal := renewalTime.Sub(now)
+
+	// Emit warning events at thresholds
+	r.emitExpiryWarnings(cert, timeUntilExpiry)
+
+	// If within the renewal window, trigger renewal
+	if timeUntilRenewal <= 0 {
+		logger := log.FromContext(ctx)
+		logger.Info("certificate within renewal window, triggering renewal",
+			"certname", cert.Spec.Certname,
+			"notAfter", notAfter,
+			"renewBefore", renewBefore)
+
+		if err := updateStatusWithRetry(ctx, r.Client, cert, func() {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhaseRenewing
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateRenewalTriggered, "Reconcile",
+			"Certificate renewal triggered, expires %s", notAfter.Format(time.RFC3339))
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Schedule next check: half the time until renewal, capped at 12h
+	requeueAfter := timeUntilRenewal / 2
+	if requeueAfter > maxRenewalCheckInterval {
+		requeueAfter = maxRenewalCheckInterval
+	}
+
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+// emitExpiryWarnings emits warning events when the certificate is approaching expiry.
+func (r *CertificateReconciler) emitExpiryWarnings(cert *openvoxv1alpha1.Certificate, timeUntilExpiry time.Duration) {
+	switch {
+	case timeUntilExpiry <= 24*time.Hour:
+		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
+			"Certificate expires in less than 1 day")
+	case timeUntilExpiry <= 7*24*time.Hour:
+		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
+			"Certificate expires in less than 7 days")
+	case timeUntilExpiry <= 30*24*time.Hour:
+		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
+			"Certificate expires in less than 30 days")
+	}
 }

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -9,11 +9,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/utils/clock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -30,6 +30,9 @@ type CertificateReconciler struct {
 	Clock    clock.PassiveClock
 }
 
+// Finalizer for Certificate cleanup on the Puppet CA.
+const certificateFinalizer = "openvox.voxpupuli.org/certificate-cleanup"
+
 // Event reasons for Certificate.
 const (
 	EventReasonCertificateSigned           = "CertificateSigned"
@@ -37,6 +40,7 @@ const (
 	EventReasonCertificateRenewalTriggered = "CertificateRenewalTriggered"
 	EventReasonCertificateRenewed          = "CertificateRenewed"
 	EventReasonCertificateExpiringSoon     = "CertificateExpiringSoon"
+	EventReasonCertificateCleaned          = "CertificateCleaned"
 )
 
 // Maximum requeue interval for renewal checks (caps the time-based backoff).
@@ -72,6 +76,29 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Handle deletion: clean the certificate on the Puppet CA before removing the finalizer.
+	if !cert.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(cert, certificateFinalizer) {
+			if err := r.handleCertificateCleanup(ctx, cert); err != nil {
+				logger.Error(err, "certificate cleanup failed, will retry")
+				return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
+			}
+			controllerutil.RemoveFinalizer(cert, certificateFinalizer)
+			if err := r.Update(ctx, cert); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure finalizer is set
+	if !controllerutil.ContainsFinalizer(cert, certificateFinalizer) {
+		controllerutil.AddFinalizer(cert, certificateFinalizer)
+		if err := r.Update(ctx, cert); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Set initial phase
@@ -398,4 +425,36 @@ func (r *CertificateReconciler) emitExpiryWarnings(ctx context.Context, cert *op
 	if err := r.Patch(ctx, cert, patch); err != nil {
 		log.FromContext(ctx).Error(err, "failed to update expiry-warned annotation")
 	}
+}
+
+// handleCertificateCleanup calls the Puppet CA clean API to revoke and remove the certificate.
+func (r *CertificateReconciler) handleCertificateCleanup(ctx context.Context, cert *openvoxv1alpha1.Certificate) error {
+	logger := log.FromContext(ctx)
+
+	// Resolve CertificateAuthority
+	ca := &openvoxv1alpha1.CertificateAuthority{}
+	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: cert.Namespace}, ca); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("CertificateAuthority not found, skipping cleanup", "authorityRef", cert.Spec.AuthorityRef)
+			return nil
+		}
+		return err
+	}
+
+	// Skip cleanup for external CAs without a signing secret (no admin access)
+	if ca.Spec.External != nil || ca.Status.SigningSecretName == "" {
+		logger.Info("skipping CA cleanup (external CA or no signing secret)", "ca", ca.Name)
+		return nil
+	}
+
+	// Resolve CA base URL
+	caBaseURL := fmt.Sprintf("https://%s.%s.svc:8140", caInternalServiceName(ca.Name), cert.Namespace)
+
+	if err := r.cleanCertViaAPI(ctx, cert, ca, caBaseURL, cert.Namespace); err != nil {
+		return err
+	}
+
+	r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateCleaned, "Reconcile",
+		"Certificate %s cleaned from Puppet CA", cert.Spec.Certname)
+	return nil
 }

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	clock "k8s.io/utils/clock"
+	"k8s.io/utils/clock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -296,7 +296,7 @@ func (r *CertificateReconciler) scheduleRenewalCheck(ctx context.Context, cert *
 		}
 		r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateRenewalTriggered, "Reconcile",
 			"Certificate renewal triggered, expires %s", notAfter.Format(time.RFC3339))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	// Schedule next check: half the time until renewal, capped at 12h

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,18 @@ const maxRenewalCheckInterval = 12 * time.Hour
 
 // defaultRenewBeforeSeconds is the fallback renewBefore value (60 days).
 const defaultRenewBeforeSeconds = 60 * 24 * 3600
+
+// minRenewalCooldown prevents renewal loops when renewBefore exceeds the cert lifetime.
+const minRenewalCooldown = 1 * time.Hour
+
+// Annotation keys for renewal tracking.
+const (
+	// AnnotationLastRenewalTime records when the cert was last renewed (RFC3339).
+	AnnotationLastRenewalTime = "openvox.voxpupuli.org/last-renewal-time"
+
+	// AnnotationExpiryWarned records which expiry warning thresholds have been emitted.
+	AnnotationExpiryWarned = "openvox.voxpupuli.org/expiry-warned"
+)
 
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=openvox.voxpupuli.org,resources=certificates/status,verbs=get;update;patch
@@ -278,11 +291,20 @@ func (r *CertificateReconciler) scheduleRenewalCheck(ctx context.Context, cert *
 	renewalTime := notAfter.Add(-renewBefore)
 	timeUntilRenewal := renewalTime.Sub(now)
 
-	// Emit warning events at thresholds
-	r.emitExpiryWarnings(cert, timeUntilExpiry)
-
-	// If within the renewal window, trigger renewal
+	// If within the renewal window, trigger renewal (with cooldown protection)
 	if timeUntilRenewal <= 0 {
+		// Prevent renewal loops: if the cert was renewed recently, skip
+		if r.isWithinRenewalCooldown(cert) {
+			logger := log.FromContext(ctx)
+			logger.Info("certificate within renewal window but recently renewed, skipping",
+				"certname", cert.Spec.Certname,
+				"renewBefore", renewBefore,
+				"timeUntilExpiry", timeUntilExpiry)
+			r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
+				"Certificate renewBefore (%s) exceeds remaining lifetime; renewal skipped to avoid loop", renewBefore)
+			return ctrl.Result{RequeueAfter: minRenewalCooldown}, nil
+		}
+
 		logger := log.FromContext(ctx)
 		logger.Info("certificate within renewal window, triggering renewal",
 			"certname", cert.Spec.Certname,
@@ -299,6 +321,9 @@ func (r *CertificateReconciler) scheduleRenewalCheck(ctx context.Context, cert *
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
+	// Emit warning events at thresholds (only outside the renewal window)
+	r.emitExpiryWarnings(ctx, cert, timeUntilExpiry)
+
 	// Schedule next check: half the time until renewal, capped at 12h
 	requeueAfter := timeUntilRenewal / 2
 	if requeueAfter > maxRenewalCheckInterval {
@@ -308,17 +333,64 @@ func (r *CertificateReconciler) scheduleRenewalCheck(ctx context.Context, cert *
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
+// isWithinRenewalCooldown checks if the certificate was renewed recently
+// (within minRenewalCooldown). This prevents infinite renewal loops when
+// renewBefore exceeds the certificate's total lifetime.
+func (r *CertificateReconciler) isWithinRenewalCooldown(cert *openvoxv1alpha1.Certificate) bool {
+	if cert.Annotations == nil {
+		return false
+	}
+	lastRenewal, ok := cert.Annotations[AnnotationLastRenewalTime]
+	if !ok {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, lastRenewal)
+	if err != nil {
+		return false
+	}
+	return time.Since(t) < minRenewalCooldown
+}
+
 // emitExpiryWarnings emits warning events when the certificate is approaching expiry.
-func (r *CertificateReconciler) emitExpiryWarnings(cert *openvoxv1alpha1.Certificate, timeUntilExpiry time.Duration) {
+// Each threshold is emitted only once, tracked via an annotation on the Certificate.
+func (r *CertificateReconciler) emitExpiryWarnings(ctx context.Context, cert *openvoxv1alpha1.Certificate, timeUntilExpiry time.Duration) {
+	var threshold string
 	switch {
 	case timeUntilExpiry <= 24*time.Hour:
-		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
-			"Certificate expires in less than 1 day")
+		threshold = "1d"
 	case timeUntilExpiry <= 7*24*time.Hour:
-		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
-			"Certificate expires in less than 7 days")
+		threshold = "7d"
 	case timeUntilExpiry <= 30*24*time.Hour:
-		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
-			"Certificate expires in less than 30 days")
+		threshold = "30d"
+	default:
+		return
+	}
+
+	// Check if this threshold was already warned
+	warned := ""
+	if cert.Annotations != nil {
+		warned = cert.Annotations[AnnotationExpiryWarned]
+	}
+	if strings.Contains(warned, threshold) {
+		return
+	}
+
+	// Emit the warning
+	r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertificateExpiringSoon, "Reconcile",
+		"Certificate expires in less than %s", threshold)
+
+	// Track the threshold in an annotation
+	if warned != "" {
+		warned += "," + threshold
+	} else {
+		warned = threshold
+	}
+	patch := client.MergeFrom(cert.DeepCopy())
+	if cert.Annotations == nil {
+		cert.Annotations = make(map[string]string)
+	}
+	cert.Annotations[AnnotationExpiryWarned] = warned
+	if err := r.Patch(ctx, cert, patch); err != nil {
+		log.FromContext(ctx).Error(err, "failed to update expiry-warned annotation")
 	}
 }

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	clock "k8s.io/utils/clock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,6 +27,7 @@ type CertificateReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
+	Clock    clock.PassiveClock
 }
 
 // Event reasons for Certificate.
@@ -142,6 +144,9 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 func (r *CertificateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openvoxv1alpha1.Certificate{}).
 		Owns(&corev1.Secret{}).
@@ -283,7 +288,7 @@ func (r *CertificateReconciler) scheduleRenewalCheck(ctx context.Context, cert *
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
 
-	now := time.Now()
+	now := r.Clock.Now()
 	notAfter := cert.Status.NotAfter.Time
 	timeUntilExpiry := notAfter.Sub(now)
 
@@ -348,7 +353,7 @@ func (r *CertificateReconciler) isWithinRenewalCooldown(cert *openvoxv1alpha1.Ce
 	if err != nil {
 		return false
 	}
-	return time.Since(t) < minRenewalCooldown
+	return r.Clock.Since(t) < minRenewalCooldown
 }
 
 // emitExpiryWarnings emits warning events when the certificate is approaching expiry.

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -332,8 +332,7 @@ func TestScheduleRenewalCheck_NotAfterNil(t *testing.T) {
 
 func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
 	// Simulate: renewBefore=365d but cert only lives 30d, recently renewed
-	certPEM, keyPEM := generateTestCertWithExpiry(t, 30*24*time.Hour)
-	_ = keyPEM
+	certPEM, _ := generateTestCertWithExpiry(t, 30*24*time.Hour)
 
 	notAfter := parseCertNotAfter(testCtx(), certPEM)
 	if notAfter == nil {

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -376,8 +377,12 @@ func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
 }
 
 func TestIsWithinRenewalCooldown(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	fakeClock := clocktesting.NewFakePassiveClock(now)
+
 	c := setupTestClient()
 	r := newCertificateReconciler(c)
+	r.Clock = fakeClock
 
 	// No annotation -> not in cooldown
 	cert := &openvoxv1alpha1.Certificate{}
@@ -385,16 +390,16 @@ func TestIsWithinRenewalCooldown(t *testing.T) {
 		t.Error("expected no cooldown without annotation")
 	}
 
-	// Recent annotation -> in cooldown
+	// Renewed 10 minutes ago -> in cooldown
 	cert.Annotations = map[string]string{
-		AnnotationLastRenewalTime: time.Now().UTC().Format(time.RFC3339),
+		AnnotationLastRenewalTime: now.Add(-10 * time.Minute).Format(time.RFC3339),
 	}
 	if !r.isWithinRenewalCooldown(cert) {
 		t.Error("expected cooldown with recent renewal annotation")
 	}
 
-	// Old annotation -> not in cooldown
-	cert.Annotations[AnnotationLastRenewalTime] = time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	// Renewed 2 hours ago -> not in cooldown
+	cert.Annotations[AnnotationLastRenewalTime] = now.Add(-2 * time.Hour).Format(time.RFC3339)
 	if r.isWithinRenewalCooldown(cert) {
 		t.Error("expected no cooldown with old renewal annotation")
 	}

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -336,6 +336,9 @@ func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
 	_ = keyPEM
 
 	notAfter := parseCertNotAfter(testCtx(), certPEM)
+	if notAfter == nil {
+		t.Fatal("failed to parse NotAfter from test certificate")
+	}
 	cert := &openvoxv1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cert",

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -335,6 +335,9 @@ func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
 	// Simulate: renewBefore=365d but cert only lives 30d, recently renewed
 	certPEM, _ := generateTestCertWithExpiry(t, 30*24*time.Hour)
 
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	fakeClock := clocktesting.NewFakePassiveClock(now)
+
 	notAfter := parseCertNotAfter(testCtx(), certPEM)
 	if notAfter == nil {
 		t.Fatal("failed to parse NotAfter from test certificate")
@@ -344,7 +347,7 @@ func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
 			Name:      "my-cert",
 			Namespace: testNamespace,
 			Annotations: map[string]string{
-				AnnotationLastRenewalTime: time.Now().UTC().Format(time.RFC3339),
+				AnnotationLastRenewalTime: now.Add(-10 * time.Minute).Format(time.RFC3339),
 			},
 		},
 		Spec: openvoxv1alpha1.CertificateSpec{
@@ -358,6 +361,7 @@ func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
 
 	c := setupTestClient(cert)
 	r := newCertificateReconciler(c)
+	r.Clock = fakeClock
 
 	res, err := r.scheduleRenewalCheck(testCtx(), cert)
 	if err != nil {

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
@@ -159,5 +160,171 @@ func TestCertReconcile_CAExternalPhase_Accepted(t *testing.T) {
 	}
 	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned {
 		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificatePhaseSigned, updated.Status.Phase)
+	}
+}
+
+func TestCertReconcile_RenewalScheduled(t *testing.T) {
+	// Cert with NotAfter 90 days out (>60d default renewBefore) should schedule a requeue
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 90*24*time.Hour)
+
+	cert := newCertificate("my-cert", "test-ca", "")
+	ca := newCertificateAuthority("test-ca")
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	c := setupTestClient(cert, ca, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("my-cert"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have a RequeueAfter > 0 (renewal check scheduled)
+	if res.RequeueAfter == 0 && !res.Requeue {
+		t.Error("expected RequeueAfter > 0 or Requeue for signed cert with NotAfter")
+	}
+	// Should not trigger renewal yet (90d > 60d renewBefore)
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned {
+		t.Errorf("expected phase %q (not yet renewing), got %q", openvoxv1alpha1.CertificatePhaseSigned, updated.Status.Phase)
+	}
+	// RequeueAfter should be capped at maxRenewalCheckInterval (12h)
+	if res.RequeueAfter > maxRenewalCheckInterval {
+		t.Errorf("expected RequeueAfter <= %v, got %v", maxRenewalCheckInterval, res.RequeueAfter)
+	}
+}
+
+func TestCertReconcile_RenewalTriggered(t *testing.T) {
+	// Cert with NotAfter 30 days out (<60d default renewBefore) should trigger renewal
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 30*24*time.Hour)
+
+	cert := newCertificate("my-cert", "test-ca", "")
+	ca := newCertificateAuthority("test-ca")
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	c := setupTestClient(cert, ca, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("my-cert"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should trigger immediate requeue (renewal triggered)
+	if !res.Requeue {
+		t.Error("expected Requeue=true when renewal is triggered")
+	}
+
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseRenewing {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificatePhaseRenewing, updated.Status.Phase)
+	}
+}
+
+func TestCertReconcile_SignedCertNoRequeue_BecomesRequeue(t *testing.T) {
+	// Verify that a signed cert with valid NotAfter now returns RequeueAfter > 0
+	// (the old behavior was ctrl.Result{} with no requeue)
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 365*24*time.Hour)
+
+	cert := newCertificate("my-cert", "test-ca", "")
+	ca := newCertificateAuthority("test-ca")
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	c := setupTestClient(cert, ca, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("my-cert"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Must have a requeue -- no longer returning empty Result
+	if res.RequeueAfter == 0 && !res.Requeue {
+		t.Error("expected RequeueAfter > 0 for signed cert with NotAfter set")
+	}
+}
+
+func TestCertReconcile_ExpiringWarningEvents(t *testing.T) {
+	// Cert expiring in 5 days should trigger the 7-day warning but not 1-day
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 5*24*time.Hour)
+
+	cert := newCertificate("my-cert", "test-ca", "")
+	cert.Spec.RenewBefore = "1d" // only 1 day renewBefore so it doesn't immediately renew
+	ca := newCertificateAuthority("test-ca")
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	c := setupTestClient(cert, ca, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	_, err := r.Reconcile(testCtx(), testRequest("my-cert"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify phase is still Signed (within 7d warning but renewBefore=1d hasn't triggered yet)
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificatePhaseSigned, updated.Status.Phase)
+	}
+}
+
+func TestParseCertRenewBefore(t *testing.T) {
+	tests := []struct {
+		renewBefore string
+		expected    time.Duration
+	}{
+		{"", 60 * 24 * time.Hour},        // default 60 days
+		{"30d", 30 * 24 * time.Hour},     // 30 days
+		{"720h", 720 * time.Hour},        // 720 hours
+		{"invalid", 60 * 24 * time.Hour}, // falls back to default
+	}
+
+	for _, tt := range tests {
+		cert := &openvoxv1alpha1.Certificate{
+			Spec: openvoxv1alpha1.CertificateSpec{
+				RenewBefore: tt.renewBefore,
+			},
+		}
+		got := parseCertRenewBefore(cert)
+		if got != tt.expected {
+			t.Errorf("parseCertRenewBefore(%q) = %v, want %v", tt.renewBefore, got, tt.expected)
+		}
+	}
+}
+
+func TestScheduleRenewalCheck_NotAfterNil(t *testing.T) {
+	cert := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+	}
+	c := setupTestClient(cert)
+	r := newCertificateReconciler(c)
+
+	res, err := r.scheduleRenewalCheck(testCtx(), cert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != RequeueIntervalShort {
+		t.Errorf("expected RequeueAfter %v, got %v", RequeueIntervalShort, res.RequeueAfter)
 	}
 }

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clocktesting "k8s.io/utils/clock/testing"
@@ -375,6 +376,97 @@ func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
 	}
 	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned {
 		t.Errorf("expected phase %q during cooldown, got %q", openvoxv1alpha1.CertificatePhaseSigned, updated.Status.Phase)
+	}
+}
+
+func TestCertReconcile_FinalizerAdded(t *testing.T) {
+	cert := newCertificate("my-cert", "test-ca", "")
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhasePending
+
+	c := setupTestClient(cert, ca)
+	r := newCertificateReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("my-cert")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+
+	found := false
+	for _, f := range updated.Finalizers {
+		if f == certificateFinalizer {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected finalizer to be added to Certificate")
+	}
+}
+
+func TestCertReconcile_DeletionCleansUp(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.Certname = "test-certname"
+	now := metav1.Now()
+	cert.DeletionTimestamp = &now
+	cert.Finalizers = []string{certificateFinalizer}
+
+	ca := newCertificateAuthority("test-ca")
+	// No signing secret -> cleanup should be skipped gracefully
+	ca.Status.SigningSecretName = ""
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+
+	_ = keyPEM // not needed when cleanup is skipped
+	c := setupTestClient(cert, ca, caSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("my-cert"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected no requeue after deletion, got %v", res.RequeueAfter)
+	}
+
+	// Object should be gone (fake client deletes once last finalizer is removed)
+	updated := &openvoxv1alpha1.Certificate{}
+	err = c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected Certificate to be deleted, got err: %v", err)
+	}
+}
+
+func TestCertReconcile_DeletionCANotFound(t *testing.T) {
+	cert := newCertificate("my-cert", "missing-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	now := metav1.Now()
+	cert.DeletionTimestamp = &now
+	cert.Finalizers = []string{certificateFinalizer}
+
+	c := setupTestClient(cert)
+	r := newCertificateReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("my-cert"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected no requeue when CA not found during deletion, got %v", res.RequeueAfter)
+	}
+
+	// Object should be gone (CA missing -> cleanup skipped -> finalizer removed)
+	updated := &openvoxv1alpha1.Certificate{}
+	err = c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected Certificate to be deleted, got err: %v", err)
 	}
 }
 

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -328,3 +328,74 @@ func TestScheduleRenewalCheck_NotAfterNil(t *testing.T) {
 		t.Errorf("expected RequeueAfter %v, got %v", RequeueIntervalShort, res.RequeueAfter)
 	}
 }
+
+func TestScheduleRenewalCheck_CooldownPreventsLoop(t *testing.T) {
+	// Simulate: renewBefore=365d but cert only lives 30d, recently renewed
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 30*24*time.Hour)
+	_ = keyPEM
+
+	notAfter := parseCertNotAfter(testCtx(), certPEM)
+	cert := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cert",
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				AnnotationLastRenewalTime: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+		Spec: openvoxv1alpha1.CertificateSpec{
+			AuthorityRef: "test-ca",
+			Certname:     "puppet",
+			RenewBefore:  "365d",
+		},
+	}
+	cert.Status.Phase = openvoxv1alpha1.CertificatePhaseSigned
+	cert.Status.NotAfter = notAfter
+
+	c := setupTestClient(cert)
+	r := newCertificateReconciler(c)
+
+	res, err := r.scheduleRenewalCheck(testCtx(), cert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT trigger renewal (cooldown active), should requeue after cooldown
+	if res.RequeueAfter != minRenewalCooldown {
+		t.Errorf("expected RequeueAfter %v (cooldown), got %v", minRenewalCooldown, res.RequeueAfter)
+	}
+
+	// Phase should remain Signed (not Renewing)
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned {
+		t.Errorf("expected phase %q during cooldown, got %q", openvoxv1alpha1.CertificatePhaseSigned, updated.Status.Phase)
+	}
+}
+
+func TestIsWithinRenewalCooldown(t *testing.T) {
+	c := setupTestClient()
+	r := newCertificateReconciler(c)
+
+	// No annotation -> not in cooldown
+	cert := &openvoxv1alpha1.Certificate{}
+	if r.isWithinRenewalCooldown(cert) {
+		t.Error("expected no cooldown without annotation")
+	}
+
+	// Recent annotation -> in cooldown
+	cert.Annotations = map[string]string{
+		AnnotationLastRenewalTime: time.Now().UTC().Format(time.RFC3339),
+	}
+	if !r.isWithinRenewalCooldown(cert) {
+		t.Error("expected cooldown with recent renewal annotation")
+	}
+
+	// Old annotation -> not in cooldown
+	cert.Annotations[AnnotationLastRenewalTime] = time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	if r.isWithinRenewalCooldown(cert) {
+		t.Error("expected no cooldown with old renewal annotation")
+	}
+}

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -183,8 +183,8 @@ func TestCertReconcile_RenewalScheduled(t *testing.T) {
 	}
 
 	// Should have a RequeueAfter > 0 (renewal check scheduled)
-	if res.RequeueAfter == 0 && !res.Requeue {
-		t.Error("expected RequeueAfter > 0 or Requeue for signed cert with NotAfter")
+	if res.RequeueAfter == 0 {
+		t.Error("expected RequeueAfter > 0 for signed cert with NotAfter")
 	}
 	// Should not trigger renewal yet (90d > 60d renewBefore)
 	updated := &openvoxv1alpha1.Certificate{}
@@ -220,8 +220,8 @@ func TestCertReconcile_RenewalTriggered(t *testing.T) {
 	}
 
 	// Should trigger immediate requeue (renewal triggered)
-	if !res.Requeue {
-		t.Error("expected Requeue=true when renewal is triggered")
+	if res.RequeueAfter == 0 {
+		t.Error("expected RequeueAfter > 0 when renewal is triggered")
 	}
 
 	updated := &openvoxv1alpha1.Certificate{}
@@ -254,7 +254,7 @@ func TestCertReconcile_SignedCertNoRequeue_BecomesRequeue(t *testing.T) {
 	}
 
 	// Must have a requeue -- no longer returning empty Result
-	if res.RequeueAfter == 0 && !res.Requeue {
+	if res.RequeueAfter == 0 {
 		t.Error("expected RequeueAfter > 0 for signed cert with NotAfter set")
 	}
 }

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -247,23 +247,11 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 		return ctrl.Result{}, fmt.Errorf("parsing pending key: %w", err)
 	}
 
-	// Build CSR extensions from spec
-	extraExts, err := buildCSRExtensions(cert.Spec.CSRExtensions)
+	// Build CSR
+	csrPEM, err := buildCSR(certname, cert.Spec.DNSAltNames, cert.Spec.CSRExtensions, privateKey)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("building CSR extensions: %w", err)
+		return ctrl.Result{}, err
 	}
-
-	// Build and submit CSR
-	csrTemplate := &x509.CertificateRequest{
-		Subject:         pkix.Name{CommonName: certname},
-		DNSNames:        cert.Spec.DNSAltNames,
-		ExtraExtensions: extraExts,
-	}
-	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, privateKey)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("creating CSR: %w", err)
-	}
-	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 
 	httpClient, err := caHTTPClientForCA(ctx, r.Client, ca, namespace)
 	if err != nil {

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -670,6 +671,9 @@ func (r *CertificateReconciler) ensurePendingKey(ctx context.Context, cert *open
 	if err == nil && len(pendingSecret.Data["key.pem"]) > 0 {
 		return pendingSecret.Data["key.pem"], nil
 	}
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("checking pending Secret: %w", err)
+	}
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
 	if err != nil {
@@ -732,7 +736,11 @@ func (r *CertificateReconciler) cleanCertViaAPI(ctx context.Context, cert *openv
 
 	// PUT /puppet-ca/v1/clean
 	cleanURL := fmt.Sprintf("%s/puppet-ca/v1/clean?environment=production", caBaseURL)
-	body := strings.NewReader(fmt.Sprintf(`{"certnames": [%q]}`, certname))
+	payload, err := json.Marshal(map[string][]string{"certnames": {certname}})
+	if err != nil {
+		return fmt.Errorf("marshalling clean request body: %w", err)
+	}
+	body := bytes.NewReader(payload)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, cleanURL, body)
 	if err != nil {

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -446,6 +446,226 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 	return ctrl.Result{}, nil
 }
 
+// reconcileCertRenewal handles the Renewing phase by calling renewCertificate.
+func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Resolve CA base URL
+	var caBaseURL string
+	if ca.Spec.External != nil {
+		caBaseURL = ca.Spec.External.URL
+	} else {
+		caBaseURL = fmt.Sprintf("https://%s.%s.svc:8140", caInternalServiceName(ca.Name), cert.Namespace)
+	}
+
+	if err := r.renewCertificate(ctx, cert, ca, caBaseURL, cert.Namespace); err != nil {
+		logger.Error(err, "certificate renewal failed, will retry")
+		errMsg := err.Error()
+		if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhaseRenewing
+			meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionCertSigned,
+				Status:             metav1.ConditionFalse,
+				Reason:             "RenewalFailed",
+				Message:            errMsg,
+				LastTransitionTime: metav1.Now(),
+			})
+		}); statusErr != nil {
+			logger.Error(statusErr, "failed to update Certificate status", "name", cert.Name)
+		}
+		return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
+	}
+
+	// Renewal succeeded -- update status to Signed
+	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
+	notAfter := r.extractNotAfter(ctx, tlsSecretName, cert.Namespace)
+	if err := updateStatusWithRetry(ctx, r.Client, cert, func() {
+		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseSigned
+		cert.Status.SecretName = tlsSecretName
+		cert.Status.NotAfter = notAfter
+		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionCertSigned,
+			Status:             metav1.ConditionTrue,
+			Reason:             "CertificateRenewed",
+			Message:            "Certificate has been renewed",
+			LastTransitionTime: metav1.Now(),
+		})
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateRenewed, "Reconcile",
+		"Certificate renewed successfully in Secret %s", tlsSecretName)
+
+	logger.Info("certificate renewed successfully", "certname", cert.Spec.Certname)
+	if notAfter == nil {
+		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
+	}
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// renewCertificate performs certificate renewal via the Puppet CA HTTP API.
+// It generates a new key+CSR, authenticates with the existing cert via mTLS,
+// and POSTs the CSR to the certificate_renewal endpoint.
+func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {
+	logger := log.FromContext(ctx)
+
+	certname := cert.Spec.Certname
+	if certname == "" {
+		certname = "puppet"
+	}
+
+	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
+	pendingSecretName := fmt.Sprintf("%s-tls-pending", cert.Name)
+
+	// Read existing cert+key from TLS Secret for mTLS authentication
+	existingSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: tlsSecretName, Namespace: namespace}, existingSecret); err != nil {
+		return fmt.Errorf("reading existing TLS Secret %s: %w", tlsSecretName, err)
+	}
+	existingCertPEM := existingSecret.Data["cert.pem"]
+	existingKeyPEM := existingSecret.Data["key.pem"]
+	if len(existingCertPEM) == 0 || len(existingKeyPEM) == 0 {
+		return fmt.Errorf("TLS Secret %s missing cert.pem or key.pem", tlsSecretName)
+	}
+
+	// Generate new RSA 4096-bit key
+	var newKeyPEM []byte
+	pendingSecret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: pendingSecretName, Namespace: namespace}, pendingSecret)
+	if err == nil {
+		newKeyPEM = pendingSecret.Data["key.pem"]
+	}
+
+	if len(newKeyPEM) == 0 {
+		privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
+		if err != nil {
+			return fmt.Errorf("generating RSA key: %w", err)
+		}
+		newKeyPEM = pem.EncodeToMemory(&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+		})
+
+		// Store key in pending Secret
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pendingSecretName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"openvox.voxpupuli.org/certificate": cert.Name,
+				},
+			},
+			Data: map[string][]byte{"key.pem": newKeyPEM},
+		}
+		if err := controllerutil.SetControllerReference(cert, secret, r.Scheme); err != nil {
+			return err
+		}
+		if err := r.Create(ctx, secret); err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating pending Secret: %w", err)
+		}
+	}
+
+	// Parse new private key to build CSR
+	block, _ := pem.Decode(newKeyPEM)
+	if block == nil {
+		return fmt.Errorf("invalid PEM in pending key")
+	}
+	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parsing pending key: %w", err)
+	}
+
+	// Build CSR with same extensions
+	extraExts, err := buildCSRExtensions(cert.Spec.CSRExtensions)
+	if err != nil {
+		return fmt.Errorf("building CSR extensions: %w", err)
+	}
+
+	csrTemplate := &x509.CertificateRequest{
+		Subject:         pkix.Name{CommonName: certname},
+		DNSNames:        cert.Spec.DNSAltNames,
+		ExtraExtensions: extraExts,
+	}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, privateKey)
+	if err != nil {
+		return fmt.Errorf("creating CSR: %w", err)
+	}
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+	// Load CA certificate for server verification
+	caCertPEM, err := getCAPublicCert(ctx, r.Client, ca, namespace)
+	if err != nil {
+		return fmt.Errorf("loading CA certificate: %w", err)
+	}
+
+	// Build mTLS HTTP client using existing cert for authentication
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCertPEM) {
+		return fmt.Errorf("failed to parse CA certificate PEM")
+	}
+	clientCert, err := tls.X509KeyPair(existingCertPEM, existingKeyPEM)
+	if err != nil {
+		return fmt.Errorf("parsing existing certificate for mTLS: %w", err)
+	}
+	httpClient := &http.Client{
+		Timeout: HTTPClientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      pool,
+				Certificates: []tls.Certificate{clientCert},
+			},
+		},
+	}
+
+	// POST /puppet-ca/v1/certificate_renewal
+	renewURL := fmt.Sprintf("%s/puppet-ca/v1/certificate_renewal?environment=production", caBaseURL)
+
+	logger.Info("submitting certificate renewal request", "url", renewURL, "certname", certname)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, renewURL, bytes.NewReader(csrPEM))
+	if err != nil {
+		return fmt.Errorf("building renewal request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("submitting renewal request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
+	if err != nil {
+		logger.Error(err, "failed to read renewal response body")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("CA rejected renewal request (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	// Validate the response is a PEM certificate
+	pemBlock, _ := pem.Decode(body)
+	if pemBlock == nil || pemBlock.Type != "CERTIFICATE" {
+		return fmt.Errorf("renewal response is not a valid PEM certificate")
+	}
+
+	// Update TLS Secret with new cert and key
+	if err := r.createOrUpdateTLSSecret(ctx, cert, ca, tlsSecretName, body, newKeyPEM); err != nil {
+		return fmt.Errorf("updating TLS Secret with renewed cert: %w", err)
+	}
+
+	// Clean up pending Secret
+	if err := r.Get(ctx, types.NamespacedName{Name: pendingSecretName, Namespace: namespace}, pendingSecret); err == nil {
+		if err := r.Delete(ctx, pendingSecret); err != nil && !errors.IsNotFound(err) {
+			logger.Info("failed to delete pending Secret", "error", err)
+		}
+	}
+
+	logger.Info("certificate renewed via CA API", "certname", certname)
+	return nil
+}
+
 // signCSRViaAPI signs a pending CSR via the Puppet CA HTTP API using mTLS with the
 // CA server's own certificate (which has the pp_cli_auth extension required by auth.conf).
 func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -505,7 +505,7 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 	if cert.Annotations == nil {
 		cert.Annotations = make(map[string]string)
 	}
-	cert.Annotations[AnnotationLastRenewalTime] = time.Now().UTC().Format(time.RFC3339)
+	cert.Annotations[AnnotationLastRenewalTime] = r.Clock.Now().UTC().Format(time.RFC3339)
 	delete(cert.Annotations, AnnotationExpiryWarned)
 	if patchErr := r.Patch(ctx, cert, patch); patchErr != nil {
 		logger.Error(patchErr, "failed to update renewal annotations, requeueing with cooldown")
@@ -517,6 +517,47 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
 	return ctrl.Result{RequeueAfter: minRenewalCooldown}, nil
+}
+
+// mTLSHTTPClient builds an HTTP client that authenticates with clientCertPEM/clientKeyPEM
+// and verifies the server using caCertPEM.
+func mTLSHTTPClient(caCertPEM, clientCertPEM, clientKeyPEM []byte) (*http.Client, error) {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCertPEM) {
+		return nil, fmt.Errorf("failed to parse CA certificate PEM")
+	}
+	clientCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parsing client certificate for mTLS: %w", err)
+	}
+	return &http.Client{
+		Timeout: HTTPClientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:   tls.VersionTLS12,
+				RootCAs:      pool,
+				Certificates: []tls.Certificate{clientCert},
+			},
+		},
+	}, nil
+}
+
+// buildCSR generates a PEM-encoded CSR using the given private key.
+func buildCSR(certname string, dnsAltNames []string, extensions *openvoxv1alpha1.CSRExtensionsSpec, privateKey *rsa.PrivateKey) ([]byte, error) {
+	extraExts, err := buildCSRExtensions(extensions)
+	if err != nil {
+		return nil, fmt.Errorf("building CSR extensions: %w", err)
+	}
+	csrTemplate := &x509.CertificateRequest{
+		Subject:         pkix.Name{CommonName: certname},
+		DNSNames:        dnsAltNames,
+		ExtraExtensions: extraExts,
+	}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating CSR: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}), nil
 }
 
 // renewCertificate performs certificate renewal via the Puppet CA HTTP API.
@@ -545,41 +586,10 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 		return fmt.Errorf("TLS Secret %s missing cert.pem or key.pem", tlsSecretName)
 	}
 
-	// Generate new RSA 4096-bit key
-	var newKeyPEM []byte
-	pendingSecret := &corev1.Secret{}
-	err := r.Get(ctx, types.NamespacedName{Name: pendingSecretName, Namespace: namespace}, pendingSecret)
-	if err == nil {
-		newKeyPEM = pendingSecret.Data["key.pem"]
-	}
-
-	if len(newKeyPEM) == 0 {
-		privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
-		if err != nil {
-			return fmt.Errorf("generating RSA key: %w", err)
-		}
-		newKeyPEM = pem.EncodeToMemory(&pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-		})
-
-		// Store key in pending Secret
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      pendingSecretName,
-				Namespace: namespace,
-				Labels: map[string]string{
-					"openvox.voxpupuli.org/certificate": cert.Name,
-				},
-			},
-			Data: map[string][]byte{"key.pem": newKeyPEM},
-		}
-		if err := controllerutil.SetControllerReference(cert, secret, r.Scheme); err != nil {
-			return err
-		}
-		if err := r.Create(ctx, secret); err != nil && !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("creating pending Secret: %w", err)
-		}
+	// Ensure a pending key exists (reuse from previous attempt or generate new)
+	newKeyPEM, err := r.ensurePendingKey(ctx, cert, pendingSecretName, namespace)
+	if err != nil {
+		return err
 	}
 
 	// Parse new private key to build CSR
@@ -592,52 +602,23 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 		return fmt.Errorf("parsing pending key: %w", err)
 	}
 
-	// Build CSR with same extensions
-	extraExts, err := buildCSRExtensions(cert.Spec.CSRExtensions)
+	csrPEM, err := buildCSR(certname, cert.Spec.DNSAltNames, cert.Spec.CSRExtensions, privateKey)
 	if err != nil {
-		return fmt.Errorf("building CSR extensions: %w", err)
+		return err
 	}
 
-	csrTemplate := &x509.CertificateRequest{
-		Subject:         pkix.Name{CommonName: certname},
-		DNSNames:        cert.Spec.DNSAltNames,
-		ExtraExtensions: extraExts,
-	}
-	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, privateKey)
-	if err != nil {
-		return fmt.Errorf("creating CSR: %w", err)
-	}
-	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
-
-	// Load CA certificate for server verification
+	// Build mTLS HTTP client using existing cert for authentication
 	caCertPEM, err := getCAPublicCert(ctx, r.Client, ca, namespace)
 	if err != nil {
 		return fmt.Errorf("loading CA certificate: %w", err)
 	}
-
-	// Build mTLS HTTP client using existing cert for authentication
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(caCertPEM) {
-		return fmt.Errorf("failed to parse CA certificate PEM")
-	}
-	clientCert, err := tls.X509KeyPair(existingCertPEM, existingKeyPEM)
+	httpClient, err := mTLSHTTPClient(caCertPEM, existingCertPEM, existingKeyPEM)
 	if err != nil {
-		return fmt.Errorf("parsing existing certificate for mTLS: %w", err)
-	}
-	httpClient := &http.Client{
-		Timeout: HTTPClientTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS12,
-				RootCAs:      pool,
-				Certificates: []tls.Certificate{clientCert},
-			},
-		},
+		return err
 	}
 
 	// POST /puppet-ca/v1/certificate_renewal
 	renewURL := fmt.Sprintf("%s/puppet-ca/v1/certificate_renewal?environment=production", caBaseURL)
-
 	logger.Info("submitting certificate renewal request", "url", renewURL, "certname", certname)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, renewURL, bytes.NewReader(csrPEM))
@@ -673,6 +654,7 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 	}
 
 	// Clean up pending Secret
+	pendingSecret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: pendingSecretName, Namespace: namespace}, pendingSecret); err == nil {
 		if err := r.Delete(ctx, pendingSecret); err != nil && !errors.IsNotFound(err) {
 			logger.Info("failed to delete pending Secret", "error", err)
@@ -681,6 +663,43 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 
 	logger.Info("certificate renewed via CA API", "certname", certname)
 	return nil
+}
+
+// ensurePendingKey returns the PEM-encoded private key from the pending Secret,
+// generating and persisting a new one if it doesn't exist yet.
+func (r *CertificateReconciler) ensurePendingKey(ctx context.Context, cert *openvoxv1alpha1.Certificate, pendingSecretName, namespace string) ([]byte, error) {
+	pendingSecret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: pendingSecretName, Namespace: namespace}, pendingSecret)
+	if err == nil && len(pendingSecret.Data["key.pem"]) > 0 {
+		return pendingSecret.Data["key.pem"], nil
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("generating RSA key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pendingSecretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"openvox.voxpupuli.org/certificate": cert.Name,
+			},
+		},
+		Data: map[string][]byte{"key.pem": keyPEM},
+	}
+	if err := controllerutil.SetControllerReference(cert, secret, r.Scheme); err != nil {
+		return nil, err
+	}
+	if err := r.Create(ctx, secret); err != nil && !errors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("creating pending Secret: %w", err)
+	}
+	return keyPEM, nil
 }
 
 // signCSRViaAPI signs a pending CSR via the Puppet CA HTTP API using mTLS with the

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -497,6 +497,17 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 	r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateRenewed, "Reconcile",
 		"Certificate renewed successfully in Secret %s", tlsSecretName)
 
+	// Record renewal time and reset expiry warnings for the new cert
+	patch := client.MergeFrom(cert.DeepCopy())
+	if cert.Annotations == nil {
+		cert.Annotations = make(map[string]string)
+	}
+	cert.Annotations[AnnotationLastRenewalTime] = time.Now().UTC().Format(time.RFC3339)
+	delete(cert.Annotations, AnnotationExpiryWarned)
+	if patchErr := r.Patch(ctx, cert, patch); patchErr != nil {
+		logger.Error(patchErr, "failed to update renewal annotations")
+	}
+
 	logger.Info("certificate renewed successfully", "certname", cert.Spec.Certname)
 	if notAfter == nil {
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
@@ -612,6 +623,7 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 		Timeout: HTTPClientTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
+				MinVersion:   tls.VersionTLS12,
 				RootCAs:      pool,
 				Certificates: []tls.Certificate{clientCert},
 			},

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -498,7 +498,9 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 	r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateRenewed, "Reconcile",
 		"Certificate renewed successfully in Secret %s", tlsSecretName)
 
-	// Record renewal time and reset expiry warnings for the new cert
+	// Record renewal time and reset expiry warnings for the new cert.
+	// If the patch fails, requeue with cooldown interval to avoid a tight
+	// re-renewal loop (the cooldown annotation would be missing).
 	patch := client.MergeFrom(cert.DeepCopy())
 	if cert.Annotations == nil {
 		cert.Annotations = make(map[string]string)
@@ -506,14 +508,15 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 	cert.Annotations[AnnotationLastRenewalTime] = time.Now().UTC().Format(time.RFC3339)
 	delete(cert.Annotations, AnnotationExpiryWarned)
 	if patchErr := r.Patch(ctx, cert, patch); patchErr != nil {
-		logger.Error(patchErr, "failed to update renewal annotations")
+		logger.Error(patchErr, "failed to update renewal annotations, requeueing with cooldown")
+		return ctrl.Result{RequeueAfter: minRenewalCooldown}, nil
 	}
 
 	logger.Info("certificate renewed successfully", "certname", cert.Spec.Certname)
 	if notAfter == nil {
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
-	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	return ctrl.Result{RequeueAfter: minRenewalCooldown}, nil
 }
 
 // renewCertificate performs certificate renewal via the Puppet CA HTTP API.
@@ -525,6 +528,7 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 	certname := cert.Spec.Certname
 	if certname == "" {
 		certname = "puppet"
+		logger.Info("certname is empty, using default", "certname", certname)
 	}
 
 	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -699,6 +699,62 @@ func (r *CertificateReconciler) ensurePendingKey(ctx context.Context, cert *open
 	return keyPEM, nil
 }
 
+// cleanCertViaAPI calls the Puppet CA clean endpoint to revoke and remove a certificate.
+// It authenticates via mTLS with the CA server's signing certificate.
+func (r *CertificateReconciler) cleanCertViaAPI(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {
+	certname := cert.Spec.Certname
+	if certname == "" {
+		certname = "puppet"
+	}
+
+	// Load CA public cert for TLS server verification
+	caCertPEM, err := getCAPublicCert(ctx, r.Client, ca, namespace)
+	if err != nil {
+		return fmt.Errorf("loading CA certificate: %w", err)
+	}
+
+	// Load signing secret (CA server cert + key) for mTLS client auth
+	signingSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: ca.Status.SigningSecretName, Namespace: namespace}, signingSecret); err != nil {
+		return fmt.Errorf("getting signing Secret %s: %w", ca.Status.SigningSecretName, err)
+	}
+
+	clientCertPEM := signingSecret.Data["cert.pem"]
+	clientKeyPEM := signingSecret.Data["key.pem"]
+	if len(clientCertPEM) == 0 || len(clientKeyPEM) == 0 {
+		return fmt.Errorf("signing Secret %s missing cert.pem or key.pem", ca.Status.SigningSecretName)
+	}
+
+	httpClient, err := mTLSHTTPClient(caCertPEM, clientCertPEM, clientKeyPEM)
+	if err != nil {
+		return err
+	}
+
+	// PUT /puppet-ca/v1/clean
+	cleanURL := fmt.Sprintf("%s/puppet-ca/v1/clean?environment=production", caBaseURL)
+	body := strings.NewReader(fmt.Sprintf(`{"certnames": [%q]}`, certname))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, cleanURL, body)
+	if err != nil {
+		return fmt.Errorf("building clean request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling clean API: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, HTTPBodyLimit))
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("CA rejected clean request (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	log.FromContext(ctx).Info("certificate cleaned via CA API", "certname", certname)
+	return nil
+}
+
 // signCSRViaAPI signs a pending CSR via the Puppet CA HTTP API using mTLS with the
 // CA server's own certificate (which has the pp_cli_auth extension required by auth.conf).
 func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -501,7 +501,7 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 	if notAfter == nil {
 		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 	}
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
 // renewCertificate performs certificate renewal via the Puppet CA HTTP API.

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -513,10 +513,7 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 	}
 
 	logger.Info("certificate renewed successfully", "certname", cert.Spec.Certname)
-	if notAfter == nil {
-		return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
-	}
-	return ctrl.Result{RequeueAfter: minRenewalCooldown}, nil
+	return r.scheduleRenewalCheck(ctx, cert)
 }
 
 // mTLSHTTPClient builds an HTTP client that authenticates with clientCertPEM/clientKeyPEM

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -50,6 +50,7 @@ func caHTTPClientForCA(ctx context.Context, reader client.Reader, ca *openvoxv1a
 // buildExternalCAHTTPClient creates an HTTP client for an external CA with optional mTLS and CA verification.
 func buildExternalCAHTTPClient(ctx context.Context, reader client.Reader, ext *openvoxv1alpha1.ExternalCASpec, namespace string) (*http.Client, error) {
 	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: ext.InsecureSkipVerify, //nolint:gosec // user-controlled option for external CAs
 	}
 
@@ -125,7 +126,7 @@ func caHTTPClient(caCertPEM []byte) (*http.Client, error) {
 	return &http.Client{
 		Timeout: HTTPClientTimeout,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: pool},
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool},
 		},
 	}, nil
 }
@@ -717,6 +718,7 @@ func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvox
 		Timeout: HTTPClientTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
+				MinVersion:   tls.VersionTLS12,
 				RootCAs:      pool,
 				Certificates: []tls.Certificate{clientCert},
 			},

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -554,8 +554,7 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 
 	certname := cert.Spec.Certname
 	if certname == "" {
-		certname = "puppet"
-		logger.Info("certname is empty, using default", "certname", certname)
+		return fmt.Errorf("certname is empty, cannot renew certificate %s", cert.Name)
 	}
 
 	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
@@ -696,7 +695,7 @@ func (r *CertificateReconciler) ensurePendingKey(ctx context.Context, cert *open
 func (r *CertificateReconciler) cleanCertViaAPI(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {
 	certname := cert.Spec.Certname
 	if certname == "" {
-		certname = "puppet"
+		return fmt.Errorf("certname is empty, cannot clean certificate %s", cert.Name)
 	}
 
 	// Load CA public cert for TLS server verification

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -777,23 +777,9 @@ func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvox
 	}
 
 	// Build mTLS HTTP client
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(caCertPEM) {
-		return fmt.Errorf("failed to parse CA certificate PEM")
-	}
-	clientCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	httpClient, err := mTLSHTTPClient(caCertPEM, clientCertPEM, clientKeyPEM)
 	if err != nil {
-		return fmt.Errorf("parsing signing certificate: %w", err)
-	}
-	httpClient := &http.Client{
-		Timeout: HTTPClientTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS12,
-				RootCAs:      pool,
-				Certificates: []tls.Certificate{clientCert},
-			},
-		},
+		return err
 	}
 
 	// PUT /puppet-ca/v1/certificate_status/{certname}?environment=production

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -116,6 +116,12 @@ func TestCSRPollBackoff(t *testing.T) {
 // The cert includes 127.0.0.1 as an IP SAN for use with httptest.NewTLSServer.
 func generateTestCert(t *testing.T) ([]byte, []byte) {
 	t.Helper()
+	return generateTestCertWithExpiry(t, 24*time.Hour)
+}
+
+// generateTestCertWithExpiry creates a self-signed certificate with a specific validity duration.
+func generateTestCertWithExpiry(t *testing.T, validity time.Duration) ([]byte, []byte) {
+	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("generating test key: %v", err)
@@ -124,7 +130,7 @@ func generateTestCert(t *testing.T) ([]byte, []byte) {
 		SerialNumber: big.NewInt(1),
 		Subject:      pkix.Name{CommonName: "test-ca"},
 		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(24 * time.Hour),
+		NotAfter:     time.Now().Add(validity),
 		IsCA:         true,
 		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
@@ -419,6 +425,131 @@ func TestSignCSRViaAPI_DefaultCertname(t *testing.T) {
 	}
 	if !strings.Contains(requestedPath, "/puppet-ca/v1/certificate_status/puppet") {
 		t.Errorf("expected path with default certname 'puppet', got: %s", requestedPath)
+	}
+}
+
+func TestRenewCertificate_Success(t *testing.T) {
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 24*time.Hour)
+
+	// Start test HTTPS server that accepts the renewal request and returns a new cert
+	newCertPEM, _ := generateTestCertWithExpiry(t, 90*24*time.Hour)
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/puppet-ca/v1/certificate_renewal") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "text/plain" {
+			t.Errorf("expected Content-Type text/plain, got %s", r.Header.Get("Content-Type"))
+		}
+		// Read CSR body
+		body, _ := io.ReadAll(r.Body)
+		if len(body) == 0 {
+			t.Error("expected CSR in request body")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newCertPEM)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRenewing)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.renewCertificate(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRenewCertificate_CADown(t *testing.T) {
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 24*time.Hour)
+
+	// Server returns an error
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("Service Unavailable"))
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRenewing)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.renewCertificate(testCtx(), cert, ca, server.URL, testNamespace)
+	if err == nil {
+		t.Fatal("expected error when CA returns error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 503") {
+		t.Errorf("expected HTTP 503 error, got: %v", err)
+	}
+}
+
+func TestRenewCertificate_mTLSAuth(t *testing.T) {
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 24*time.Hour)
+
+	newCertPEM, _ := generateTestCertWithExpiry(t, 90*24*time.Hour)
+
+	// Verify that the client presents a certificate (mTLS)
+	var clientCertPresented bool
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			clientCertPresented = true
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newCertPEM)
+	}))
+	// Enable client cert verification on the server
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(certPEM)
+	server.TLS.ClientAuth = tls.VerifyClientCertIfGiven
+	server.TLS.ClientCAs = caCertPool
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRenewing)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.renewCertificate(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !clientCertPresented {
+		t.Error("expected client certificate to be presented for mTLS authentication")
 	}
 }
 

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -428,6 +428,126 @@ func TestSignCSRViaAPI_DefaultCertname(t *testing.T) {
 	}
 }
 
+func TestCleanCertViaAPI_Success(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	var requestedPath string
+	var requestBody string
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		requestedPath = r.URL.Path
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		requestBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.cleanCertViaAPI(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(requestedPath, "/puppet-ca/v1/clean") {
+		t.Errorf("expected path containing /puppet-ca/v1/clean, got: %s", requestedPath)
+	}
+	if !strings.Contains(requestBody, `"test-certname"`) {
+		t.Errorf("expected certname in body, got: %s", requestBody)
+	}
+}
+
+func TestCleanCertViaAPI_CARejects(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("Not Authorized"))
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.cleanCertViaAPI(testCtx(), cert, ca, server.URL, testNamespace)
+	if err == nil {
+		t.Fatal("expected error when CA rejects clean request")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Errorf("expected HTTP 403 error, got: %v", err)
+	}
+}
+
+func TestCleanCertViaAPI_DefaultCertname(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	var requestBody string
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requestBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.Certname = "" // should default to "puppet"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	err := r.cleanCertViaAPI(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(requestBody, `"puppet"`) {
+		t.Errorf("expected default certname 'puppet' in body, got: %s", requestBody)
+	}
+}
+
 func TestRenewCertificate_Success(t *testing.T) {
 	certPEM, keyPEM := generateTestCertWithExpiry(t, 24*time.Hour)
 

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -511,40 +511,22 @@ func TestCleanCertViaAPI_CARejects(t *testing.T) {
 	}
 }
 
-func TestCleanCertViaAPI_DefaultCertname(t *testing.T) {
-	certPEM, keyPEM := generateTestCert(t)
-
-	var requestBody string
-	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		requestBody = string(body)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	caSecret := newSecret("test-ca-ca", map[string][]byte{
-		"ca_crt.pem": certPEM,
-	})
-	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
-		"cert.pem": certPEM,
-		"key.pem":  keyPEM,
-	})
-
+func TestCleanCertViaAPI_EmptyCertname(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.SigningSecretName = "ca-cert-tls"
 
 	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
-	cert.Spec.Certname = "" // should default to "puppet"
+	cert.Spec.Certname = ""
 
-	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	c := setupTestClient(ca, cert)
 	r := newCertificateReconciler(c)
 
-	err := r.cleanCertViaAPI(testCtx(), cert, ca, server.URL, testNamespace)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	err := r.cleanCertViaAPI(testCtx(), cert, ca, "https://localhost:8140", testNamespace)
+	if err == nil {
+		t.Fatal("expected error when certname is empty")
 	}
-	if !strings.Contains(requestBody, `"puppet"`) {
-		t.Errorf("expected default certname 'puppet' in body, got: %s", requestBody)
+	if !strings.Contains(err.Error(), "certname is empty") {
+		t.Errorf("expected 'certname is empty' error, got: %v", err)
 	}
 }
 

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -17,6 +17,9 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
@@ -528,6 +531,91 @@ func TestCleanCertViaAPI_EmptyCertname(t *testing.T) {
 	if !strings.Contains(err.Error(), "certname is empty") {
 		t.Errorf("expected 'certname is empty' error, got: %v", err)
 	}
+}
+
+func TestReconcileCertRenewal_Success(t *testing.T) {
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 24*time.Hour)
+	newCertPEM, newKeyPEM := generateTestCertWithExpiry(t, 90*24*time.Hour)
+
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newCertPEM)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("ext-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("ext-ca", withExternal(server.URL))
+	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseExternal
+
+	cert := newCertificate("my-cert", "ext-ca", openvoxv1alpha1.CertificatePhaseRenewing)
+	cert.Spec.Certname = "test-certname"
+
+	c := setupTestClient(ca, cert, caSecret, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.reconcileCertRenewal(testCtx(), cert, ca)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify phase transitioned to Signed
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificatePhaseSigned, updated.Status.Phase)
+	}
+	if updated.Status.SecretName != "my-cert-tls" {
+		t.Errorf("expected SecretName %q, got %q", "my-cert-tls", updated.Status.SecretName)
+	}
+
+	// Verify CertSigned condition with reason CertificateRenewed
+	found := false
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == openvoxv1alpha1.ConditionCertSigned && cond.Reason == "CertificateRenewed" {
+			found = true
+			if cond.Status != "True" {
+				t.Errorf("expected condition status True, got %q", cond.Status)
+			}
+		}
+	}
+	if !found {
+		t.Error("CertSigned condition with reason CertificateRenewed not set")
+	}
+
+	// Verify renewal annotation was set
+	if updated.Annotations == nil || updated.Annotations[AnnotationLastRenewalTime] == "" {
+		t.Error("expected last-renewal-time annotation to be set")
+	}
+
+	// Verify expiry-warned annotation was cleared
+	if warned, ok := updated.Annotations[AnnotationExpiryWarned]; ok && warned != "" {
+		t.Errorf("expected expiry-warned annotation to be cleared, got %q", warned)
+	}
+
+	// Verify RequeueAfter is set (scheduleRenewalCheck called)
+	if res.RequeueAfter == 0 {
+		t.Error("expected RequeueAfter > 0 after successful renewal")
+	}
+
+	// Verify the TLS secret was updated with new cert
+	tlsUpdated := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert-tls", Namespace: testNamespace}, tlsUpdated); err != nil {
+		t.Fatalf("failed to get TLS Secret: %v", err)
+	}
+	if string(tlsUpdated.Data["cert.pem"]) == string(certPEM) {
+		t.Error("expected TLS secret cert.pem to be updated with new cert")
+	}
+
+	_ = newKeyPEM // new key is generated internally
 }
 
 func TestRenewCertificate_Success(t *testing.T) {

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -11,7 +11,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
-	clock "k8s.io/utils/clock"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -11,6 +11,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
+	clock "k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -463,6 +464,7 @@ func newCertificateReconciler(c client.Client) *CertificateReconciler {
 		Client:   c,
 		Scheme:   testScheme(),
 		Recorder: testRecorder(),
+		Clock:    clock.RealClock{},
 	}
 }
 

--- a/internal/webhook/certificate_webhook.go
+++ b/internal/webhook/certificate_webhook.go
@@ -54,6 +54,10 @@ func (v *CertificateValidator) validate(ctx context.Context, c *openvoxv1alpha1.
 		}
 	}
 
+	if err := validateDuration(c.Spec.RenewBefore, "renewBefore"); err != nil {
+		errs = append(errs, field.Invalid(specPath.Child("renewBefore"), c.Spec.RenewBefore, err.Error()))
+	}
+
 	if ext := c.Spec.CSRExtensions; ext != nil {
 		extPath := specPath.Child("csrExtensions")
 		conflicting := map[string]bool{

--- a/internal/webhook/certificate_webhook_test.go
+++ b/internal/webhook/certificate_webhook_test.go
@@ -144,6 +144,42 @@ func TestCertificateValidator(t *testing.T) {
 		}
 	})
 
+	t.Run("valid renewBefore", func(t *testing.T) {
+		for _, val := range []string{"60d", "30d", "720h", "90d", ""} {
+			c := setupTestClient(ca)
+			v := &CertificateValidator{Client: c}
+			cert := &openvoxv1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: openvoxv1alpha1.CertificateSpec{
+					AuthorityRef: "my-ca",
+					Certname:     "puppet",
+					RenewBefore:  val,
+				},
+			}
+			_, err := v.ValidateCreate(context.Background(), cert)
+			if err != nil {
+				t.Errorf("expected no error for renewBefore=%q, got %v", val, err)
+			}
+		}
+	})
+
+	t.Run("invalid renewBefore", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &CertificateValidator{Client: c}
+		cert := &openvoxv1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.CertificateSpec{
+				AuthorityRef: "my-ca",
+				Certname:     "puppet",
+				RenewBefore:  "invalid",
+			},
+		}
+		_, err := v.ValidateCreate(context.Background(), cert)
+		if err == nil {
+			t.Error("expected error for invalid renewBefore")
+		}
+	})
+
 	t.Run("delete always succeeds", func(t *testing.T) {
 		v := &CertificateValidator{Client: setupTestClient()}
 		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.Certificate{})


### PR DESCRIPTION
## Summary

Closes #49
Relates to #289

### Certificate Renewal

- Add `spec.renewBefore` field (default `60d`) with CRD pattern validation (unit suffix required)
- Add `Renewing` phase to `CertificatePhase` enum
- After signing, schedule periodic renewal checks via `RequeueAfter` (capped at 12h)
- Trigger renewal when certificate is within the `renewBefore` window
- Implement certificate renewal via `POST /puppet-ca/v1/certificate_renewal` using mTLS with the existing (still-valid) certificate
- Crash-safe pending key pattern (reuses key across controller restarts)
- Cooldown mechanism prevents renewal loops when `renewBefore` exceeds cert lifetime

### Expiry Warnings

- Emit warning events at 30d/7d/1d expiry thresholds
- Annotation-based deduplication (each threshold emitted only once per cert lifecycle)

### Cleanup Finalizer

- Add finalizer `openvox.voxpupuli.org/certificate-cleanup` to all Certificate CRs
- On deletion, call `PUT /puppet-ca/v1/clean` to revoke and remove the certificate from the Puppet CA
- Uses mTLS with the CA signing secret (same auth as CSR signing)
- Graceful skip when CA is not found, external, or has no signing secret
- Retry limit (5 attempts) prevents blocking deletion indefinitely when CA is unreachable

### Security & Refactoring

- Enforce TLS 1.2 minimum on all CA HTTP clients
- Inject `clock.PassiveClock` for deterministic time-based tests
- Extract `buildCSR`, `ensurePendingKey`, `mTLSHTTPClient` helpers (used by both initial signing and renewal)
- `submitCSR` reuses extracted `buildCSR` (no more duplicate CSR construction)
- Use `json.Marshal` for clean API request body (proper JSON escaping)
- Guard `ensurePendingKey` against transient errors (propagate non-NotFound errors)

## Test plan

- [x] `make generate manifests` succeeds
- [x] `make test` passes (controller + webhook + signing tests)
- [x] `go vet` clean
- [ ] Manual: create a Certificate with short TTL, verify renewal triggers before expiry
- [ ] Manual: delete a Certificate CR, verify `puppetserver ca list --all` no longer shows it