### PR TITLE
fix: prevent reconcile loop that blocked certificate renewal

### DIFF
--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -164,7 +164,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
 
-	// Handle renewal phase before anything else — a Renewing cert must not
+	// Handle renewal phase before anything else - a Renewing cert must not
 	// be overridden by the adopt-existing-secret block below.
 	if cert.Status.Phase == openvoxv1alpha1.CertificatePhaseRenewing {
 		return r.reconcileCertRenewal(ctx, cert, ca)

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -164,6 +164,22 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
 
+	// Handle renewal phase before anything else — a Renewing cert must not
+	// be overridden by the adopt-existing-secret block below.
+	if cert.Status.Phase == openvoxv1alpha1.CertificatePhaseRenewing {
+		return r.reconcileCertRenewal(ctx, cert, ca)
+	}
+
+	// If the certificate is already signed, just schedule renewal checks.
+	// This avoids re-adopting the TLS Secret on every reconcile, which would
+	// reset the phase and prevent entering the Renewing state.
+	if cert.Status.Phase == openvoxv1alpha1.CertificatePhaseSigned {
+		if cert.Status.NotAfter == nil {
+			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
+		}
+		return r.scheduleRenewalCheck(ctx, cert)
+	}
+
 	// Check if TLS Secret already exists (may have been created by CA setup job)
 	if isSecretReady(ctx, r.Client, tlsSecretName, cert.Namespace, "cert.pem") {
 		if err := r.adoptTLSSecret(ctx, cert, tlsSecretName); err != nil {
@@ -190,11 +206,6 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
 		return r.scheduleRenewalCheck(ctx, cert)
-	}
-
-	// Handle renewal phase
-	if cert.Status.Phase == openvoxv1alpha1.CertificatePhaseRenewing {
-		return r.reconcileCertRenewal(ctx, cert, ca)
 	}
 
 	// Sign certificate via CA HTTP API

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -235,6 +235,36 @@ func TestCertReconcile_RenewalTriggered(t *testing.T) {
 	}
 }
 
+func TestCertReconcile_RenewingPhaseNotOverriddenByAdopt(t *testing.T) {
+	// Regression test: a cert already in Renewing phase must not be reset to
+	// Signed by the adopt-existing-secret block on the next reconcile.
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 30*24*time.Hour)
+
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRenewing)
+	cert.Status.NotAfter = parseCertNotAfter(testCtx(), certPEM)
+	cert.Status.SecretName = "my-cert-tls"
+	ca := newCertificateAuthority("test-ca")
+	tlsSecret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	c := setupTestClient(cert, ca, tlsSecret)
+	r := newCertificateReconciler(c)
+
+	// Reconcile should enter reconcileCertRenewal, not the adopt block.
+	// It will fail (no actual CA server) but must NOT reset the phase to Signed.
+	_, _ = r.Reconcile(testCtx(), testRequest("my-cert"))
+
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseRenewing {
+		t.Errorf("expected phase %q to be preserved, got %q", openvoxv1alpha1.CertificatePhaseRenewing, updated.Status.Phase)
+	}
+}
+
 func TestCertReconcile_SignedCertNoRequeue_BecomesRequeue(t *testing.T) {
 	// Verify that a signed cert with valid NotAfter now returns RequeueAfter > 0
 	// (the old behavior was ctrl.Result{} with no requeue)


### PR DESCRIPTION
## Summary

- Fix reconcile ordering bug where the adopt-existing-secret block ran before the Renewing phase handler, resetting the phase to `Signed` on every reconcile and preventing `reconcileCertRenewal` from ever executing
- Certificates in `Renewing` or `Signed` phase now skip secret re-adoption and go directly to their respective handlers
- Add regression test `TestCertReconcile_RenewingPhaseNotOverriddenByAdopt`

## Root Cause

The `Reconcile` function checked for an existing TLS Secret (line 168) **before** checking the certificate phase (line 196). When `renewBefore` triggered a renewal, the flow was:

1. `scheduleRenewalCheck` sets phase to `Renewing`, requeues after 1s
2. Next reconcile: TLS Secret still exists → adopt block sets phase back to `Signed`
3. `scheduleRenewalCheck` sets phase to `Renewing` again → infinite loop

The actual renewal code (`reconcileCertRenewal`) was unreachable because the adopt block always ran first.

## Test plan

- [x] All existing unit tests pass (130+)
- [x] New regression test verifies `Renewing` phase is preserved across reconciles
- [ ] E2E `cert-rotation` test should now pass (certificate actually gets renewed)

Fixes #334