### PR TITLE
fix: add emptyDir volumes for puppet vardir and rundir

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -138,6 +138,8 @@ Server pods can optionally use `readOnlyRootFilesystem: true` for security harde
 | `logback-xml` | ConfigMap | `.../puppetserver/logback.xml` | Yes | Logging configuration |
 | `metrics-conf` | ConfigMap | `.../conf.d/metrics.conf` | Yes | Metrics endpoint configuration |
 | `puppetserver-data` | emptyDir | `/run/puppetserver` | No | Server runtime data (`server-var-dir`) |
+| `puppet-cache` | emptyDir | `/opt/puppetlabs/puppet/cache` | No | Puppet vardir (facts, state, lib) |
+| `puppet-run` | emptyDir | `/var/run/puppetlabs` | No | Puppet rundir (PID files) |
 | `tmp` | emptyDir | `/tmp` | No | Temporary files |
 | `var-log` | emptyDir | `/var/log/puppetlabs` | No | Server logs |
 

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -172,6 +172,8 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 		{Name: "logback-xml", MountPath: "/etc/puppetlabs/puppetserver/logback.xml", SubPath: "logback.xml", ReadOnly: true},
 		{Name: "metrics-conf", MountPath: "/etc/puppetlabs/puppetserver/conf.d/metrics.conf", SubPath: "metrics.conf", ReadOnly: true},
 		{Name: "puppetserver-data", MountPath: "/run/puppetserver"},
+		{Name: "puppet-cache", MountPath: "/opt/puppetlabs/puppet/cache"},
+		{Name: "puppet-run", MountPath: "/var/run/puppetlabs"},
 		{Name: "tmp", MountPath: "/tmp"},
 		{Name: "var-log", MountPath: "/var/log/puppetlabs"},
 	}
@@ -184,6 +186,8 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 	volumes := []corev1.Volume{
 		{Name: "ssl", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: "puppetserver-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "puppet-cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: "puppet-run", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: "var-log", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{


### PR DESCRIPTION
## Summary
- Add emptyDir volumes for `/opt/puppetlabs/puppet/cache` (puppet vardir) and `/var/run/puppetlabs` (puppet rundir)
- Fixes the `readonly-rootfs` E2E test: with `readOnlyRootFilesystem: true` the server pod could not write to these paths and crashed before reaching Running phase
- `puppet.conf` references both paths (`vardir`, `rundir`), but they had no emptyDir backing, unlike `/run/puppetserver`, `/tmp`, and `/var/log/puppetlabs` which were already covered

## Test plan
- [x] Unit tests pass (`go test ./internal/controller/`)
- [x] Helm unit tests pass (`helm unittest`)
- [ ] E2E `readonly-rootfs` test passes in CI