### PR TITLE
feat: add E2E tests and mock server enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,14 +287,19 @@ e2e-group-base: e2e-operator-base chainsaw ## Group: base tests (stack, agent, d
 		tests/e2e/agent-idempotent \
 		tests/e2e/agent-concurrent \
 		tests/e2e/agent-report \
-		tests/e2e/database-cnpg; \
+		tests/e2e/database-cnpg \
+		tests/e2e/readonly-rootfs \
+		tests/e2e/code-pvc \
+		tests/e2e/autosign-policy \
+		tests/e2e/cert-rotation; \
 	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
 .PHONY: e2e-group-enc
 e2e-group-enc: e2e-operator-base chainsaw ## Group: ENC and full agent tests.
 	$(E2E_CHAINSAW) \
 		tests/e2e/agent-enc \
-		tests/e2e/agent-full; \
+		tests/e2e/agent-full \
+		tests/e2e/external-ca; \
 	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
 .PHONY: e2e-group-gateway

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,12 @@ e2e-group-base: e2e-operator-base chainsaw ## Group: base tests (stack, agent, d
 e2e-group-enc: e2e-operator-base chainsaw ## Group: ENC and full agent tests.
 	$(E2E_CHAINSAW) \
 		tests/e2e/agent-enc \
-		tests/e2e/agent-full \
+		tests/e2e/agent-full; \
+	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
+
+.PHONY: e2e-group-ca
+e2e-group-ca: e2e-operator-base chainsaw ## Group: CA tests (external CA).
+	$(E2E_CHAINSAW) \
 		tests/e2e/external-ca; \
 	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
@@ -321,6 +326,7 @@ e2e-group-webhooks-cm: e2e-operator-webhooks-cm chainsaw ## Group: webhook tests
 e2e-all: ## Run all E2E test groups sequentially.
 	$(MAKE) e2e-group-base
 	$(MAKE) e2e-group-enc
+	$(MAKE) e2e-group-ca
 	$(MAKE) e2e-group-gateway
 	$(MAKE) e2e-group-webhooks-cm
 

--- a/charts/openvox-stack/ci/autosign-policy-values.yaml
+++ b/charts/openvox-stack/ci/autosign-policy-values.yaml
@@ -1,0 +1,37 @@
+signingPolicies:
+  - name: preshared-key
+    csrAttributes:
+      - name: pp_preshared_key
+        value: "e2e-correct-key"
+
+config:
+  code:
+    image: ghcr.io/slauger/openvox-e2e-code:latest
+    imagePullPolicy: Always
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+      dnsAltNames:
+        - e2e-autosign-policy-server
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/charts/openvox-stack/ci/cert-rotation-values.yaml
+++ b/charts/openvox-stack/ci/cert-rotation-values.yaml
@@ -1,0 +1,38 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+ca:
+  allowAutoRenewal: true
+
+config:
+  code:
+    image: ghcr.io/slauger/openvox-e2e-code:latest
+    imagePullPolicy: Always
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+      dnsAltNames:
+        - e2e-cert-rotation-server
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/charts/openvox-stack/ci/code-pvc-values.yaml
+++ b/charts/openvox-stack/ci/code-pvc-values.yaml
@@ -1,0 +1,34 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+config:
+  code:
+    claimName: puppet-code
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+      dnsAltNames:
+        - e2e-code-pvc-server
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/charts/openvox-stack/ci/external-ca-stack-a-values.yaml
+++ b/charts/openvox-stack/ci/external-ca-stack-a-values.yaml
@@ -1,0 +1,37 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+config:
+  code:
+    image: ghcr.io/slauger/openvox-e2e-code:latest
+    imagePullPolicy: Always
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+      dnsAltNames:
+        - e2e-ext-ca-a-server
+        - e2e-ext-ca-a-server.e2e-ext-ca-a.svc
+        - e2e-ext-ca-a-server.e2e-ext-ca-a.svc.cluster.local
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/charts/openvox-stack/ci/external-ca-stack-b-values.yaml
+++ b/charts/openvox-stack/ci/external-ca-stack-b-values.yaml
@@ -1,0 +1,37 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+ca:
+  external:
+    url: https://e2e-ext-ca-a-ca-internal.e2e-ext-ca-a.svc:8140
+    caSecretRef: external-ca-cert
+    insecureSkipVerify: true
+
+config:
+  code:
+    image: ghcr.io/slauger/openvox-e2e-code:latest
+    imagePullPolicy: Always
+
+servers:
+  - name: ca
+    ca: false
+    server: true
+    poolRefs: [server]
+    certificate:
+      certname: puppet
+      dnsAltNames:
+        - e2e-ext-ca-b-server
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/charts/openvox-stack/ci/readonly-rootfs-values.yaml
+++ b/charts/openvox-stack/ci/readonly-rootfs-values.yaml
@@ -1,0 +1,36 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+config:
+  readOnlyRootFilesystem: true
+  code:
+    image: ghcr.io/slauger/openvox-e2e-code:latest
+    imagePullPolicy: Always
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+      dnsAltNames:
+        - e2e-readonly-rootfs-server
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -33,6 +33,11 @@ type storedClassification struct {
 	ServedAt time.Time `json:"served_at"`
 }
 
+type storedHECEvent struct {
+	ReceivedAt time.Time       `json:"received_at"`
+	Body       json.RawMessage `json:"body"`
+}
+
 type classificationEntry struct {
 	Classes     []string `yaml:"classes"`
 	Environment string   `yaml:"environment"`
@@ -51,6 +56,7 @@ type server struct {
 	reports         []storedReport
 	pdbCommands     []storedPDBCommand
 	classifications []storedClassification
+	hecEvents       []storedHECEvent
 
 	// Static ENC config (env vars)
 	encClasses     []string
@@ -123,6 +129,9 @@ func newServeMux(s *server) *http.ServeMux {
 	mux.HandleFunc("GET /api/reports", s.handleAPIReports)
 	mux.HandleFunc("GET /api/pdb-commands", s.handleAPIPDBCommands)
 	mux.HandleFunc("GET /api/classifications", s.handleAPIClassifications)
+	mux.HandleFunc("POST /services/collector/event", s.handleHECEvent)
+	mux.HandleFunc("GET /api/hec-events", s.handleAPIHECEvents)
+	mux.HandleFunc("DELETE /api/reset", s.handleAPIReset)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	return mux
 }
@@ -363,6 +372,54 @@ func (s *server) handleAPIClassifications(w http.ResponseWriter, _ *http.Request
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	writeJSON(w, s.classifications)
+}
+
+func (s *server) handleHECEvent(w http.ResponseWriter, r *http.Request) {
+	if !s.checkAuth(w, r) {
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	log.Printf("Received HEC event (%d bytes)", len(body))
+
+	if !json.Valid(body) {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	s.hecEvents = append(s.hecEvents, storedHECEvent{
+		ReceivedAt: time.Now(),
+		Body:       json.RawMessage(body),
+	})
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"text":"Success","code":0}`))
+}
+
+func (s *server) handleAPIHECEvents(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	writeJSON(w, s.hecEvents)
+}
+
+func (s *server) handleAPIReset(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	s.reports = nil
+	s.pdbCommands = nil
+	s.classifications = nil
+	s.hecEvents = nil
+	s.mu.Unlock()
+
+	log.Printf("All stored data cleared")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
 }
 
 func (s *server) handleHealthz(w http.ResponseWriter, _ *http.Request) {

--- a/cmd/mock/main_test.go
+++ b/cmd/mock/main_test.go
@@ -537,6 +537,106 @@ func TestAuth_NoAuthRequired(t *testing.T) {
 	}
 }
 
+func TestHECEvent_Store(t *testing.T) {
+	ts, _ := newTestServer()
+	defer ts.Close()
+
+	event := `{"event":"test event","sourcetype":"puppet:summary"}`
+	resp, err := http.Post(ts.URL+"/services/collector/event", "application/json", strings.NewReader(event))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), `"code":0`) {
+		t.Errorf("expected success response, got: %s", string(body))
+	}
+
+	// Verify stored event
+	resp, err = http.Get(ts.URL + "/api/hec-events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var events []struct {
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(events[0].Body, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["event"] != "test event" {
+		t.Errorf("event = %v", parsed["event"])
+	}
+}
+
+func TestHECEvent_InvalidJSON(t *testing.T) {
+	ts, _ := newTestServer()
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/services/collector/event", "application/json", strings.NewReader("not json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestAPIReset(t *testing.T) {
+	ts, _ := newTestServer()
+	defer ts.Close()
+
+	// Store some data
+	http.Post(ts.URL+"/reports", "application/json", strings.NewReader(`{"host":"test"}`))
+	http.Post(ts.URL+"/services/collector/event", "application/json", strings.NewReader(`{"event":"test"}`))
+	cmd := `{"command":"replace facts","version":5,"payload":{"certname":"node1"}}`
+	http.Post(ts.URL+"/pdb/cmd/v1", "application/json", strings.NewReader(cmd))
+	http.Get(ts.URL + "/node/test-node")
+
+	// Reset
+	req, _ := http.NewRequest("DELETE", ts.URL+"/api/reset", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("reset status = %d, want 200", resp.StatusCode)
+	}
+
+	// Verify all data is cleared
+	for _, endpoint := range []string{"/api/reports", "/api/pdb-commands", "/api/classifications", "/api/hec-events"} {
+		resp, err := http.Get(ts.URL + endpoint)
+		if err != nil {
+			t.Fatalf("GET %s: %v", endpoint, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if string(body) != "null\n" {
+			t.Errorf("GET %s after reset: expected null, got %s", endpoint, string(body))
+		}
+	}
+}
+
 func TestAuth_APIEndpointsSkipAuth(t *testing.T) {
 	ts, _ := newTestServer(func(s *server) {
 		s.auth = authConfig{authType: "bearer", authToken: "secret"}
@@ -544,7 +644,7 @@ func TestAuth_APIEndpointsSkipAuth(t *testing.T) {
 	defer ts.Close()
 
 	// API endpoints should not require auth
-	for _, path := range []string{"/api/reports", "/api/pdb-commands", "/api/classifications", "/healthz"} {
+	for _, path := range []string{"/api/reports", "/api/pdb-commands", "/api/classifications", "/api/hec-events", "/healthz"} {
 		resp, err := http.Get(ts.URL + path)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)

--- a/cmd/mock/main_test.go
+++ b/cmd/mock/main_test.go
@@ -604,11 +604,11 @@ func TestAPIReset(t *testing.T) {
 	defer ts.Close()
 
 	// Store some data
-	http.Post(ts.URL+"/reports", "application/json", strings.NewReader(`{"host":"test"}`))
-	http.Post(ts.URL+"/services/collector/event", "application/json", strings.NewReader(`{"event":"test"}`))
+	_, _ = http.Post(ts.URL+"/reports", "application/json", strings.NewReader(`{"host":"test"}`))
+	_, _ = http.Post(ts.URL+"/services/collector/event", "application/json", strings.NewReader(`{"event":"test"}`))
 	cmd := `{"command":"replace facts","version":5,"payload":{"certname":"node1"}}`
-	http.Post(ts.URL+"/pdb/cmd/v1", "application/json", strings.NewReader(cmd))
-	http.Get(ts.URL + "/node/test-node")
+	_, _ = http.Post(ts.URL+"/pdb/cmd/v1", "application/json", strings.NewReader(cmd))
+	_, _ = http.Get(ts.URL + "/node/test-node")
 
 	// Reset
 	req, _ := http.NewRequest("DELETE", ts.URL+"/api/reset", nil)

--- a/tests/e2e/autosign-policy/chainsaw-test.yaml
+++ b/tests/e2e/autosign-policy/chainsaw-test.yaml
@@ -1,0 +1,131 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: autosign-policy
+spec:
+  namespace: e2e-autosign-policy
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Install openvox-stack
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-autosign-policy "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-autosign-policy --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/autosign-policy-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-autosign-policy-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Run Puppet agent with matching CSR attribute (expect success)
+      try:
+        - apply:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: puppet-agent-match
+                namespace: e2e-autosign-policy
+              spec:
+                backoffLimit: 0
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: puppet-agent
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        imagePullPolicy: Always
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            mkdir -p /etc/puppetlabs/puppet
+                            cat > /etc/puppetlabs/puppet/csr_attributes.yaml << 'CSRATTR'
+                            extension_requests:
+                              pp_preshared_key: e2e-correct-key
+                            CSRATTR
+                            puppet agent --test \
+                              --server e2e-autosign-policy-server \
+                              --waitforcert 30 \
+                              --certname agent-match-test;
+                            EXIT=$?;
+                            if [ $EXIT -eq 0 ] || [ $EXIT -eq 2 ]; then exit 0; else exit $EXIT; fi
+                        securityContext:
+                          runAsUser: 0
+        - script:
+            timeout: 5m
+            content: |
+              kubectl wait --for=condition=Complete job/puppet-agent-match \
+                -n e2e-autosign-policy --timeout=300s
+
+    - name: Run Puppet agent with wrong CSR attribute (expect failure)
+      try:
+        - apply:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: puppet-agent-nomatch
+                namespace: e2e-autosign-policy
+              spec:
+                activeDeadlineSeconds: 90
+                backoffLimit: 0
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: puppet-agent
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        imagePullPolicy: Always
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            mkdir -p /etc/puppetlabs/puppet
+                            cat > /etc/puppetlabs/puppet/csr_attributes.yaml << 'CSRATTR'
+                            extension_requests:
+                              pp_preshared_key: wrong-key
+                            CSRATTR
+                            puppet agent --test \
+                              --server e2e-autosign-policy-server \
+                              --waitforcert 5 \
+                              --certname agent-nomatch-test;
+                            EXIT=$?;
+                            if [ $EXIT -eq 0 ] || [ $EXIT -eq 2 ]; then exit 0; else exit $EXIT; fi
+                        securityContext:
+                          runAsUser: 0
+        - script:
+            timeout: 3m
+            content: |
+              kubectl wait --for=condition=Failed job/puppet-agent-nomatch \
+                -n e2e-autosign-policy --timeout=120s
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              kubectl logs -n e2e-autosign-policy job/puppet-agent-match || true
+              kubectl logs -n e2e-autosign-policy job/puppet-agent-nomatch || true
+              helm uninstall e2e-autosign-policy --namespace e2e-autosign-policy --wait 2>/dev/null || true
+              kubectl delete namespace e2e-autosign-policy --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/cert-rotation/chainsaw-test.yaml
+++ b/tests/e2e/cert-rotation/chainsaw-test.yaml
@@ -1,0 +1,139 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cert-rotation
+spec:
+  namespace: e2e-cert-rotation
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Install openvox-stack
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-cert-rotation "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-cert-rotation --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/cert-rotation-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-cert-rotation-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Assert Certificate is Signed
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Certificate
+              metadata:
+                name: e2e-cert-rotation-ca
+              status:
+                phase: Signed
+
+    - name: Record original cert serial and trigger rotation
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              SECRET_NAME=$(kubectl get certificate.openvox.voxpupuli.org e2e-cert-rotation-ca \
+                -n e2e-cert-rotation -o jsonpath='{.status.secretName}')
+              SERIAL=$(kubectl get secret "${SECRET_NAME}" -n e2e-cert-rotation \
+                -o jsonpath='{.data.cert\.pem}' | base64 -d | openssl x509 -noout -serial)
+              echo "Original cert serial: ${SERIAL}"
+              echo "${SERIAL}" > /tmp/e2e-cert-rotation-original-serial
+        - script:
+            timeout: 30s
+            content: |
+              kubectl patch certificate.openvox.voxpupuli.org e2e-cert-rotation-ca \
+                -n e2e-cert-rotation \
+                --type=merge -p '{"spec":{"renewBefore":"99999d"}}'
+
+    - name: Wait for Certificate renewal to complete
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              echo "Waiting for Certificate to enter Renewing phase..."
+              for i in $(seq 1 60); do
+                PHASE=$(kubectl get certificate.openvox.voxpupuli.org e2e-cert-rotation-ca \
+                  -n e2e-cert-rotation -o jsonpath='{.status.phase}' 2>/dev/null)
+                if [ "${PHASE}" = "Renewing" ]; then
+                  echo "Certificate entered Renewing phase"
+                  break
+                fi
+                sleep 2
+              done
+              echo "Waiting for Certificate to return to Signed phase..."
+              for i in $(seq 1 60); do
+                PHASE=$(kubectl get certificate.openvox.voxpupuli.org e2e-cert-rotation-ca \
+                  -n e2e-cert-rotation -o jsonpath='{.status.phase}' 2>/dev/null)
+                if [ "${PHASE}" = "Signed" ]; then
+                  echo "Certificate is Signed again"
+                  break
+                fi
+                sleep 2
+              done
+              if [ "${PHASE}" != "Signed" ]; then
+                echo "ERROR: Certificate did not return to Signed phase (current: ${PHASE})"
+                exit 1
+              fi
+
+    - name: Verify cert serial changed
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              SECRET_NAME=$(kubectl get certificate.openvox.voxpupuli.org e2e-cert-rotation-ca \
+                -n e2e-cert-rotation -o jsonpath='{.status.secretName}')
+              NEW_SERIAL=$(kubectl get secret "${SECRET_NAME}" -n e2e-cert-rotation \
+                -o jsonpath='{.data.cert\.pem}' | base64 -d | openssl x509 -noout -serial)
+              ORIGINAL_SERIAL=$(cat /tmp/e2e-cert-rotation-original-serial)
+              echo "Original serial: ${ORIGINAL_SERIAL}"
+              echo "New serial:      ${NEW_SERIAL}"
+              if [ "${NEW_SERIAL}" = "${ORIGINAL_SERIAL}" ]; then
+                echo "ERROR: Certificate serial did not change after rotation"
+                exit 1
+              fi
+              echo "Certificate was successfully rotated"
+
+    - name: Assert Server still Running after rotation
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-cert-rotation-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              rm -f /tmp/e2e-cert-rotation-original-serial
+              helm uninstall e2e-cert-rotation --namespace e2e-cert-rotation --wait 2>/dev/null || true
+              kubectl delete namespace e2e-cert-rotation --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/code-pvc/chainsaw-test.yaml
+++ b/tests/e2e/code-pvc/chainsaw-test.yaml
@@ -1,0 +1,140 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: code-pvc
+spec:
+  namespace: e2e-code-pvc
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Create PVC and populate with Puppet code
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: puppet-code
+                namespace: e2e-code-pvc
+              spec:
+                accessModes: [ReadWriteOnce]
+                resources:
+                  requests:
+                    storage: 64Mi
+        - apply:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: init-code
+                namespace: e2e-code-pvc
+              spec:
+                backoffLimit: 0
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: init
+                        image: busybox:1.37
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            mkdir -p /code/production/manifests
+                            cat > /code/production/manifests/site.pp << 'SITEPP'
+                            node default {
+                              notify { 'code-pvc-test': message => 'Hello from PVC code' }
+                            }
+                            SITEPP
+                            cat > /code/production/environment.conf << 'ENVCONF'
+                            modulepath = modules:$basemodulepath
+                            manifest = manifests/site.pp
+                            ENVCONF
+                            echo "PVC code initialized"
+                            ls -laR /code/
+                        volumeMounts:
+                          - name: code
+                            mountPath: /code
+                    volumes:
+                      - name: code
+                        persistentVolumeClaim:
+                          claimName: puppet-code
+        - script:
+            timeout: 2m
+            content: |
+              kubectl wait --for=condition=Complete job/init-code \
+                -n e2e-code-pvc --timeout=120s
+
+    - name: Install openvox-stack with PVC code
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-code-pvc "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-code-pvc --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/code-pvc-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-code-pvc-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Run Puppet agent
+      try:
+        - apply:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: puppet-agent-code-pvc
+                namespace: e2e-code-pvc
+              spec:
+                backoffLimit: 0
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: puppet-agent
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        imagePullPolicy: Always
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            puppet agent --test \
+                              --server e2e-code-pvc-server \
+                              --waitforcert 30 \
+                              --certname agent-code-pvc-test;
+                            EXIT=$?;
+                            if [ $EXIT -eq 0 ] || [ $EXIT -eq 2 ]; then exit 0; else exit $EXIT; fi
+                        securityContext:
+                          runAsUser: 0
+        - script:
+            timeout: 5m
+            content: |
+              kubectl wait --for=condition=Complete job/puppet-agent-code-pvc \
+                -n e2e-code-pvc --timeout=300s
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              kubectl logs -n e2e-code-pvc job/puppet-agent-code-pvc || true
+              helm uninstall e2e-code-pvc --namespace e2e-code-pvc --wait 2>/dev/null || true
+              kubectl delete namespace e2e-code-pvc --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/external-ca/chainsaw-test.yaml
+++ b/tests/e2e/external-ca/chainsaw-test.yaml
@@ -1,0 +1,155 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: external-ca
+spec:
+  namespace: e2e-ext-ca-a
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Install Stack A (CA provider)
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-ext-ca-a "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-ext-ca-a --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/external-ca-stack-a-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
+      catch:
+        - events: {}
+
+    - name: Assert Stack A CA is Ready
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: CertificateAuthority
+              metadata:
+                name: e2e-ext-ca-a-ca
+              status:
+                phase: Ready
+
+    - name: Assert Stack A Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-ext-ca-a-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Copy CA Secret to Stack B namespace
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl create namespace e2e-ext-ca-b --dry-run=client -o yaml | kubectl apply -f -
+              CA_SECRET_NAME=$(kubectl get certificateauthority e2e-ext-ca-a-ca \
+                -n e2e-ext-ca-a -o jsonpath='{.status.caSecretName}')
+              echo "CA Secret: ${CA_SECRET_NAME}"
+              kubectl get secret "${CA_SECRET_NAME}" -n e2e-ext-ca-a -o json \
+                | jq 'del(.metadata.namespace,.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp,.metadata.ownerReferences)' \
+                | jq '.metadata.name = "external-ca-cert"' \
+                | kubectl apply -n e2e-ext-ca-b -f -
+
+    - name: Install Stack B (external CA consumer)
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-ext-ca-b "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-ext-ca-b \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/external-ca-stack-b-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
+      catch:
+        - events: {}
+
+    - name: Assert Stack B CA phase is External
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: CertificateAuthority
+              metadata:
+                name: e2e-ext-ca-b-ca
+                namespace: e2e-ext-ca-b
+              status:
+                phase: External
+
+    - name: Assert Stack B Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-ext-ca-b-ca
+                namespace: e2e-ext-ca-b
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Run Puppet agent against Stack B server
+      try:
+        - apply:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: puppet-agent-ext-ca
+                namespace: e2e-ext-ca-b
+              spec:
+                backoffLimit: 0
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: puppet-agent
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        imagePullPolicy: Always
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            puppet agent --test \
+                              --server e2e-ext-ca-b-server \
+                              --waitforcert 30 \
+                              --certname agent-ext-ca-test;
+                            EXIT=$?;
+                            if [ $EXIT -eq 0 ] || [ $EXIT -eq 2 ]; then exit 0; else exit $EXIT; fi
+                        securityContext:
+                          runAsUser: 0
+        - script:
+            timeout: 5m
+            content: |
+              kubectl wait --for=condition=Complete job/puppet-agent-ext-ca \
+                -n e2e-ext-ca-b --timeout=300s
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              kubectl logs -n e2e-ext-ca-b job/puppet-agent-ext-ca || true
+              helm uninstall e2e-ext-ca-b --namespace e2e-ext-ca-b --wait 2>/dev/null || true
+              helm uninstall e2e-ext-ca-a --namespace e2e-ext-ca-a --wait 2>/dev/null || true
+              kubectl delete namespace e2e-ext-ca-b --ignore-not-found 2>/dev/null || true
+              kubectl delete namespace e2e-ext-ca-a --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/readonly-rootfs/chainsaw-test.yaml
+++ b/tests/e2e/readonly-rootfs/chainsaw-test.yaml
@@ -1,0 +1,98 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: readonly-rootfs
+spec:
+  namespace: e2e-readonly-rootfs
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Install openvox-stack
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-readonly-rootfs "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-readonly-rootfs --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/readonly-rootfs-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always \
+                --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-readonly-rootfs-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Verify readOnlyRootFilesystem is set on pod
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              READONLY=$(kubectl get pods -n e2e-readonly-rootfs \
+                -l openvox.voxpupuli.org/server=e2e-readonly-rootfs-ca \
+                -o jsonpath='{.items[0].spec.containers[0].securityContext.readOnlyRootFilesystem}')
+              echo "readOnlyRootFilesystem=${READONLY}"
+              if [ "${READONLY}" != "true" ]; then
+                echo "ERROR: readOnlyRootFilesystem is not true"
+                exit 1
+              fi
+
+    - name: Run Puppet agent
+      try:
+        - apply:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: puppet-agent-readonly
+                namespace: e2e-readonly-rootfs
+              spec:
+                backoffLimit: 0
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: puppet-agent
+                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        imagePullPolicy: Always
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            puppet agent --test \
+                              --server e2e-readonly-rootfs-server \
+                              --waitforcert 30 \
+                              --certname agent-readonly-test;
+                            EXIT=$?;
+                            if [ $EXIT -eq 0 ] || [ $EXIT -eq 2 ]; then exit 0; else exit $EXIT; fi
+                        securityContext:
+                          runAsUser: 0
+        - script:
+            timeout: 5m
+            content: |
+              kubectl wait --for=condition=Complete job/puppet-agent-readonly \
+                -n e2e-readonly-rootfs --timeout=300s
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              kubectl logs -n e2e-readonly-rootfs job/puppet-agent-readonly || true
+              helm uninstall e2e-readonly-rootfs --namespace e2e-readonly-rootfs --wait 2>/dev/null || true
+              kubectl delete namespace e2e-readonly-rootfs --ignore-not-found 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add 5 new E2E tests covering previously untested features: readonly-rootfs, code-pvc, autosign-policy, cert-rotation, external-ca
- Enhance mock server with Splunk HEC endpoint and data reset capability
- Add new tests to Makefile e2e-group-base and e2e-group-enc

## New E2E Tests

| Test | Feature | Group |
|------|---------|-------|
| readonly-rootfs | `readOnlyRootFilesystem` security hardening (#97) | base |
| code-pvc | PVC-based Puppet code via `config.code.claimName` (#246) | base |
| autosign-policy | CSR attribute-based signing policy (#246) | base |
| cert-rotation | Certificate renewal via `renewBefore` patch (#246) | base |
| external-ca | Cross-namespace external CA with two stacks (#244) | enc |

## Mock Server Enhancements (#59)

- `POST /services/collector/event` - Splunk HEC event ingestion
- `GET /api/hec-events` - Query stored HEC events
- `DELETE /api/reset` - Clear all stored data
- Unit tests for all new endpoints

## Test plan

- [ ] `go test ./cmd/mock/...` passes locally
- [ ] `helm template` renders correctly for all new values files
- [ ] CI runs E2E test groups after merge