### PR TITLE
fix: remove versioning=loose and bump openvox-agent to 8.26.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
       - 'LICENSE'
       - 'CHANGELOG*'
       - '.github/*.md'
+      - 'mkdocs.yml'
+      - 'renovate.json'
   pull_request:
     branches: [main, develop]
     paths-ignore:
@@ -17,6 +19,8 @@ on:
       - 'LICENSE'
       - 'CHANGELOG*'
       - '.github/*.md'
+      - 'mkdocs.yml'
+      - 'renovate.json'
 
 jobs:
   unicode:

--- a/images/openvox-agent/Containerfile
+++ b/images/openvox-agent/Containerfile
@@ -6,8 +6,8 @@
 # Run:
 #   podman run --rm openvox-agent:latest agent --test --server puppet
 
-# renovate: datasource=github-releases depName=OpenVoxProject/openvox versioning=loose
-ARG OPENVOX_AGENT_VERSION=8.25.0
+# renovate: datasource=github-releases depName=OpenVoxProject/openvox
+ARG OPENVOX_AGENT_VERSION=8.26.2
 
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1776645994
 

--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -66,7 +66,7 @@ spec:
       try:
         - assert:
             resource:
-              apiVersion: gateway.networking.k8s.io/v1alpha2
+              apiVersion: gateway.networking.k8s.io/v1
               kind: TLSRoute
               metadata:
                 name: openvox-stack-gw-server

--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -66,7 +66,7 @@ spec:
       try:
         - assert:
             resource:
-              apiVersion: gateway.networking.k8s.io/v1
+              apiVersion: gateway.networking.k8s.io/v1alpha2
               kind: TLSRoute
               metadata:
                 name: openvox-stack-gw-server


### PR DESCRIPTION
## Summary

- Remove unsupported `versioning=loose` from renovate comment in the agent Containerfile so the regex custom manager can match it
- Bump openvox-agent from 8.25.0 to 8.26.2, which includes the openfact 5.6.0 fix for the `oci` container runtime warning
- Agent version bumps are now grouped with all other OpenVox deps in a single Renovate PR