### PR TITLE
fix: increase operator memory limits to prevent OOMKill

### DIFF
--- a/charts/openvox-operator/tests/deployment_test.yaml
+++ b/charts/openvox-operator/tests/deployment_test.yaml
@@ -123,4 +123,4 @@ tests:
           value: 500m
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: 128Mi
+          value: 256Mi

--- a/charts/openvox-operator/values.yaml
+++ b/charts/openvox-operator/values.yaml
@@ -38,10 +38,10 @@ gatewayAPI:
 resources:
   limits:
     cpu: 500m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 10m
-    memory: 64Mi
+    memory: 128Mi
 
 # Admission webhook configuration.
 #


### PR DESCRIPTION
## Summary

- Raise memory limit from 128Mi to 256Mi
- Raise memory request from 64Mi to 128Mi
- Previous limits caused OOMKill under sustained reconciliation load

## Test plan

- [ ] Operator pod runs stable without OOMKill