### PR TITLE
fix: remove concurrency block from e2e-single to avoid deadlock

### DIFF
--- a/.github/workflows/e2e-single.yaml
+++ b/.github/workflows/e2e-single.yaml
@@ -19,10 +19,6 @@ on:
           - webhooks-byo
           - webhooks-cm
 
-concurrency:
-  group: e2e
-  cancel-in-progress: false
-
 jobs:
   e2e:
     uses: ./.github/workflows/_e2e-run.yaml


### PR DESCRIPTION
## Summary
- Remove the `concurrency` block from `e2e-single.yaml` to fix a deadlock with `_e2e-run.yaml`

The reusable workflow `_e2e-run.yaml` already defines `concurrency: group: e2e`. Having the same group on the caller causes GitHub Actions to deadlock: the parent holds the lock while the child tries to acquire it.

## Test plan
- [ ] Trigger `E2E (single group)` with any group - runs without deadlock