### PR TITLE
fix: e2e pool-gateway TLSRoute API version and cleanup order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,9 +209,9 @@ e2e-wait: ## Wait for E2E dependencies to be available (pre-installed via ArgoCD
 
 .PHONY: e2e-cleanup
 e2e-cleanup: ## Remove operator and all E2E test namespaces (keeps CRDs).
+	@echo "Cleaning up leftover E2E namespaces (operator still running to process finalizers)..."
+	@kubectl get namespaces -o name | grep '^namespace/e2e-' | xargs -r kubectl delete --timeout=120s --ignore-not-found 2>/dev/null || true
 	helm uninstall openvox-operator --namespace $(NAMESPACE) --wait 2>/dev/null || true
-	@echo "Cleaning up leftover E2E namespaces..."
-	@kubectl get namespaces -o name | grep '^namespace/e2e-' | xargs -r kubectl delete --ignore-not-found 2>/dev/null || true
 	kubectl delete namespace $(NAMESPACE) --ignore-not-found 2>/dev/null || true
 
 .PHONY: e2e-cleanup-full

--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -66,7 +66,7 @@ spec:
       try:
         - assert:
             resource:
-              apiVersion: gateway.networking.k8s.io/v1alpha2
+              apiVersion: gateway.networking.k8s.io/v1
               kind: TLSRoute
               metadata:
                 name: openvox-stack-gw-server


### PR DESCRIPTION
## Summary
- Fix TLSRoute API version in pool-gateway e2e test: the operator creates TLSRoutes using the GA `gateway.networking.k8s.io/v1` API, but the test asserted against the deprecated `v1alpha2` version, causing it to fail with `actual resource not found`
- Fix e2e-cleanup target in Makefile: delete e2e namespaces before uninstalling the operator, so finalizers on CRs (e.g. `openvox.voxpupuli.org/certificate-cleanup`) can still be processed. The previous order removed the operator first, causing namespace deletion to hang indefinitely.

## Test plan
- [ ] CI e2e-group-gateway passes with the corrected API version
- [ ] e2e-cleanup no longer hangs when tests fail mid-run