### PR TITLE
fix: reduce activeDeadlineSeconds for autosign-policy nomatch job

### DIFF
--- a/tests/e2e/autosign-policy/chainsaw-test.yaml
+++ b/tests/e2e/autosign-policy/chainsaw-test.yaml
@@ -91,7 +91,7 @@ spec:
                 name: puppet-agent-nomatch
                 namespace: e2e-autosign-policy
               spec:
-                activeDeadlineSeconds: 90
+                activeDeadlineSeconds: 60
                 backoffLimit: 0
                 template:
                   spec:

--- a/tests/e2e/autosign-policy/chainsaw-test.yaml
+++ b/tests/e2e/autosign-policy/chainsaw-test.yaml
@@ -119,7 +119,7 @@ spec:
         - script:
             timeout: 3m
             content: |
-              kubectl wait --for=condition=Failed job/puppet-agent-nomatch \
+              kubectl wait --for=jsonpath='{.status.failed}'=1 job/puppet-agent-nomatch \
                 -n e2e-autosign-policy --timeout=120s
       finally:
         - script:


### PR DESCRIPTION
## Summary
- Reduce `activeDeadlineSeconds` from 90s to 60s for the `puppet-agent-nomatch` job in the autosign-policy E2E test
- Switch from `kubectl wait --for=condition=Failed` to `--for=jsonpath='{.status.failed}'=1` which is set immediately when the pod exits, avoiding condition propagation delays
- The `kubectl wait --timeout=120s` remains unchanged, giving 60s of headroom (was 30s) for image pull and scheduling overhead

Closes #338