### PR TITLE
fix: use CN-based auth.conf rules for operator-signing cert

### DIFF
--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -751,7 +751,7 @@ func (r *CertificateReconciler) cleanCertViaAPI(ctx context.Context, cert *openv
 }
 
 // signCSRViaAPI signs a pending CSR via the Puppet CA HTTP API using mTLS with the
-// CA server's own certificate (which has the pp_cli_auth extension required by auth.conf).
+// operator-signing certificate (authorized by CN-based auth.conf rules).
 func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {
 	certname := cert.Spec.Certname
 	if certname == "" {

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -740,11 +740,8 @@ func TestCAReconcile_OperatorSigningCertCreated(t *testing.T) {
 	if signingCert.Spec.Certname != "test-ca-operator" {
 		t.Errorf("expected certname %q, got %q", "test-ca-operator", signingCert.Spec.Certname)
 	}
-	if signingCert.Spec.CSRExtensions == nil {
-		t.Fatal("expected csrExtensions to be set")
-	}
-	if !signingCert.Spec.CSRExtensions.PpCliAuth {
-		t.Error("expected csrExtensions.ppCliAuth=true")
+	if signingCert.Spec.CSRExtensions != nil {
+		t.Error("expected no csrExtensions on operator-signing cert")
 	}
 	if len(signingCert.OwnerReferences) == 0 {
 		t.Error("expected ownerReference on operator-signing cert")

--- a/internal/controller/certificateauthority_signing.go
+++ b/internal/controller/certificateauthority_signing.go
@@ -16,8 +16,8 @@ import (
 )
 
 // reconcileOperatorSigningCert ensures a dedicated operator-signing Certificate CR
-// exists for internal CAs. This certificate carries the pp_cli_auth extension and
-// is used for mTLS authentication when signing CSRs via the CA HTTP API.
+// exists for internal CAs. This certificate is used for mTLS authentication when
+// signing CSRs via the CA HTTP API; access is granted by CN-based auth.conf rules.
 func (r *CertificateAuthorityReconciler) reconcileOperatorSigningCert(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, certs []openvoxv1alpha1.Certificate) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -48,9 +48,6 @@ func (r *CertificateAuthorityReconciler) reconcileOperatorSigningCert(ctx contex
 			Spec: openvoxv1alpha1.CertificateSpec{
 				AuthorityRef: ca.Name,
 				Certname:     certname,
-				CSRExtensions: &openvoxv1alpha1.CSRExtensionsSpec{
-					PpCliAuth: true,
-				},
 			},
 		}
 		if err := controllerutil.SetControllerReference(ca, newCert, r.Scheme); err != nil {

--- a/internal/controller/certificateauthority_signing_test.go
+++ b/internal/controller/certificateauthority_signing_test.go
@@ -39,8 +39,8 @@ func TestReconcileOperatorSigningCert_CreatesWhenMissing(t *testing.T) {
 	if cert.Spec.Certname != "test-ca-operator" {
 		t.Errorf("expected certname 'test-ca-operator', got %q", cert.Spec.Certname)
 	}
-	if cert.Spec.CSRExtensions == nil || !cert.Spec.CSRExtensions.PpCliAuth {
-		t.Error("expected csrExtensions.ppCliAuth=true")
+	if cert.Spec.CSRExtensions != nil {
+		t.Error("expected no csrExtensions on operator-signing cert")
 	}
 	if len(cert.OwnerReferences) == 0 {
 		t.Error("expected ownerReference to be set")

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -148,7 +148,7 @@ func (r *ConfigReconciler) reconcileConfigMap(ctx context.Context, cfg *openvoxv
 		"webserver.conf":    r.renderWebserverConf(cfg),
 		"webserver-ca.conf": r.renderWebserverConfCA(cfg),
 		"puppetserver.conf": r.renderPuppetserverConf(cfg),
-		"auth.conf":         r.renderAuthConf(cfg),
+		"auth.conf":         r.renderAuthConf(cfg, ca),
 		"ca.conf":           r.renderCAConf(ca),
 		"product.conf":      "product: {\n    check-for-updates: false\n}\n",
 		"logback.xml":       r.renderLogbackXML(cfg),

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -197,12 +197,18 @@ func (r *ConfigReconciler) renderPuppetserverConf(cfg *openvoxv1alpha1.Config) s
 	return sb.String()
 }
 
-func (r *ConfigReconciler) renderAuthConf(cfg *openvoxv1alpha1.Config) string {
+func (r *ConfigReconciler) renderAuthConf(cfg *openvoxv1alpha1.Config, ca *openvoxv1alpha1.CertificateAuthority) string {
+	// Derive the operator-signing certname when an internal CA exists.
+	var operatorCertname string
+	if ca != nil && ca.Spec.External == nil {
+		operatorCertname = fmt.Sprintf("%s-operator", ca.Name)
+	}
+
 	var sb strings.Builder
 	sb.WriteString("authorization: {\n    version: 1\n    rules: [\n")
 
 	// Built-in rules (always included)
-	sb.WriteString(r.builtinAuthRules())
+	sb.WriteString(r.builtinAuthRules(operatorCertname))
 
 	// Custom authorization rules (inserted before the deny-all rule)
 	for _, rule := range cfg.Spec.PuppetServer.AuthorizationRules {
@@ -254,8 +260,32 @@ func (r *ConfigReconciler) renderAuthConf(cfg *openvoxv1alpha1.Config) string {
 }
 
 // builtinAuthRules returns the built-in auth.conf rules as HOCON (without the deny-all).
-func (r *ConfigReconciler) builtinAuthRules() string {
-	return `        {
+// When operatorCertname is non-empty, CA admin rules emit a combined allow list that
+// permits both the pp_cli_auth extension and the operator-signing certificate CN.
+func (r *ConfigReconciler) builtinAuthRules(operatorCertname string) string {
+	// ppCliAuthAllow returns the HOCON allow block for CA admin endpoints.
+	// With an operator certname it emits a list allowing both pp_cli_auth and the CN.
+	ppCliAuthAllow := func() string {
+		if operatorCertname != "" {
+			return fmt.Sprintf(`            allow: [
+                {
+                    extensions: {
+                        pp_cli_auth: "true"
+                    }
+                },
+                %q
+            ]`, operatorCertname)
+		}
+		return `            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }`
+	}
+
+	caAdminAllow := ppCliAuthAllow()
+
+	return fmt.Sprintf(`        {
             match-request: {
                 path: "^/puppet/v3/catalog/([^/]+)$"
                 type: regex
@@ -321,11 +351,7 @@ func (r *ConfigReconciler) builtinAuthRules() string {
                 type: path
                 method: [get, put, delete]
             }
-            allow: {
-               extensions: {
-                   pp_cli_auth: "true"
-               }
-            }
+%s
             sort-order: 500
             name: "puppetlabs cert status"
         },
@@ -335,11 +361,7 @@ func (r *ConfigReconciler) builtinAuthRules() string {
                 type: regex
                 method: put
             }
-            allow: {
-               extensions: {
-                   pp_cli_auth: "true"
-               }
-            }
+%s
             sort-order: 500
             name: "puppetlabs CRL update"
         },
@@ -349,11 +371,7 @@ func (r *ConfigReconciler) builtinAuthRules() string {
                 type: path
                 method: get
             }
-            allow: {
-               extensions: {
-                   pp_cli_auth: "true"
-               }
-            }
+%s
             sort-order: 500
             name: "puppetlabs cert statuses"
         },
@@ -373,11 +391,7 @@ func (r *ConfigReconciler) builtinAuthRules() string {
                 type: path
                 method: put
             }
-            allow: {
-               extensions: {
-                   pp_cli_auth: "true"
-               }
-            }
+%s
             sort-order: 500
             name: "puppetlabs cert clean"
         },
@@ -387,11 +401,7 @@ func (r *ConfigReconciler) builtinAuthRules() string {
                 type: path
                 method: post
             }
-            allow: {
-               extensions: {
-                   pp_cli_auth: "true"
-               }
-            }
+%s
             sort-order: 500
             name: "puppetlabs cert sign"
         },
@@ -401,11 +411,7 @@ func (r *ConfigReconciler) builtinAuthRules() string {
                 type: path
                 method: post
             }
-            allow: {
-               extensions: {
-                   pp_cli_auth: "true"
-               }
-            }
+%s
             sort-order: 500
             name: "puppetlabs cert sign all"
         },
@@ -538,7 +544,7 @@ func (r *ConfigReconciler) builtinAuthRules() string {
             sort-order: 500
             name: "puppet tasks information"
         },
-`
+`, caAdminAllow, caAdminAllow, caAdminAllow, caAdminAllow, caAdminAllow, caAdminAllow)
 }
 
 // renderLogbackXML generates logback.xml from LoggingSpec.

--- a/internal/controller/config_rendering_test.go
+++ b/internal/controller/config_rendering_test.go
@@ -142,6 +142,62 @@ func TestRenderWebserverConfCA(t *testing.T) {
 	}
 }
 
+func TestRenderAuthConf(t *testing.T) {
+	r := newConfigReconciler(setupTestClient())
+	cfg := newConfig("test")
+
+	t.Run("no CA emits pp_cli_auth only", func(t *testing.T) {
+		out := r.renderAuthConf(cfg, nil)
+
+		if !strings.Contains(out, `pp_cli_auth: "true"`) {
+			t.Error("expected pp_cli_auth rule in output")
+		}
+		// Must not contain any CN-based allow list
+		if strings.Contains(out, "test-ca-operator") {
+			t.Error("unexpected operator certname in output without CA")
+		}
+	})
+
+	t.Run("external CA emits pp_cli_auth only", func(t *testing.T) {
+		ca := newCertificateAuthority("test-ca", withExternal("https://puppet-ca.example.com:8140"))
+		out := r.renderAuthConf(cfg, ca)
+
+		if !strings.Contains(out, `pp_cli_auth: "true"`) {
+			t.Error("expected pp_cli_auth rule in output")
+		}
+		if strings.Contains(out, "test-ca-operator") {
+			t.Error("unexpected operator certname for external CA")
+		}
+	})
+
+	t.Run("internal CA emits combined CN and pp_cli_auth allow", func(t *testing.T) {
+		ca := newCertificateAuthority("my-ca")
+		out := r.renderAuthConf(cfg, ca)
+
+		// Must contain both pp_cli_auth and the operator certname
+		if !strings.Contains(out, `pp_cli_auth: "true"`) {
+			t.Error("expected pp_cli_auth in combined allow")
+		}
+		if !strings.Contains(out, `"my-ca-operator"`) {
+			t.Errorf("expected operator certname in combined allow, got:\n%s", out)
+		}
+
+		// Verify the combined allow appears for CA admin endpoints
+		for _, ruleName := range []string{
+			"puppetlabs cert status",
+			"puppetlabs CRL update",
+			"puppetlabs cert statuses",
+			"puppetlabs cert clean",
+			"puppetlabs cert sign",
+			"puppetlabs cert sign all",
+		} {
+			if !strings.Contains(out, ruleName) {
+				t.Errorf("expected rule %q in output", ruleName)
+			}
+		}
+	})
+}
+
 func TestRenderCAConf(t *testing.T) {
 	r := newConfigReconciler(setupTestClient())
 


### PR DESCRIPTION
## Summary

- Remove `pp_cli_auth` extension from operator-signing CSR (the openvoxserver CA rejects it in CSRs submitted via the HTTP sign path)
- Grant CA admin access to the operator-signing cert via CN-based `auth.conf` rules instead (`{ca.Name}-operator`)
- CA admin endpoints now emit a combined allow list permitting both `pp_cli_auth` (backwards compat) and the operator CN
- External/nil CAs retain the original pp_cli_auth-only rules

## Test plan

- [x] `go test ./internal/controller/...` passes
- [x] `make helm-unittest` passes
- [ ] Local deploy with `make local-deploy && make local-stack` - operator-signing cert gets signed and operator stops crashlooping