### PR TITLE
fix: robust e2e-cleanup with finalizer handling, remove BYO webhook tests

### DIFF
--- a/.github/workflows/_e2e-run.yaml
+++ b/.github/workflows/_e2e-run.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       group:
-        description: 'Test group to run (base, enc, gateway, webhooks-byo, webhooks-cm)'
+        description: 'Test group to run (base, enc, gateway, webhooks-cm)'
         required: true
         type: string
 

--- a/.github/workflows/e2e-single.yaml
+++ b/.github/workflows/e2e-single.yaml
@@ -16,7 +16,6 @@ on:
           - base
           - enc
           - gateway
-          - webhooks-byo
           - webhooks-cm
 
 jobs:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,16 +33,8 @@ jobs:
       group: gateway
     secrets: inherit
 
-  e2e-webhooks-byo:
-    needs: [e2e-gateway]
-    uses: ./.github/workflows/_e2e-run.yaml
-    with:
-      image_tag: ${{ inputs.image_tag }}
-      group: webhooks-byo
-    secrets: inherit
-
   e2e-webhooks-cm:
-    needs: [e2e-webhooks-byo]
+    needs: [e2e-gateway]
     uses: ./.github/workflows/_e2e-run.yaml
     with:
       image_tag: ${{ inputs.image_tag }}

--- a/Makefile
+++ b/Makefile
@@ -185,8 +185,6 @@ $(CHAINSAW):
 
 E2E_CHAINSAW = IMAGE_TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) $(CHAINSAW) test --config tests/e2e/chainsaw-config.yaml
 
-WEBHOOK_CERT_SECRET ?= openvox-operator-webhook-cert
-WEBHOOK_SAN ?= openvox-operator-webhook.$(NAMESPACE).svc
 
 .PHONY: e2e-setup
 e2e-setup: ## Install all E2E external dependencies (CNPG, Envoy Gateway, cert-manager).
@@ -211,35 +209,30 @@ e2e-wait: ## Wait for E2E dependencies to be available (pre-installed via ArgoCD
 e2e-cleanup: ## Remove operator and all E2E test namespaces (keeps CRDs).
 	@echo "Cleaning up leftover E2E namespaces (operator still running to process finalizers)..."
 	@kubectl get namespaces -o name | grep '^namespace/e2e-' | xargs -r kubectl delete --timeout=120s --ignore-not-found 2>/dev/null || true
+	@# Strip certificate finalizers from any namespaces stuck in Terminating
+	@for ns in $$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do \
+		echo "Namespace $${ns} stuck in Terminating, stripping certificate finalizers..."; \
+		kubectl get certificates.openvox.voxpupuli.org -n "$${ns}" -o name 2>/dev/null \
+			| xargs -r -I{} kubectl patch {} -n "$${ns}" --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true; \
+	done
+	@# Wait for Terminating namespaces to be fully gone
+	@for ns in $$(kubectl get namespaces -o jsonpath='{range .items[?(@.status.phase=="Terminating")]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do \
+		echo "Waiting for namespace $${ns} to terminate..."; \
+		kubectl wait --for=delete namespace/"$${ns}" --timeout=30s 2>/dev/null || true; \
+	done
 	helm uninstall openvox-operator --namespace $(NAMESPACE) --wait 2>/dev/null || true
-	kubectl delete namespace $(NAMESPACE) --ignore-not-found 2>/dev/null || true
+	@# Strip certificate finalizers in operator namespace if stuck
+	@if kubectl get namespace $(NAMESPACE) -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Terminating; then \
+		echo "Namespace $(NAMESPACE) stuck in Terminating, stripping certificate finalizers..."; \
+		kubectl get certificates.openvox.voxpupuli.org -n $(NAMESPACE) -o name 2>/dev/null \
+			| xargs -r -I{} kubectl patch {} -n $(NAMESPACE) --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true; \
+	fi
+	kubectl delete namespace $(NAMESPACE) --ignore-not-found --wait 2>/dev/null || true
 
 .PHONY: e2e-cleanup-full
 e2e-cleanup-full: e2e-cleanup ## Full cleanup including CRDs (use between test groups).
 	@echo "Removing CRDs..."
 	@kubectl get crds -o name | grep 'openvox\.voxpupuli\.org' | xargs -r kubectl delete --ignore-not-found 2>/dev/null || true
-
-.PHONY: e2e-webhook-byo-cert
-e2e-webhook-byo-cert: ## Generate self-signed TLS cert and create webhook Secret.
-	@if kubectl get secret $(WEBHOOK_CERT_SECRET) -n $(NAMESPACE) &>/dev/null; then \
-		echo "Secret $(WEBHOOK_CERT_SECRET) already exists, skipping."; \
-	else \
-		kubectl create namespace $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
-		TMPDIR=$$(mktemp -d); \
-		openssl req -x509 -newkey rsa:2048 -nodes \
-			-keyout "$${TMPDIR}/tls.key" -out "$${TMPDIR}/tls.crt" \
-			-subj "/CN=$(WEBHOOK_SAN)" \
-			-addext "subjectAltName=DNS:$(WEBHOOK_SAN)" \
-			-days 365 2>/dev/null; \
-		cp "$${TMPDIR}/tls.crt" "$${TMPDIR}/ca.crt"; \
-		kubectl create secret generic $(WEBHOOK_CERT_SECRET) \
-			--namespace $(NAMESPACE) \
-			--from-file=tls.crt="$${TMPDIR}/tls.crt" \
-			--from-file=tls.key="$${TMPDIR}/tls.key" \
-			--from-file=ca.crt="$${TMPDIR}/ca.crt"; \
-		rm -rf "$${TMPDIR}"; \
-		echo "Created webhook TLS secret $(WEBHOOK_CERT_SECRET)."; \
-	fi
 
 .PHONY: e2e-operator-base
 e2e-operator-base: e2e-cleanup ## Install operator: webhooks=false, gatewayAPI=false.
@@ -266,24 +259,6 @@ e2e-operator-gateway: e2e-cleanup ## Install operator: webhooks=false, gatewayAP
 		--set resources.limits.memory=null \
 		--set webhook.enabled=false \
 		--set gatewayAPI.enabled=true
-	kubectl wait --for=condition=Available deployment/openvox-operator \
-		-n $(NAMESPACE) --timeout=2m
-
-.PHONY: e2e-operator-webhooks-byo
-e2e-operator-webhooks-byo: e2e-cleanup e2e-webhook-byo-cert ## Install operator: webhooks=true, BYO TLS cert.
-	CA_BUNDLE=$$(kubectl get secret $(WEBHOOK_CERT_SECRET) -n $(NAMESPACE) -o jsonpath='{.data.ca\.crt}') && \
-	helm upgrade --install openvox-operator charts/openvox-operator \
-		--namespace $(NAMESPACE) --create-namespace \
-		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
-		--set image.tag=$(IMAGE_TAG) \
-		--set image.pullPolicy=Always \
-		--set resources.limits.cpu=null \
-		--set resources.limits.memory=null \
-		--set webhook.enabled=true \
-		--set webhook.certManager.enabled=false \
-		--set webhook.tls.certSecret=$(WEBHOOK_CERT_SECRET) \
-		--set webhook.tls.caBundle=$${CA_BUNDLE} \
-		--set gatewayAPI.enabled=false
 	kubectl wait --for=condition=Available deployment/openvox-operator \
 		-n $(NAMESPACE) --timeout=2m
 
@@ -328,15 +303,6 @@ e2e-group-gateway: e2e-operator-gateway chainsaw ## Group: Gateway API TLSRoute 
 		tests/e2e/pool-gateway; \
 	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
-.PHONY: e2e-group-webhooks-byo
-e2e-group-webhooks-byo: e2e-operator-webhooks-byo chainsaw ## Group: webhook tests with BYO TLS cert.
-	$(E2E_CHAINSAW) \
-		tests/e2e/webhook-validation-server \
-		tests/e2e/webhook-validation-config \
-		tests/e2e/webhook-validation-database \
-		tests/e2e/webhook-smoke; \
-	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
-
 .PHONY: e2e-group-webhooks-cm
 e2e-group-webhooks-cm: e2e-operator-webhooks-cm chainsaw ## Group: webhook tests with cert-manager.
 	$(E2E_CHAINSAW) \
@@ -351,7 +317,6 @@ e2e-all: ## Run all E2E test groups sequentially.
 	$(MAKE) e2e-group-base
 	$(MAKE) e2e-group-enc
 	$(MAKE) e2e-group-gateway
-	$(MAKE) e2e-group-webhooks-byo
 	$(MAKE) e2e-group-webhooks-cm
 
 ##@ Help

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -159,7 +159,6 @@ Tests are organized into groups. Each group installs the operator with specific 
 | base | webhook=false, gatewayAPI=false | single-node, multi-server, agent-basic, agent-broken, agent-idempotent, agent-concurrent, agent-report, database-cnpg | `make e2e-group-base` |
 | enc | webhook=false, gatewayAPI=false | agent-enc, agent-full | `make e2e-group-enc` |
 | gateway | webhook=false, gatewayAPI=true | pool-gateway | `make e2e-group-gateway` |
-| webhooks-byo | webhook=true, BYO TLS cert | webhook-validation-server, webhook-validation-config, webhook-validation-database, webhook-smoke | `make e2e-group-webhooks-byo` |
 | webhooks-cm | webhook=true, cert-manager | webhook-validation-server, webhook-validation-config, webhook-validation-database, webhook-smoke | `make e2e-group-webhooks-cm` |
 
 Run all groups sequentially:
@@ -214,15 +213,15 @@ make e2e-all IMAGE_TAG=develop
 
 ### Running in CI
 
-The E2E workflow connects to a persistent K3S cluster via `E2E_KUBECONFIG` secret. External dependencies (CNPG, Envoy Gateway, cert-manager) are managed by ArgoCD on the cluster -- the workflow only verifies they are available before starting tests. Test groups run sequentially: base, enc, gateway, webhooks-byo, webhooks-cm.
+The E2E workflow connects to a persistent K3S cluster via `E2E_KUBECONFIG` secret. External dependencies (CNPG, Envoy Gateway, cert-manager) are managed by ArgoCD on the cluster -- the workflow only verifies they are available before starting tests. Test groups run sequentially: base, enc, gateway, webhooks-cm.
 
 Images are built by the CI workflow on push to develop (`:develop` tag) or manually via `e2e-images.yaml`. The `e2e.yaml` workflow only runs tests against already-pushed images.
 
 Manual trigger with group selection:
 
 ```bash
-gh workflow run e2e.yaml -f group=webhooks-byo -f image_tag=develop
-gh workflow run e2e.yaml -f group=all -f image_tag=develop
+gh workflow run e2e-single.yaml -f group=webhooks-cm -f image_tag=develop
+gh workflow run e2e.yaml -f image_tag=develop
 ```
 
 ### Chainsaw Configuration


### PR DESCRIPTION
## Summary
- Make `e2e-cleanup` handle namespaces stuck in `Terminating` state by stripping `openvox.voxpupuli.org/certificate-cleanup` finalizers from Certificate CRs before uninstalling the operator
- Wait for Terminating namespaces to be fully gone before proceeding
- Remove the entire BYO webhook test group (`e2e-group-webhooks-byo`) and all associated infrastructure (`e2e-webhook-byo-cert`, `e2e-operator-webhooks-byo`, `WEBHOOK_CERT_SECRET`, `WEBHOOK_SAN`)
- cert-manager (`e2e-group-webhooks-cm`) covers the same webhook validation tests without the fragile self-signed cert setup that caused race conditions with namespace lifecycle

Closes #326

## Test plan
- [x] `make e2e-cleanup` works from clean and dirty state
- [x] `make e2e-operator-webhooks-cm` deploys operator successfully
- [ ] Full CI run with all E2E groups