### PR TITLE
fix: include auto-generated dnsAltNames in pool-gateway e2e assertion

### DIFF
--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -89,6 +89,8 @@ spec:
                 name: openvox-stack-gw-ca
               spec:
                 dnsAltNames:
+                  - openvox-stack-gw-ca
+                  - puppet
                   - puppet.e2e.example.com
 
     - name: Verify no TLSRoute for CA pool


### PR DESCRIPTION
## Summary
- Add missing auto-generated dnsAltNames (`openvox-stack-gw-ca`, `puppet`) to the pool-gateway e2e test assertion

The Helm chart template (`certificates.yaml`) auto-generates dnsAltNames from the server name and appends `puppet` when the server name differs. The test only asserted the injected hostname from `injectDNSAltName`, causing a mismatch.

## Test plan
- [x] Verified locally against e2e-openvox cluster - all pool-gateway steps pass