### PR TITLE
feat: test upstream openvoxserver-ca#33 rootless fix

### DIFF
--- a/charts/openvox-operator/tests/deployment_test.yaml
+++ b/charts/openvox-operator/tests/deployment_test.yaml
@@ -123,4 +123,4 @@ tests:
           value: 500m
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: 128Mi
+          value: 256Mi

--- a/charts/openvox-operator/values.yaml
+++ b/charts/openvox-operator/values.yaml
@@ -38,10 +38,10 @@ gatewayAPI:
 resources:
   limits:
     cpu: 500m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 10m
-    memory: 64Mi
+    memory: 128Mi
 
 # Admission webhook configuration.
 #

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -151,9 +151,7 @@ RUN printf '%s\n' \
     && puppetserver gem install --no-document openvox -v "${OPENVOX_VERSION}" \
     && puppetserver gem install --no-document jruby-openssl -v 0.15.7
 
-# Replace openvoxserver-ca file_system.rb with upstream fix from
-# OpenVoxProject/openvoxserver-ca#33 (ensure_ownership helper skips chown
-# when not running as root, eliminating the need for our sed patches).
+# Patch openvoxserver-ca to skip chown in rootless containers (OpenVoxProject/openvoxserver-ca#33)
 RUN curl -fsSL https://raw.githubusercontent.com/dotconfig404/openvoxserver-ca/016db7f606ebaac614bd92a597249cb256c6c514/lib/puppetserver/ca/utils/file_system.rb \
       -o /tmp/file_system.rb \
     && find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb' \

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -154,7 +154,7 @@ RUN printf '%s\n' \
 # Replace openvoxserver-ca file_system.rb with upstream fix from
 # OpenVoxProject/openvoxserver-ca#33 (ensure_ownership helper skips chown
 # when not running as root, eliminating the need for our sed patches).
-RUN curl -fsSL https://raw.githubusercontent.com/dotconfig404/openvoxserver-ca/fix/chown-in-rootless-containers/lib/puppetserver/ca/utils/file_system.rb \
+RUN curl -fsSL https://raw.githubusercontent.com/dotconfig404/openvoxserver-ca/016db7f606ebaac614bd92a597249cb256c6c514/lib/puppetserver/ca/utils/file_system.rb \
       -o /tmp/file_system.rb \
     && cp /tmp/file_system.rb /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems/gems/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb
 

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -154,7 +154,7 @@ RUN printf '%s\n' \
 # Replace openvoxserver-ca file_system.rb with upstream fix from
 # OpenVoxProject/openvoxserver-ca#33 (ensure_ownership helper skips chown
 # when not running as root, eliminating the need for our sed patches).
-RUN curl -fsSL https://raw.githubusercontent.com/OpenVoxProject/openvoxserver-ca/fix/chown-in-rootless-containers/lib/puppetserver/ca/utils/file_system.rb \
+RUN curl -fsSL https://raw.githubusercontent.com/dotconfig404/openvoxserver-ca/fix/chown-in-rootless-containers/lib/puppetserver/ca/utils/file_system.rb \
       -o /tmp/file_system.rb \
     && cp /tmp/file_system.rb /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems/gems/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb
 

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -156,7 +156,8 @@ RUN printf '%s\n' \
 # when not running as root, eliminating the need for our sed patches).
 RUN curl -fsSL https://raw.githubusercontent.com/dotconfig404/openvoxserver-ca/016db7f606ebaac614bd92a597249cb256c6c514/lib/puppetserver/ca/utils/file_system.rb \
       -o /tmp/file_system.rb \
-    && cp /tmp/file_system.rb /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems/gems/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb
+    && find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb' \
+         -exec cp /tmp/file_system.rb {} \; 2>/dev/null
 
 ################################################################################
 # Stage: autosign — compile the openvox-autosign Go binary

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -151,12 +151,12 @@ RUN printf '%s\n' \
     && puppetserver gem install --no-document openvox -v "${OPENVOX_VERSION}" \
     && puppetserver gem install --no-document jruby-openssl -v 0.15.7
 
-# Patch openvoxserver-ca to skip cadir symlink and chown (fails rootless)
-RUN find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/action/setup.rb' \
-         -exec sed -i '/Puppetserver::Ca::Utils::Config\.symlink_to_old_cadir/ s/^/# /' {} + 2>/dev/null \
-    ; find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb' \
-         -exec sed -i 's/FileUtils\.chown/# FileUtils.chown/' {} + 2>/dev/null \
-    ; true
+# Replace openvoxserver-ca file_system.rb with upstream fix from
+# OpenVoxProject/openvoxserver-ca#33 (ensure_ownership helper skips chown
+# when not running as root, eliminating the need for our sed patches).
+RUN curl -fsSL https://raw.githubusercontent.com/OpenVoxProject/openvoxserver-ca/fix/chown-in-rootless-containers/lib/puppetserver/ca/utils/file_system.rb \
+      -o /tmp/file_system.rb \
+    && cp /tmp/file_system.rb /opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems/gems/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb
 
 ################################################################################
 # Stage: autosign — compile the openvox-autosign Go binary


### PR DESCRIPTION
## Summary

- Replaces our sed-based patches for rootless chown issues with the upstream file_system.rb from OpenVoxProject/openvoxserver-ca#33
- The upstream PR introduces an ensure_ownership helper that skips chown when not running as root
- This covers both the file_system.rb chown calls and the forcibly_symlink used by symlink_to_old_cadir in setup.rb
- Eliminates the need for both of our previous sed patches

## Test plan

- [ ] CI image build passes (openvox-server image builds successfully)
- [ ] E2E tests pass (puppetserver ca setup works rootless)
- [ ] If successful, we can drop our patches once openvoxserver-ca#33 is merged and released