### PR TITLE
feat: upgrade JDK from 17 to 21

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -240,7 +240,7 @@ The operator uses a minimal container image:
 
 **Included:**
 
-- UBI9 + JDK 17
+- UBI9 + JDK 21
 - Tarball installation (puppet-server-release.jar, CLI tools, vendored JRuby gems)
 - OpenVox DB termini
 - OpenShift random-UID pattern (chgrp 0, chmod g=u)

--- a/images/openvox-db/Containerfile
+++ b/images/openvox-db/Containerfile
@@ -16,7 +16,7 @@ ARG OPENVOXDB_VERSION=8.12.1
 ################################################################################
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1776645994 AS base
 
-ARG JDK_VERSION=17
+ARG JDK_VERSION=21
 
 RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
         java-${JDK_VERSION}-openjdk-headless \

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -19,7 +19,7 @@ ARG OPENVOX_VERSION=8.26.2
 ################################################################################
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1776645994 AS base
 
-ARG JDK_VERSION=17
+ARG JDK_VERSION=21
 
 RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
         java-${JDK_VERSION}-openjdk-headless \


### PR DESCRIPTION
## Summary

- Upgrade JDK from 17 to 21 in both openvox-server and openvox-db Containerfiles
- Update architecture docs to reflect JDK 21

Both openvox-server and openvoxdb are tested against JDK 21 in upstream CI. The official `container-openvoxserver` community image already uses JDK 21 via Ubuntu 24.04 package dependencies. On newer platforms (EL 10, Debian 13, Ubuntu 20.04+) JDK 21 is the default in upstream packaging.

## Test plan

- [ ] Build openvox-server image with JDK 21
- [ ] Build openvox-db image with JDK 21
- [ ] Run e2e tests to verify both services start and operate correctly