### PR TITLE
fix: split E2E workflow into all-groups and single-group triggers

### DIFF
--- a/.github/workflows/e2e-single.yaml
+++ b/.github/workflows/e2e-single.yaml
@@ -1,0 +1,32 @@
+name: E2E (single group)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag for E2E images'
+        required: false
+        type: string
+        default: 'develop'
+      group:
+        description: 'Test group to run'
+        required: true
+        type: choice
+        options:
+          - base
+          - enc
+          - gateway
+          - webhooks-byo
+          - webhooks-cm
+
+concurrency:
+  group: e2e
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    uses: ./.github/workflows/_e2e-run.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      group: ${{ inputs.group }}
+    secrets: inherit

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,22 +8,9 @@ on:
         required: false
         type: string
         default: 'develop'
-      group:
-        description: 'Test group to run'
-        required: false
-        type: choice
-        default: 'all'
-        options:
-          - all
-          - base
-          - enc
-          - gateway
-          - webhooks-byo
-          - webhooks-cm
 
 jobs:
   e2e-base:
-    if: inputs.group == 'all' || inputs.group == 'base'
     uses: ./.github/workflows/_e2e-run.yaml
     with:
       image_tag: ${{ inputs.image_tag }}
@@ -31,7 +18,6 @@ jobs:
     secrets: inherit
 
   e2e-enc:
-    if: inputs.group == 'all' || inputs.group == 'enc'
     needs: [e2e-base]
     uses: ./.github/workflows/_e2e-run.yaml
     with:
@@ -40,7 +26,6 @@ jobs:
     secrets: inherit
 
   e2e-gateway:
-    if: inputs.group == 'all' || inputs.group == 'gateway'
     needs: [e2e-enc]
     uses: ./.github/workflows/_e2e-run.yaml
     with:
@@ -49,7 +34,6 @@ jobs:
     secrets: inherit
 
   e2e-webhooks-byo:
-    if: inputs.group == 'all' || inputs.group == 'webhooks-byo'
     needs: [e2e-gateway]
     uses: ./.github/workflows/_e2e-run.yaml
     with:
@@ -58,7 +42,6 @@ jobs:
     secrets: inherit
 
   e2e-webhooks-cm:
-    if: inputs.group == 'all' || inputs.group == 'webhooks-cm'
     needs: [e2e-webhooks-byo]
     uses: ./.github/workflows/_e2e-run.yaml
     with:


### PR DESCRIPTION
## Summary
- Remove `group` choice input from `e2e.yaml` - it always runs all groups sequentially now (base -> enc -> gateway -> webhooks-byo -> webhooks-cm)
- Add new `e2e-single.yaml` workflow for running a single group via workflow_dispatch, with the same `e2e` concurrency group

GitHub Actions treats skipped jobs (via `if:`) as fulfilled `needs` dependencies. When a single group was selected, preceding groups were skipped but the chain broke: the selected group triggered immediately and all downstream jobs ran too.

## Test plan
- [ ] Trigger `E2E` workflow - all five groups run sequentially
- [ ] Trigger `E2E (single group)` with group=gateway - only gateway runs