### PR TITLE
test: improve Go test coverage across all packages

### DIFF
--- a/cmd/autosign/policy_test.go
+++ b/cmd/autosign/policy_test.go
@@ -421,3 +421,22 @@ func TestPuppetOIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeExtensionValue_RawFallback(t *testing.T) {
+	// Extension value that is not valid ASN.1 UTF8String triggers raw fallback
+	ext := pkix.Extension{
+		Id:    puppet.PuppetOIDs["pp_uuid"],
+		Value: []byte("raw-value"),
+	}
+	val := decodeExtensionValue(ext)
+	if val != "raw-value" {
+		t.Errorf("expected raw fallback %q, got %q", "raw-value", val)
+	}
+}
+
+func TestGlobMatch_InvalidPattern(t *testing.T) {
+	// filepath.Match returns error for patterns with unclosed bracket
+	if globMatch("[invalid", "test") {
+		t.Error("expected false for invalid glob pattern")
+	}
+}

--- a/cmd/enc/classifier_test.go
+++ b/cmd/enc/classifier_test.go
@@ -1,13 +1,21 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -549,5 +557,211 @@ func TestBuildHTTPClient_WithCA(t *testing.T) {
 	_, err := buildHTTPClient(cfg)
 	if err == nil {
 		t.Fatal("expected error for missing CA file")
+	}
+}
+
+func TestBuildHTTPClient_WithValidCA(t *testing.T) {
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.pem")
+
+	// Generate a self-signed CA certificate
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	if err := os.WriteFile(caFile, caPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &ENCConfig{
+		TimeoutSeconds: 5,
+		SSL:            SSLConfig{CAFile: caFile},
+	}
+
+	client, err := buildHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("buildHTTPClient: %v", err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Error("expected RootCAs to be set")
+	}
+}
+
+func TestBuildHTTPClient_InvalidCAPEM(t *testing.T) {
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "bad-ca.pem")
+	if err := os.WriteFile(caFile, []byte("not a cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &ENCConfig{
+		TimeoutSeconds: 5,
+		SSL:            SSLConfig{CAFile: caFile},
+	}
+
+	_, err := buildHTTPClient(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid CA PEM")
+	}
+}
+
+func TestBuildHTTPClient_MTLS(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate CA
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, _ := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+
+	// Generate client cert signed by CA
+	clientKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	clientDER, _ := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+
+	certFile := filepath.Join(dir, "client.pem")
+	keyFile := filepath.Join(dir, "client-key.pem")
+	caFile := filepath.Join(dir, "ca.pem")
+
+	os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0644)
+	os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}), 0644)
+
+	keyBytes, _ := x509.MarshalECPrivateKey(clientKey)
+	os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0644)
+
+	cfg := &ENCConfig{
+		TimeoutSeconds: 5,
+		Auth:           AuthConfig{Type: "mtls"},
+		SSL: SSLConfig{
+			CAFile:   caFile,
+			CertFile: certFile,
+			KeyFile:  keyFile,
+		},
+	}
+
+	client, err := buildHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("buildHTTPClient: %v", err)
+	}
+	transport := client.Transport.(*http.Transport)
+	if len(transport.TLSClientConfig.Certificates) != 1 {
+		t.Errorf("expected 1 client certificate, got %d", len(transport.TLSClientConfig.Certificates))
+	}
+}
+
+func TestBuildHTTPClient_MTLS_InvalidKeyPair(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+
+	os.WriteFile(certFile, []byte("not a cert"), 0644)
+	os.WriteFile(keyFile, []byte("not a key"), 0644)
+
+	cfg := &ENCConfig{
+		TimeoutSeconds: 5,
+		Auth:           AuthConfig{Type: "mtls"},
+		SSL: SSLConfig{
+			CertFile: certFile,
+			KeyFile:  keyFile,
+		},
+	}
+
+	_, err := buildHTTPClient(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid client cert/key")
+	}
+}
+
+func TestLoadFacts(t *testing.T) {
+	// loadFacts reads from a hardcoded path, so we test the fallback behavior
+	// when the file doesn't exist (returns empty map)
+	facts := loadFacts("nonexistent-node")
+	if facts == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if len(facts) != 0 {
+		t.Errorf("expected empty facts, got %d entries", len(facts))
+	}
+}
+
+func TestBuildRequestBody_Facts(t *testing.T) {
+	// "facts" body type calls loadFacts, which will return empty map for
+	// non-existent nodes, but the JSON structure should be correct
+	body, err := buildRequestBody("facts", "test-node")
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &data); err != nil {
+		t.Fatalf("parsing body: %v", err)
+	}
+	if data["certname"] != "test-node" {
+		t.Errorf("certname = %v", data["certname"])
+	}
+	if _, ok := data["facts"]; !ok {
+		t.Error("expected 'facts' key in body")
+	}
+}
+
+func TestNotFoundError(t *testing.T) {
+	err := &notFoundError{msg: "HTTP 404: https://example.com/node/test"}
+	if err.Error() != "HTTP 404: https://example.com/node/test" {
+		t.Errorf("Error() = %q", err.Error())
+	}
+}
+
+func TestNormalizeResponse_InvalidJSON(t *testing.T) {
+	_, err := normalizeResponse([]byte("{invalid json"), "json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestNormalizeResponse_InvalidYAML(t *testing.T) {
+	_, err := normalizeResponse([]byte(":\n  :\n    - :\n  invalid"), "yaml")
+	// YAML parser is lenient, so this may or may not error; just ensure no panic
+	_ = err
+}
+
+func TestLoadENCConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enc.yaml")
+	os.WriteFile(path, []byte(":\n\t- invalid yaml\x00"), 0644)
+
+	_, err := loadENCConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
 	}
 }

--- a/cmd/enc/classifier_test.go
+++ b/cmd/enc/classifier_test.go
@@ -654,11 +654,17 @@ func TestBuildHTTPClient_MTLS(t *testing.T) {
 	keyFile := filepath.Join(dir, "client-key.pem")
 	caFile := filepath.Join(dir, "ca.pem")
 
-	os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0644)
-	os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}), 0644)
+	if err := os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	keyBytes, _ := x509.MarshalECPrivateKey(clientKey)
-	os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0644)
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	cfg := &ENCConfig{
 		TimeoutSeconds: 5,

--- a/cmd/enc/classifier_test.go
+++ b/cmd/enc/classifier_test.go
@@ -691,8 +691,12 @@ func TestBuildHTTPClient_MTLS_InvalidKeyPair(t *testing.T) {
 	certFile := filepath.Join(dir, "cert.pem")
 	keyFile := filepath.Join(dir, "key.pem")
 
-	os.WriteFile(certFile, []byte("not a cert"), 0644)
-	os.WriteFile(keyFile, []byte("not a key"), 0644)
+	if err := os.WriteFile(certFile, []byte("not a cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("not a key"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	cfg := &ENCConfig{
 		TimeoutSeconds: 5,
@@ -764,7 +768,9 @@ func TestNormalizeResponse_InvalidYAML(t *testing.T) {
 func TestLoadENCConfig_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "enc.yaml")
-	os.WriteFile(path, []byte(":\n\t- invalid yaml\x00"), 0644)
+	if err := os.WriteFile(path, []byte(":\n\t- invalid yaml\x00"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := loadENCConfig(path)
 	if err == nil {

--- a/cmd/mock/main_test.go
+++ b/cmd/mock/main_test.go
@@ -637,6 +637,102 @@ func TestAPIReset(t *testing.T) {
 	}
 }
 
+func TestReloadClassificationsIfChanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "classifications.yaml")
+
+	initial := `_default:
+  classes: [base]
+  environment: production
+`
+	if err := os.WriteFile(path, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &server{classificationsFile: path}
+	if err := s.loadClassificationsFile(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same modtime - should not reload
+	s.reloadClassificationsIfChanged()
+	if entry, ok := s.classificationsData["_default"]; !ok || len(entry.Classes) != 1 || entry.Classes[0] != "base" {
+		t.Error("expected no change on same modtime")
+	}
+
+	// Update file
+	updated := `_default:
+  classes: [updated]
+  environment: staging
+`
+	if err := os.WriteFile(path, []byte(updated), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.reloadClassificationsIfChanged()
+	if entry, ok := s.classificationsData["_default"]; !ok || entry.Classes[0] != "updated" {
+		t.Error("expected reload after file change")
+	}
+}
+
+func TestReloadClassificationsIfChanged_MissingFile(t *testing.T) {
+	s := &server{classificationsFile: "/nonexistent/file.yaml"}
+	// Should not panic, just return
+	s.reloadClassificationsIfChanged()
+}
+
+func TestLoadClassificationsFile_StatError(t *testing.T) {
+	s := &server{classificationsFile: "/nonexistent/file.yaml"}
+	err := s.loadClassificationsFile()
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadClassificationsFile_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	os.WriteFile(path, []byte(":\n\t[invalid\x00"), 0644)
+
+	s := &server{classificationsFile: path}
+	err := s.loadClassificationsFile()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestPDBCommand_MissingVersion(t *testing.T) {
+	ts, _ := newTestServer()
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/pdb/cmd/v1", "application/json", strings.NewReader(`{"command":"store report"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestPDBCommand_NonReportCommand(t *testing.T) {
+	ts, _ := newTestServer()
+	defer ts.Close()
+
+	cmd := `{"command":"replace facts","version":5,"payload":{"certname":"node1"}}`
+	resp, err := http.Post(ts.URL+"/pdb/cmd/v1", "application/json", strings.NewReader(cmd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 200 for non-report command, body: %s", resp.StatusCode, body)
+	}
+}
+
 func TestAuth_APIEndpointsSkipAuth(t *testing.T) {
 	ts, _ := newTestServer(func(s *server) {
 		s.auth = authConfig{authType: "bearer", authToken: "secret"}

--- a/cmd/mock/main_test.go
+++ b/cmd/mock/main_test.go
@@ -692,7 +692,9 @@ func TestLoadClassificationsFile_StatError(t *testing.T) {
 func TestLoadClassificationsFile_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bad.yaml")
-	os.WriteFile(path, []byte(":\n\t[invalid\x00"), 0644)
+	if err := os.WriteFile(path, []byte(":\n\t[invalid\x00"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	s := &server{classificationsFile: path}
 	err := s.loadClassificationsFile()

--- a/cmd/report/processor_test.go
+++ b/cmd/report/processor_test.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -286,5 +295,220 @@ func TestForward_NoAuth(t *testing.T) {
 
 	if receivedAuth != "" {
 		t.Errorf("Authorization should be empty when no auth configured, got %q", receivedAuth)
+	}
+}
+
+func TestLoadReportConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.yaml")
+
+	content := `endpoints:
+  - name: puppetdb
+    processor: puppetdb
+    url: https://puppetdb.example.com
+    timeoutSeconds: 15
+    auth:
+      type: bearer
+      token: my-token
+  - name: splunk
+    url: https://splunk.example.com/services/collector
+    headers:
+      - name: Authorization
+        value: "Splunk secret-token"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadReportConfig(path)
+	if err != nil {
+		t.Fatalf("loadReportConfig: %v", err)
+	}
+
+	if len(cfg.Endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(cfg.Endpoints))
+	}
+	if cfg.Endpoints[0].Name != "puppetdb" {
+		t.Errorf("endpoint[0].Name = %q", cfg.Endpoints[0].Name)
+	}
+	if cfg.Endpoints[0].Processor != "puppetdb" {
+		t.Errorf("endpoint[0].Processor = %q", cfg.Endpoints[0].Processor)
+	}
+	if cfg.Endpoints[0].TimeoutSeconds != 15 {
+		t.Errorf("endpoint[0].TimeoutSeconds = %d, want 15", cfg.Endpoints[0].TimeoutSeconds)
+	}
+	if cfg.Endpoints[1].TimeoutSeconds != 30 {
+		t.Errorf("endpoint[1].TimeoutSeconds = %d, want 30 (default)", cfg.Endpoints[1].TimeoutSeconds)
+	}
+}
+
+func TestLoadReportConfig_FileNotFound(t *testing.T) {
+	_, err := loadReportConfig("/nonexistent/report.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadReportConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.yaml")
+	os.WriteFile(path, []byte(":\n\t- invalid\x00"), 0644)
+
+	_, err := loadReportConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestBuildHTTPClient_Basic(t *testing.T) {
+	endpoint := EndpointConfig{
+		TimeoutSeconds: 20,
+	}
+
+	client, err := buildHTTPClient(endpoint)
+	if err != nil {
+		t.Fatalf("buildHTTPClient: %v", err)
+	}
+	if client.Timeout != 20*time.Second {
+		t.Errorf("Timeout = %v, want 20s", client.Timeout)
+	}
+}
+
+func TestBuildHTTPClient_WithValidCA(t *testing.T) {
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.pem")
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	os.WriteFile(caFile, caPEM, 0644)
+
+	endpoint := EndpointConfig{
+		TimeoutSeconds: 5,
+		SSL:            SSLConfig{CAFile: caFile},
+	}
+
+	client, err := buildHTTPClient(endpoint)
+	if err != nil {
+		t.Fatalf("buildHTTPClient: %v", err)
+	}
+	transport := client.Transport.(*http.Transport)
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Error("expected RootCAs to be set")
+	}
+}
+
+func TestBuildHTTPClient_MissingCA(t *testing.T) {
+	endpoint := EndpointConfig{
+		TimeoutSeconds: 5,
+		SSL:            SSLConfig{CAFile: "/nonexistent/ca.pem"},
+	}
+
+	_, err := buildHTTPClient(endpoint)
+	if err == nil {
+		t.Fatal("expected error for missing CA file")
+	}
+}
+
+func TestBuildHTTPClient_InvalidCAPEM(t *testing.T) {
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "bad-ca.pem")
+	os.WriteFile(caFile, []byte("not a cert"), 0644)
+
+	endpoint := EndpointConfig{
+		TimeoutSeconds: 5,
+		SSL:            SSLConfig{CAFile: caFile},
+	}
+
+	_, err := buildHTTPClient(endpoint)
+	if err == nil {
+		t.Fatal("expected error for invalid CA PEM")
+	}
+}
+
+func TestBuildHTTPClient_MTLS(t *testing.T) {
+	dir := t.TempDir()
+
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	clientKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	clientDER, _ := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+
+	certFile := filepath.Join(dir, "client.pem")
+	keyFile := filepath.Join(dir, "client-key.pem")
+
+	os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}), 0644)
+	keyBytes, _ := x509.MarshalECPrivateKey(clientKey)
+	os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0644)
+
+	endpoint := EndpointConfig{
+		TimeoutSeconds: 5,
+		Auth:           AuthConfig{Type: "mtls"},
+		SSL: SSLConfig{
+			CertFile: certFile,
+			KeyFile:  keyFile,
+		},
+	}
+
+	client, err := buildHTTPClient(endpoint)
+	if err != nil {
+		t.Fatalf("buildHTTPClient: %v", err)
+	}
+	transport := client.Transport.(*http.Transport)
+	if len(transport.TLSClientConfig.Certificates) != 1 {
+		t.Errorf("expected 1 client cert, got %d", len(transport.TLSClientConfig.Certificates))
+	}
+}
+
+func TestBuildHTTPClient_MTLS_InvalidKeyPair(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+
+	os.WriteFile(certFile, []byte("not a cert"), 0644)
+	os.WriteFile(keyFile, []byte("not a key"), 0644)
+
+	endpoint := EndpointConfig{
+		TimeoutSeconds: 5,
+		Auth:           AuthConfig{Type: "mtls"},
+		SSL: SSLConfig{
+			CertFile: certFile,
+			KeyFile:  keyFile,
+		},
+	}
+
+	_, err := buildHTTPClient(endpoint)
+	if err == nil {
+		t.Fatal("expected error for invalid cert/key")
 	}
 }

--- a/cmd/report/processor_test.go
+++ b/cmd/report/processor_test.go
@@ -352,7 +352,9 @@ func TestLoadReportConfig_FileNotFound(t *testing.T) {
 func TestLoadReportConfig_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.yaml")
-	os.WriteFile(path, []byte(":\n\t- invalid\x00"), 0644)
+	if err := os.WriteFile(path, []byte(":\n\t- invalid\x00"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := loadReportConfig(path)
 	if err == nil {
@@ -396,7 +398,9 @@ func TestBuildHTTPClient_WithValidCA(t *testing.T) {
 		t.Fatal(err)
 	}
 	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
-	os.WriteFile(caFile, caPEM, 0644)
+	if err := os.WriteFile(caFile, caPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	endpoint := EndpointConfig{
 		TimeoutSeconds: 5,
@@ -428,7 +432,9 @@ func TestBuildHTTPClient_MissingCA(t *testing.T) {
 func TestBuildHTTPClient_InvalidCAPEM(t *testing.T) {
 	dir := t.TempDir()
 	caFile := filepath.Join(dir, "bad-ca.pem")
-	os.WriteFile(caFile, []byte("not a cert"), 0644)
+	if err := os.WriteFile(caFile, []byte("not a cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	endpoint := EndpointConfig{
 		TimeoutSeconds: 5,
@@ -467,9 +473,13 @@ func TestBuildHTTPClient_MTLS(t *testing.T) {
 	certFile := filepath.Join(dir, "client.pem")
 	keyFile := filepath.Join(dir, "client-key.pem")
 
-	os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}), 0644)
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}), 0644); err != nil {
+		t.Fatal(err)
+	}
 	keyBytes, _ := x509.MarshalECPrivateKey(clientKey)
-	os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0644)
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	endpoint := EndpointConfig{
 		TimeoutSeconds: 5,
@@ -495,8 +505,12 @@ func TestBuildHTTPClient_MTLS_InvalidKeyPair(t *testing.T) {
 	certFile := filepath.Join(dir, "cert.pem")
 	keyFile := filepath.Join(dir, "key.pem")
 
-	os.WriteFile(certFile, []byte("not a cert"), 0644)
-	os.WriteFile(keyFile, []byte("not a key"), 0644)
+	if err := os.WriteFile(certFile, []byte("not a cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("not a key"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	endpoint := EndpointConfig{
 		TimeoutSeconds: 5,

--- a/cmd/report/puppetdb_test.go
+++ b/cmd/report/puppetdb_test.go
@@ -377,3 +377,136 @@ func TestEmptyMetrics(t *testing.T) {
 		t.Errorf("expected empty metrics for nil, got %d", len(result))
 	}
 }
+
+func TestCalculateEndTime_EmptyStartTime(t *testing.T) {
+	report := map[string]any{
+		"metrics": map[string]any{},
+	}
+	result := calculateEndTime(report)
+	if result != "" {
+		t.Errorf("expected empty string for missing start_time, got %q", result)
+	}
+}
+
+func TestCalculateEndTime_InvalidTime(t *testing.T) {
+	report := map[string]any{
+		"time":    "not-a-time",
+		"metrics": map[string]any{},
+	}
+	result := calculateEndTime(report)
+	if result != "not-a-time" {
+		t.Errorf("expected fallback to original time, got %q", result)
+	}
+}
+
+func TestGetRunDuration_NoTimeMetric(t *testing.T) {
+	report := map[string]any{
+		"metrics": map[string]any{
+			"resources": map[string]any{
+				"name":   "resources",
+				"values": []any{[]any{"total", "Total", float64(10)}},
+			},
+		},
+	}
+	d := getRunDuration(report)
+	if d != 0 {
+		t.Errorf("expected 0 duration without time metric, got %f", d)
+	}
+}
+
+func TestGetRunDuration_NoValues(t *testing.T) {
+	report := map[string]any{
+		"metrics": map[string]any{
+			"time": map[string]any{
+				"name": "time",
+			},
+		},
+	}
+	d := getRunDuration(report)
+	if d != 0 {
+		t.Errorf("expected 0 for missing values, got %f", d)
+	}
+}
+
+func TestGetRunDuration_MalformedTuple(t *testing.T) {
+	report := map[string]any{
+		"metrics": map[string]any{
+			"time": map[string]any{
+				"name":   "time",
+				"values": []any{[]any{"short"}, "not-a-slice"},
+			},
+		},
+	}
+	d := getRunDuration(report)
+	if d != 0 {
+		t.Errorf("expected 0 for malformed tuples, got %f", d)
+	}
+}
+
+func TestGetRunDuration_NoMetricsKey(t *testing.T) {
+	report := map[string]any{}
+	d := getRunDuration(report)
+	if d != 0 {
+		t.Errorf("expected 0 for no metrics, got %f", d)
+	}
+}
+
+func TestTransformToPuppetDB_InvalidJSON(t *testing.T) {
+	_, err := transformToPuppetDB([]byte("{invalid"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestTransformEvents_Empty(t *testing.T) {
+	result := transformEvents(nil)
+	if len(result) != 0 {
+		t.Errorf("expected empty events for nil, got %d", len(result))
+	}
+
+	result = transformEvents([]any{})
+	if len(result) != 0 {
+		t.Errorf("expected empty events for empty slice, got %d", len(result))
+	}
+}
+
+func TestTransformEvents_NonMapEntry(t *testing.T) {
+	result := transformEvents([]any{"not-a-map", 42})
+	if len(result) != 0 {
+		t.Errorf("expected empty events for non-map entries, got %d", len(result))
+	}
+}
+
+func TestTransformResources_NonMapStatus(t *testing.T) {
+	// resource_statuses values that aren't maps should be skipped
+	statuses := map[string]any{
+		"Notify[test]": "not-a-map",
+	}
+	result := transformResources(statuses)
+	if len(result) != 0 {
+		t.Errorf("expected empty resources for non-map status, got %d", len(result))
+	}
+}
+
+func TestTransformMetrics_NonMapCategory(t *testing.T) {
+	metrics := map[string]any{
+		"time": "not-a-map",
+	}
+	result := transformMetrics(metrics)
+	if len(result) != 0 {
+		t.Errorf("expected empty metrics for non-map category, got %d", len(result))
+	}
+}
+
+func TestTransformMetrics_NonSliceValues(t *testing.T) {
+	metrics := map[string]any{
+		"time": map[string]any{
+			"name":   "time",
+			"values": "not-a-slice",
+		},
+	}
+	result := transformMetrics(metrics)
+	if len(result) != 0 {
+		t.Errorf("expected empty metrics for non-slice values, got %d", len(result))
+	}
+}

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -501,6 +502,105 @@ func TestCertReconcile_DeletionCANotFound(t *testing.T) {
 	err = c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated)
 	if !errors.IsNotFound(err) {
 		t.Errorf("expected Certificate to be deleted, got err: %v", err)
+	}
+}
+
+func TestExtractNotAfter_ValidCert(t *testing.T) {
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 90*24*time.Hour)
+	secret := newSecret("test-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	c := setupTestClient(secret)
+	r := newCertificateReconciler(c)
+
+	notAfter := r.extractNotAfter(testCtx(), "test-tls", testNamespace)
+	if notAfter == nil {
+		t.Fatal("expected non-nil NotAfter")
+	}
+	if notAfter.Time.Before(time.Now()) {
+		t.Error("expected NotAfter to be in the future")
+	}
+}
+
+func TestExtractNotAfter_SecretNotFound(t *testing.T) {
+	c := setupTestClient()
+	r := newCertificateReconciler(c)
+
+	notAfter := r.extractNotAfter(testCtx(), "nonexistent", testNamespace)
+	if notAfter != nil {
+		t.Errorf("expected nil NotAfter for missing secret, got %v", notAfter)
+	}
+}
+
+func TestExtractNotAfter_InvalidCertPEM(t *testing.T) {
+	secret := newSecret("test-tls", map[string][]byte{
+		"cert.pem": []byte("not a cert"),
+		"key.pem":  []byte("not a key"),
+	})
+
+	c := setupTestClient(secret)
+	r := newCertificateReconciler(c)
+
+	notAfter := r.extractNotAfter(testCtx(), "test-tls", testNamespace)
+	if notAfter != nil {
+		t.Errorf("expected nil NotAfter for invalid cert, got %v", notAfter)
+	}
+}
+
+func TestAdoptTLSSecret_NewOwner(t *testing.T) {
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.UID = "test-uid-123"
+	secret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": []byte("cert-data"),
+	})
+
+	c := setupTestClient(cert, secret)
+	r := newCertificateReconciler(c)
+
+	if err := r.adoptTLSSecret(testCtx(), cert, "my-cert-tls"); err != nil {
+		t.Fatalf("adoptTLSSecret: %v", err)
+	}
+
+	updated := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert-tls", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get secret: %v", err)
+	}
+	if len(updated.OwnerReferences) == 0 {
+		t.Error("expected owner reference to be set")
+	}
+}
+
+func TestAdoptTLSSecret_AlreadyOwned(t *testing.T) {
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.UID = "test-uid-123"
+	secret := newSecret("my-cert-tls", map[string][]byte{
+		"cert.pem": []byte("cert-data"),
+	})
+
+	c := setupTestClient(cert, secret)
+	r := newCertificateReconciler(c)
+
+	// First adopt
+	if err := r.adoptTLSSecret(testCtx(), cert, "my-cert-tls"); err != nil {
+		t.Fatalf("first adoptTLSSecret: %v", err)
+	}
+
+	// Second adopt should be a no-op
+	if err := r.adoptTLSSecret(testCtx(), cert, "my-cert-tls"); err != nil {
+		t.Fatalf("second adoptTLSSecret: %v", err)
+	}
+}
+
+func TestAdoptTLSSecret_SecretNotFound(t *testing.T) {
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	c := setupTestClient(cert)
+	r := newCertificateReconciler(c)
+
+	err := r.adoptTLSSecret(testCtx(), cert, "nonexistent-tls")
+	if err == nil {
+		t.Fatal("expected error for missing secret")
 	}
 }
 

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -1029,6 +1029,87 @@ func TestSignCertificate_FullFlow(t *testing.T) {
 	_ = res
 }
 
+func TestEnsurePendingKey_New(t *testing.T) {
+	cert := newCertificate("my-cert", "test-ca", "")
+	c := setupTestClient(cert)
+	r := newCertificateReconciler(c)
+
+	keyPEM, err := r.ensurePendingKey(testCtx(), cert, "my-cert-tls-pending", testNamespace)
+	if err != nil {
+		t.Fatalf("ensurePendingKey: %v", err)
+	}
+	if len(keyPEM) == 0 {
+		t.Fatal("expected non-empty key PEM")
+	}
+
+	// Verify the secret was created
+	secret := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert-tls-pending", Namespace: testNamespace}, secret); err != nil {
+		t.Fatalf("pending Secret not created: %v", err)
+	}
+}
+
+func TestEnsurePendingKey_Existing(t *testing.T) {
+	cert := newCertificate("my-cert", "test-ca", "")
+	existingKey := []byte("-----BEGIN RSA PRIVATE KEY-----\nexisting-key\n-----END RSA PRIVATE KEY-----\n")
+	pendingSecret := newSecret("my-cert-tls-pending", map[string][]byte{
+		"key.pem": existingKey,
+	})
+
+	c := setupTestClient(cert, pendingSecret)
+	r := newCertificateReconciler(c)
+
+	keyPEM, err := r.ensurePendingKey(testCtx(), cert, "my-cert-tls-pending", testNamespace)
+	if err != nil {
+		t.Fatalf("ensurePendingKey: %v", err)
+	}
+	if string(keyPEM) != string(existingKey) {
+		t.Error("expected existing key to be returned")
+	}
+}
+
+func TestHandleCertificateCleanup_ExternalCA(t *testing.T) {
+	ca := newCertificateAuthority("test-ca", withExternal("https://puppet.example.com"))
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert)
+	r := newCertificateReconciler(c)
+
+	// External CA: cleanup should be skipped gracefully
+	if err := r.handleCertificateCleanup(testCtx(), cert); err != nil {
+		t.Fatalf("handleCertificateCleanup: %v", err)
+	}
+}
+
+func TestHandleCertificateCleanup_NoSigningSecret(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = ""
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert)
+	r := newCertificateReconciler(c)
+
+	// No signing secret: cleanup should be skipped
+	if err := r.handleCertificateCleanup(testCtx(), cert); err != nil {
+		t.Fatalf("handleCertificateCleanup: %v", err)
+	}
+}
+
+func TestHandleCertificateCleanup_CANotFound(t *testing.T) {
+	cert := newCertificate("my-cert", "missing-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(cert)
+	r := newCertificateReconciler(c)
+
+	// Missing CA: should skip cleanup gracefully
+	if err := r.handleCertificateCleanup(testCtx(), cert); err != nil {
+		t.Fatalf("handleCertificateCleanup: %v", err)
+	}
+}
+
 func TestReconcileCertSigning_ExternalCA(t *testing.T) {
 	// Use long-lived cert to avoid immediate renewal trigger (default renewBefore is 60d)
 	certPEM, keyPEM := generateTestCertWithExpiry(t, 365*24*time.Hour)

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -743,6 +743,344 @@ func TestRenewCertificate_mTLSAuth(t *testing.T) {
 	}
 }
 
+func TestSubmitCSR_Success(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	var csrReceived bool
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/puppet-ca/v1/certificate_request/") {
+			csrReceived = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.submitCSR(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("submitCSR: %v", err)
+	}
+	if !csrReceived {
+		t.Error("expected CSR to be submitted to the server")
+	}
+
+	// Should have created a pending secret with the key
+	pendingSecret := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert-tls-pending", Namespace: testNamespace}, pendingSecret); err != nil {
+		t.Fatalf("pending Secret not created: %v", err)
+	}
+	if len(pendingSecret.Data["key.pem"]) == 0 {
+		t.Error("pending Secret should contain key.pem")
+	}
+	_ = res
+}
+
+func TestSubmitCSR_AlreadyPending(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("already has a requested certificate"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret)
+	r := newCertificateReconciler(c)
+
+	_, err := r.submitCSR(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("submitCSR should not error for already-pending: %v", err)
+	}
+}
+
+func TestSubmitCSR_Rejected(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret)
+	r := newCertificateReconciler(c)
+
+	_, err := r.submitCSR(testCtx(), cert, ca, server.URL, testNamespace)
+	if err == nil {
+		t.Fatal("expected error for rejected CSR")
+	}
+}
+
+func TestSubmitCSR_ExistingPendingKey(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	var csrReceived bool
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			csrReceived = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	// Pre-create the pending secret with a key
+	pendingSecret := newSecret("my-cert-tls-pending", map[string][]byte{
+		"key.pem": keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret, pendingSecret)
+	r := newCertificateReconciler(c)
+
+	_, err := r.submitCSR(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("submitCSR with existing key: %v", err)
+	}
+	if !csrReceived {
+		t.Error("expected CSR to be submitted even with existing key")
+	}
+}
+
+func TestFetchSignedCert_Signed(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/puppet-ca/v1/certificate/") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(certPEM) // return the cert as "signed"
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret)
+	r := newCertificateReconciler(c)
+
+	signedCert, err := r.fetchSignedCert(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("fetchSignedCert: %v", err)
+	}
+	if signedCert == nil {
+		t.Fatal("expected signed cert to be returned")
+	}
+}
+
+func TestFetchSignedCert_NotYetSigned(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret)
+	r := newCertificateReconciler(c)
+
+	signedCert, err := r.fetchSignedCert(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("fetchSignedCert: %v", err)
+	}
+	if signedCert != nil {
+		t.Error("expected nil for unsigned cert")
+	}
+}
+
+func TestFetchSignedCert_EmptyCertname(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	var requestedPath string
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(certPEM)
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhaseRequesting)
+	cert.Spec.Certname = "" // empty -> defaults to "puppet"
+
+	c := setupTestClient(ca, cert, caSecret)
+	r := newCertificateReconciler(c)
+
+	_, err := r.fetchSignedCert(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("fetchSignedCert: %v", err)
+	}
+	if !strings.Contains(requestedPath, "/puppet") {
+		t.Errorf("expected path to contain /puppet for empty certname, got %s", requestedPath)
+	}
+}
+
+func TestSignCertificate_FullFlow(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	// Server handles CSR submit and cert fetch
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/certificate_request/"):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/certificate/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(certPEM)
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/certificate_status/"):
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.signCertificate(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("signCertificate: %v", err)
+	}
+
+	// Should have created the TLS secret
+	tlsSecret := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert-tls", Namespace: testNamespace}, tlsSecret); err != nil {
+		t.Fatalf("TLS Secret not created: %v", err)
+	}
+	if len(tlsSecret.Data["cert.pem"]) == 0 {
+		t.Error("TLS Secret should contain cert.pem")
+	}
+	if len(tlsSecret.Data["key.pem"]) == 0 {
+		t.Error("TLS Secret should contain key.pem")
+	}
+
+	// Pending secret should be cleaned up
+	pendingSecret := &corev1.Secret{}
+	err = c.Get(testCtx(), types.NamespacedName{Name: "my-cert-tls-pending", Namespace: testNamespace}, pendingSecret)
+	if err == nil {
+		t.Error("pending Secret should have been deleted")
+	}
+	_ = res
+}
+
+func TestSignCertificate_WaitingForSigning(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	// Server accepts CSR but never returns signed cert
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/certificate_request/"):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/certificate/"):
+			w.WriteHeader(http.StatusNotFound) // not yet signed
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/certificate_status/"):
+			w.WriteHeader(http.StatusForbidden) // signing fails
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": certPEM,
+	})
+	signingSecret := newSecret("ca-cert-tls", map[string][]byte{
+		"cert.pem": certPEM,
+		"key.pem":  keyPEM,
+	})
+
+	ca := newCertificateAuthority("test-ca")
+	ca.Status.SigningSecretName = "ca-cert-tls"
+
+	cert := newCertificate("my-cert", "test-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert, caSecret, signingSecret)
+	r := newCertificateReconciler(c)
+
+	res, err := r.signCertificate(testCtx(), cert, ca, server.URL, testNamespace)
+	if err != nil {
+		t.Fatalf("signCertificate: %v", err)
+	}
+
+	// Should requeue since cert is not yet signed
+	if res.RequeueAfter == 0 {
+		t.Error("expected RequeueAfter > 0 when cert is not yet signed")
+	}
+
+	// Pending secret should still exist
+	pendingSecret := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert-tls-pending", Namespace: testNamespace}, pendingSecret); err != nil {
+		t.Fatalf("pending Secret should still exist: %v", err)
+	}
+}
+
 // newTestTLSServer creates a test HTTPS server using the given cert/key for TLS.
 func newTestTLSServer(t *testing.T, certPEM, keyPEM []byte, handler http.Handler) *httptest.Server {
 	t.Helper()

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -1029,6 +1029,92 @@ func TestSignCertificate_FullFlow(t *testing.T) {
 	_ = res
 }
 
+func TestReconcileCertSigning_ExternalCA(t *testing.T) {
+	// Use long-lived cert to avoid immediate renewal trigger (default renewBefore is 60d)
+	certPEM, keyPEM := generateTestCertWithExpiry(t, 365*24*time.Hour)
+
+	// Server returns the signed cert immediately
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/certificate_request/"):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/certificate/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(certPEM)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ca := newCertificateAuthority("ext-ca", withExternal(server.URL))
+	ca.Spec.External.InsecureSkipVerify = true
+	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseExternal
+
+	cert := newCertificate("my-cert", "ext-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert)
+	r := newCertificateReconciler(c)
+
+	res, err := r.reconcileCertSigning(testCtx(), cert, ca)
+	if err != nil {
+		t.Fatalf("reconcileCertSigning: %v", err)
+	}
+
+	// Should have created TLS secret and updated status
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseSigned {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificatePhaseSigned, updated.Status.Phase)
+	}
+	if updated.Status.SecretName != "my-cert-tls" {
+		t.Errorf("expected SecretName %q, got %q", "my-cert-tls", updated.Status.SecretName)
+	}
+	_ = res
+}
+
+func TestReconcileCertSigning_Error(t *testing.T) {
+	certPEM, keyPEM := generateTestCert(t)
+
+	// Server rejects all requests
+	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	ca := newCertificateAuthority("ext-ca", withExternal(server.URL))
+	ca.Spec.External.InsecureSkipVerify = true
+	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseExternal
+
+	cert := newCertificate("my-cert", "ext-ca", "")
+	cert.Spec.Certname = "test-node"
+
+	c := setupTestClient(ca, cert)
+	r := newCertificateReconciler(c)
+
+	res, err := r.reconcileCertSigning(testCtx(), cert, ca)
+	if err != nil {
+		// reconcileCertSigning swallows errors and requeues
+		t.Fatalf("reconcileCertSigning should not return error: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Error("expected requeue after error")
+	}
+
+	// Phase should be Error
+	updated := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.CertificatePhaseError {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificatePhaseError, updated.Status.Phase)
+	}
+}
+
 func TestSignCertificate_WaitingForSigning(t *testing.T) {
 	certPEM, keyPEM := generateTestCert(t)
 

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -861,6 +861,34 @@ func TestCAReconcile_ExternalCA_SkipsOperatorSigning(t *testing.T) {
 	}
 }
 
+func TestCAReconcile_CAServiceDirectUpdate(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	c := setupTestClient(ca)
+	r := newCertificateAuthorityReconciler(c)
+
+	// Create
+	if err := r.reconcileCAService(testCtx(), ca); err != nil {
+		t.Fatalf("first reconcileCAService: %v", err)
+	}
+
+	// Update (should not error, exercises update path)
+	if err := r.reconcileCAService(testCtx(), ca); err != nil {
+		t.Fatalf("second reconcileCAService: %v", err)
+	}
+
+	svc := &corev1.Service{}
+	svcName := caInternalServiceName("test-ca")
+	if err := c.Get(testCtx(), types.NamespacedName{Name: svcName, Namespace: testNamespace}, svc); err != nil {
+		t.Fatalf("Service not found after update: %v", err)
+	}
+	if svc.Spec.Ports[0].Port != 8140 {
+		t.Errorf("expected port 8140 after update, got %d", svc.Spec.Ports[0].Port)
+	}
+	if svc.Spec.Selector[LabelCA] != "true" {
+		t.Error("service selector missing CA label after update")
+	}
+}
+
 func TestCAReconcile_ExternalCA_NoConfigRequired(t *testing.T) {
 	// External CA should work without any Config object (unlike internal CA which requires it)
 	ca := newCertificateAuthority("ext-ca", withExternal("https://puppet-ca.example.com:8140"))

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -861,6 +861,102 @@ func TestCAReconcile_ExternalCA_SkipsOperatorSigning(t *testing.T) {
 	}
 }
 
+func TestEnsureCARole_CreateAndUpdate(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	c := setupTestClient(ca)
+	r := newCertificateAuthorityReconciler(c)
+
+	labels := caLabels(ca.Name)
+	resourceNames := []string{"test-ca-ca", "test-ca-ca-key", "test-ca-ca-crl"}
+
+	// Create
+	if err := r.ensureCARole(testCtx(), "test-ca-ca-setup", testNamespace, labels, resourceNames, ca); err != nil {
+		t.Fatalf("ensureCARole create: %v", err)
+	}
+
+	role := &rbacv1.Role{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca-setup", Namespace: testNamespace}, role); err != nil {
+		t.Fatalf("Role not created: %v", err)
+	}
+	if len(role.Rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(role.Rules))
+	}
+
+	// Update with additional resource names
+	updatedNames := append(resourceNames, "extra-cert-tls")
+	if err := r.ensureCARole(testCtx(), "test-ca-ca-setup", testNamespace, labels, updatedNames, ca); err != nil {
+		t.Fatalf("ensureCARole update: %v", err)
+	}
+
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca-setup", Namespace: testNamespace}, role); err != nil {
+		t.Fatalf("Role not found after update: %v", err)
+	}
+	if len(role.Rules[0].ResourceNames) != 4 {
+		t.Errorf("expected 4 resource names after update, got %d", len(role.Rules[0].ResourceNames))
+	}
+}
+
+func TestReconcileCASetupRBAC(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhasePending)
+
+	c := setupTestClient(ca)
+	r := newCertificateAuthorityReconciler(c)
+
+	certs := []openvoxv1alpha1.Certificate{*cert}
+	if err := r.reconcileCASetupRBAC(testCtx(), ca, certs); err != nil {
+		t.Fatalf("reconcileCASetupRBAC: %v", err)
+	}
+
+	// Check ServiceAccount, Role, and RoleBinding were created
+	sa := &corev1.ServiceAccount{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca-setup", Namespace: testNamespace}, sa); err != nil {
+		t.Fatalf("ServiceAccount not created: %v", err)
+	}
+
+	role := &rbacv1.Role{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca-setup", Namespace: testNamespace}, role); err != nil {
+		t.Fatalf("Role not created: %v", err)
+	}
+
+	rb := &rbacv1.RoleBinding{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca-setup", Namespace: testNamespace}, rb); err != nil {
+		t.Fatalf("RoleBinding not created: %v", err)
+	}
+}
+
+func TestUpdateCRLSecret(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	c := setupTestClient(ca)
+	r := newCertificateAuthorityReconciler(c)
+
+	crlPEM := []byte("-----BEGIN X509 CRL-----\ntest-crl-data\n-----END X509 CRL-----\n")
+
+	if err := r.updateCRLSecret(testCtx(), ca, "test-ca-ca-crl", crlPEM); err != nil {
+		t.Fatalf("updateCRLSecret: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca-crl", Namespace: testNamespace}, secret); err != nil {
+		t.Fatalf("CRL Secret not created: %v", err)
+	}
+	if string(secret.Data["ca_crl.pem"]) != string(crlPEM) {
+		t.Errorf("CRL data mismatch")
+	}
+
+	// Update
+	newCRL := []byte("-----BEGIN X509 CRL-----\nupdated-crl\n-----END X509 CRL-----\n")
+	if err := r.updateCRLSecret(testCtx(), ca, "test-ca-ca-crl", newCRL); err != nil {
+		t.Fatalf("updateCRLSecret update: %v", err)
+	}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca-crl", Namespace: testNamespace}, secret); err != nil {
+		t.Fatalf("CRL Secret not found after update: %v", err)
+	}
+	if string(secret.Data["ca_crl.pem"]) != string(newCRL) {
+		t.Errorf("CRL data not updated")
+	}
+}
+
 func TestCAReconcile_CAServiceDirectUpdate(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	c := setupTestClient(ca)

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -985,6 +985,60 @@ func TestCAReconcile_CAServiceDirectUpdate(t *testing.T) {
 	}
 }
 
+func TestAdoptSecret_New(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.UID = "ca-uid-123"
+	secret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": []byte("ca-cert"),
+	})
+
+	c := setupTestClient(ca, secret)
+	r := newCertificateAuthorityReconciler(c)
+
+	if err := r.adoptSecret(testCtx(), ca, "test-ca-ca"); err != nil {
+		t.Fatalf("adoptSecret: %v", err)
+	}
+
+	updated := &corev1.Secret{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-ca", Namespace: testNamespace}, updated); err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.OwnerReferences) == 0 {
+		t.Error("expected owner reference to be set")
+	}
+}
+
+func TestAdoptSecret_AlreadyOwned(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.UID = "ca-uid-123"
+	secret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": []byte("ca-cert"),
+	})
+
+	c := setupTestClient(ca, secret)
+	r := newCertificateAuthorityReconciler(c)
+
+	// First adopt
+	if err := r.adoptSecret(testCtx(), ca, "test-ca-ca"); err != nil {
+		t.Fatalf("first adoptSecret: %v", err)
+	}
+	// Second adopt (no-op)
+	if err := r.adoptSecret(testCtx(), ca, "test-ca-ca"); err != nil {
+		t.Fatalf("second adoptSecret: %v", err)
+	}
+}
+
+func TestAdoptSecret_NotFound(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	c := setupTestClient(ca)
+	r := newCertificateAuthorityReconciler(c)
+
+	// Should not error for missing secret
+	if err := r.adoptSecret(testCtx(), ca, "nonexistent"); err != nil {
+		t.Fatalf("adoptSecret should not error for missing secret: %v", err)
+	}
+}
+
 func TestCAReconcile_ExternalCA_NoConfigRequired(t *testing.T) {
 	// External CA should work without any Config object (unlike internal CA which requires it)
 	ca := newCertificateAuthority("ext-ca", withExternal("https://puppet-ca.example.com:8140"))

--- a/internal/controller/certificateauthority_job_test.go
+++ b/internal/controller/certificateauthority_job_test.go
@@ -4,9 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -234,4 +236,212 @@ func TestResolveCAJobResources(t *testing.T) {
 			t.Errorf("expected memory limit 4Gi, got %s", res.Limits.Memory().String())
 		}
 	})
+}
+
+func TestReconcileJob_CreatesNew(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	cfg := caPrereqs("test-ca")
+	c := setupTestClient(ca, cfg)
+	r := newCertificateAuthorityReconciler(c)
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ca-setup",
+			Namespace: testNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "setup", Image: "test:latest"}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	res, err := r.reconcileJob(testCtx(), ca, "test-ca-setup", job, "test-ca-ca")
+	if err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+	if res.RequeueAfter != RequeueIntervalMedium {
+		t.Errorf("expected requeue after %v, got %v", RequeueIntervalMedium, res.RequeueAfter)
+	}
+
+	created := &batchv1.Job{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca-setup", Namespace: testNamespace}, created); err != nil {
+		t.Fatalf("Job not created: %v", err)
+	}
+}
+
+func TestReconcileJob_Succeeded(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	cfg := caPrereqs("test-ca")
+
+	// Pre-create the expected secret
+	caSecret := newSecret("test-ca-ca", map[string][]byte{
+		"ca_crt.pem": []byte("ca-cert-pem"),
+	})
+
+	existingJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ca-setup",
+			Namespace: testNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "setup", Image: "test:latest"}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Succeeded: 1,
+		},
+	}
+
+	c := setupTestClient(ca, cfg, caSecret, existingJob)
+	r := newCertificateAuthorityReconciler(c)
+
+	desiredJob := existingJob.DeepCopy()
+	res, err := r.reconcileJob(testCtx(), ca, "test-ca-setup", desiredJob, "test-ca-ca")
+	if err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected no requeue for succeeded job, got %v", res.RequeueAfter)
+	}
+}
+
+func TestReconcileJob_Failed(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	cfg := caPrereqs("test-ca")
+
+	existingJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ca-setup",
+			Namespace: testNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "setup", Image: "test:latest"}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	c := setupTestClient(ca, cfg, existingJob)
+	r := newCertificateAuthorityReconciler(c)
+
+	desiredJob := existingJob.DeepCopy()
+	res, err := r.reconcileJob(testCtx(), ca, "test-ca-setup", desiredJob, "test-ca-ca")
+	if err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+	if res.RequeueAfter != RequeueIntervalMedium {
+		t.Errorf("expected requeue after %v for failed job, got %v", RequeueIntervalMedium, res.RequeueAfter)
+	}
+}
+
+func TestReconcileJob_Running(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	cfg := caPrereqs("test-ca")
+
+	existingJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ca-setup",
+			Namespace: testNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "setup", Image: "test:latest"}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	c := setupTestClient(ca, cfg, existingJob)
+	r := newCertificateAuthorityReconciler(c)
+
+	desiredJob := existingJob.DeepCopy()
+	res, err := r.reconcileJob(testCtx(), ca, "test-ca-setup", desiredJob, "test-ca-ca")
+	if err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+	if res.RequeueAfter != RequeueIntervalLong {
+		t.Errorf("expected requeue after %v for running job, got %v", RequeueIntervalLong, res.RequeueAfter)
+	}
+}
+
+func TestReconcileJob_ImageChanged(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	cfg := caPrereqs("test-ca")
+
+	existingJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ca-setup",
+			Namespace: testNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "setup", Image: "old:v1"}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	c := setupTestClient(ca, cfg, existingJob)
+	r := newCertificateAuthorityReconciler(c)
+
+	desiredJob := existingJob.DeepCopy()
+	desiredJob.Spec.Template.Spec.Containers[0].Image = "new:v2"
+
+	res, err := r.reconcileJob(testCtx(), ca, "test-ca-setup", desiredJob, "test-ca-ca")
+	if err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+	// Should delete and requeue
+	if res.RequeueAfter != RequeueIntervalMedium {
+		t.Errorf("expected requeue after %v for image change, got %v", RequeueIntervalMedium, res.RequeueAfter)
+	}
+}
+
+func TestDeleteAndRequeueJob(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: testNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "setup", Image: "test:latest"}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	c := setupTestClient(ca, job)
+	r := newCertificateAuthorityReconciler(c)
+
+	res, err := r.deleteAndRequeueJob(testCtx(), job, "test reason")
+	if err != nil {
+		t.Fatalf("deleteAndRequeueJob: %v", err)
+	}
+	if res.RequeueAfter != RequeueIntervalMedium {
+		t.Errorf("expected requeue after %v, got %v", RequeueIntervalMedium, res.RequeueAfter)
+	}
 }

--- a/internal/controller/config_autosign_test.go
+++ b/internal/controller/config_autosign_test.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
@@ -211,5 +213,37 @@ func TestRenderAutosignPolicyConfig_SortOrder(t *testing.T) {
 
 	if alphaIdx >= bravoIdx || bravoIdx >= charlieIdx {
 		t.Errorf("policies not sorted by name; alpha=%d, bravo=%d, charlie=%d", alphaIdx, bravoIdx, charlieIdx)
+	}
+}
+
+func TestUpdateSigningPolicyStatus_Success(t *testing.T) {
+	sp := newSigningPolicy("test-policy", "test-ca", true)
+	c := setupTestClient(sp)
+	r := newConfigReconciler(c)
+
+	r.updateSigningPolicyStatus(testCtx(), sp, nil)
+
+	updated := &openvoxv1alpha1.SigningPolicy{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-policy", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get SigningPolicy: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.SigningPolicyPhaseActive {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.SigningPolicyPhaseActive, updated.Status.Phase)
+	}
+}
+
+func TestUpdateSigningPolicyStatus_Error(t *testing.T) {
+	sp := newSigningPolicy("test-policy", "test-ca", true)
+	c := setupTestClient(sp)
+	r := newConfigReconciler(c)
+
+	r.updateSigningPolicyStatus(testCtx(), sp, fmt.Errorf("rendering failed"))
+
+	updated := &openvoxv1alpha1.SigningPolicy{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-policy", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get SigningPolicy: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.SigningPolicyPhaseError {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.SigningPolicyPhaseError, updated.Status.Phase)
 	}
 }

--- a/internal/controller/config_enc_test.go
+++ b/internal/controller/config_enc_test.go
@@ -1,8 +1,11 @@
 package controller
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -262,5 +265,37 @@ func TestRenderENCConfig_CacheCustomDirectory(t *testing.T) {
 
 	if !strings.Contains(out, "directory: /custom/cache/dir") {
 		t.Errorf("expected custom cache directory in output:\n%s", out)
+	}
+}
+
+func TestUpdateNodeClassifierStatus_Success(t *testing.T) {
+	nc := newNodeClassifier("test-nc", "https://foreman.example.com")
+	c := setupTestClient(nc)
+	r := newConfigReconciler(c)
+
+	r.updateNodeClassifierStatus(testCtx(), nc, nil)
+
+	updated := &openvoxv1alpha1.NodeClassifier{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-nc", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get NodeClassifier: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.NodeClassifierPhaseActive {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.NodeClassifierPhaseActive, updated.Status.Phase)
+	}
+}
+
+func TestUpdateNodeClassifierStatus_Error(t *testing.T) {
+	nc := newNodeClassifier("test-nc", "https://foreman.example.com")
+	c := setupTestClient(nc)
+	r := newConfigReconciler(c)
+
+	r.updateNodeClassifierStatus(testCtx(), nc, fmt.Errorf("render failed"))
+
+	updated := &openvoxv1alpha1.NodeClassifier{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-nc", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get NodeClassifier: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.NodeClassifierPhaseError {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.NodeClassifierPhaseError, updated.Status.Phase)
 	}
 }

--- a/internal/controller/config_reports_test.go
+++ b/internal/controller/config_reports_test.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
@@ -299,5 +301,37 @@ func TestRenderReportWebhookConfig_MultipleEndpoints(t *testing.T) {
 		if !strings.Contains(out, s) {
 			t.Errorf("expected %q in output:\n%s", s, out)
 		}
+	}
+}
+
+func TestUpdateReportProcessorStatus_Success(t *testing.T) {
+	rp := newReportProcessor("test-rp", "production", "https://puppetdb.example.com")
+	c := setupTestClient(rp)
+	r := newConfigReconciler(c)
+
+	r.updateReportProcessorStatus(testCtx(), rp, nil)
+
+	updated := &openvoxv1alpha1.ReportProcessor{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-rp", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get ReportProcessor: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.ReportProcessorPhaseActive {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.ReportProcessorPhaseActive, updated.Status.Phase)
+	}
+}
+
+func TestUpdateReportProcessorStatus_Error(t *testing.T) {
+	rp := newReportProcessor("test-rp", "production", "https://puppetdb.example.com")
+	c := setupTestClient(rp)
+	r := newConfigReconciler(c)
+
+	r.updateReportProcessorStatus(testCtx(), rp, fmt.Errorf("rendering failed"))
+
+	updated := &openvoxv1alpha1.ReportProcessor{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-rp", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get ReportProcessor: %v", err)
+	}
+	if updated.Status.Phase != openvoxv1alpha1.ReportProcessorPhaseError {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.ReportProcessorPhaseError, updated.Status.Phase)
 	}
 }

--- a/internal/controller/database_controller_test.go
+++ b/internal/controller/database_controller_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -523,5 +524,120 @@ func TestDatabaseReconcile_NetworkPolicyAdditionalIngress(t *testing.T) {
 	}
 	if np.Spec.Ingress[1].Ports[0].Port.IntVal != 9090 {
 		t.Errorf("expected additional ingress port 9090, got %d", np.Spec.Ingress[1].Ports[0].Port.IntVal)
+	}
+}
+
+func TestDatabaseReconcile_PDBCreation(t *testing.T) {
+	pdbEnabled := &openvoxv1alpha1.PDBSpec{Enabled: true}
+	db := newDatabase("test-db")
+	db.Spec.PDB = pdbEnabled
+
+	objs := append(databasePrereqs(), db)
+	c := setupTestClient(objs...)
+	r := newDatabaseReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, pdb); err != nil {
+		t.Fatalf("PDB not created: %v", err)
+	}
+
+	if pdb.Spec.Selector == nil || pdb.Spec.Selector.MatchLabels[LabelDatabase] != "test-db" {
+		t.Error("PDB selector missing database label")
+	}
+	// Default should be MinAvailable=1
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.IntVal != DefaultPDBMinAvailable {
+		t.Errorf("expected default MinAvailable=%d", DefaultPDBMinAvailable)
+	}
+}
+
+func TestDatabaseReconcile_PDBWithMaxUnavailable(t *testing.T) {
+	maxUnavail := intstr.FromInt32(2)
+	pdbSpec := &openvoxv1alpha1.PDBSpec{Enabled: true, MaxUnavailable: &maxUnavail}
+	db := newDatabase("test-db")
+	db.Spec.PDB = pdbSpec
+
+	objs := append(databasePrereqs(), db)
+	c := setupTestClient(objs...)
+	r := newDatabaseReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, pdb); err != nil {
+		t.Fatalf("PDB not created: %v", err)
+	}
+	if pdb.Spec.MaxUnavailable == nil || pdb.Spec.MaxUnavailable.IntVal != 2 {
+		t.Errorf("expected MaxUnavailable=2, got %v", pdb.Spec.MaxUnavailable)
+	}
+	if pdb.Spec.MinAvailable != nil {
+		t.Error("MinAvailable should be nil when MaxUnavailable is set")
+	}
+}
+
+func TestDatabaseReconcile_PDBDisabledDeletesExisting(t *testing.T) {
+	// Pre-create a PDB
+	existingPDB := &policyv1.PodDisruptionBudget{}
+	existingPDB.Name = "test-db"
+	existingPDB.Namespace = testNamespace
+
+	db := newDatabase("test-db")
+	// PDB disabled (nil)
+
+	objs := append(databasePrereqs(), db, existingPDB)
+	c := setupTestClient(objs...)
+	r := newDatabaseReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, pdb)
+	if err == nil {
+		t.Error("PDB should have been deleted when disabled")
+	}
+}
+
+func TestDatabaseReconcile_PDBUpdate(t *testing.T) {
+	// Create initial PDB via first reconcile
+	pdbSpec := &openvoxv1alpha1.PDBSpec{Enabled: true}
+	db := newDatabase("test-db")
+	db.Spec.PDB = pdbSpec
+
+	objs := append(databasePrereqs(), db)
+	c := setupTestClient(objs...)
+	r := newDatabaseReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+		t.Fatalf("first reconcile error: %v", err)
+	}
+
+	// Update to use MinAvailable=2
+	updated := &openvoxv1alpha1.Database{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get Database: %v", err)
+	}
+	minAvail := intstr.FromInt32(2)
+	updated.Spec.PDB = &openvoxv1alpha1.PDBSpec{Enabled: true, MinAvailable: &minAvail}
+	if err := c.Update(testCtx(), updated); err != nil {
+		t.Fatalf("failed to update Database: %v", err)
+	}
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-db")); err != nil {
+		t.Fatalf("second reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-db", Namespace: testNamespace}, pdb); err != nil {
+		t.Fatalf("PDB not found: %v", err)
+	}
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.IntVal != 2 {
+		t.Errorf("expected MinAvailable=2 after update, got %v", pdb.Spec.MinAvailable)
 	}
 }

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -234,6 +234,68 @@ func TestPoolReconcile_UpdateExistingService(t *testing.T) {
 	}
 }
 
+func TestPoolReconcile_TLSRouteDirectUpdate(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"))
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, true)
+
+	// Create
+	if err := r.reconcileTLSRoute(testCtx(), pool); err != nil {
+		t.Fatalf("first reconcileTLSRoute: %v", err)
+	}
+
+	// Update hostname
+	pool.Spec.Route.Hostname = "puppet2.example.com"
+	if err := r.reconcileTLSRoute(testCtx(), pool); err != nil {
+		t.Fatalf("second reconcileTLSRoute: %v", err)
+	}
+
+	route := &gwapiv1.TLSRoute{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, route); err != nil {
+		t.Fatalf("TLSRoute not found: %v", err)
+	}
+	if len(route.Spec.Hostnames) != 1 || string(route.Spec.Hostnames[0]) != "puppet2.example.com" {
+		t.Errorf("hostname not updated, got %v", route.Spec.Hostnames)
+	}
+}
+
+func TestPoolReconcile_TLSRouteWithSectionName(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"))
+	pool.Spec.Route.GatewayRef.SectionName = "https"
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, true)
+
+	if err := r.reconcileTLSRoute(testCtx(), pool); err != nil {
+		t.Fatalf("reconcileTLSRoute: %v", err)
+	}
+
+	route := &gwapiv1.TLSRoute{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, route); err != nil {
+		t.Fatalf("TLSRoute not created: %v", err)
+	}
+	if route.Spec.ParentRefs[0].SectionName == nil || string(*route.Spec.ParentRefs[0].SectionName) != "https" {
+		t.Error("expected SectionName 'https' on parent ref")
+	}
+}
+
+func TestPoolReconcile_TLSRouteCustomPort(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"), withServicePort(9140))
+	c := setupTestClient(pool)
+	r := newPoolReconciler(c, true)
+
+	if err := r.reconcileTLSRoute(testCtx(), pool); err != nil {
+		t.Fatalf("reconcileTLSRoute: %v", err)
+	}
+
+	route := &gwapiv1.TLSRoute{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, route); err != nil {
+		t.Fatalf("TLSRoute not created: %v", err)
+	}
+	if route.Spec.Rules[0].BackendRefs[0].Port == nil || int32(*route.Spec.Rules[0].BackendRefs[0].Port) != 9140 {
+		t.Errorf("expected port 9140 on backend ref")
+	}
+}
+
 func TestPoolReconcile_InjectDNSAltNames(t *testing.T) {
 	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gw"))
 	server := newServer("srv1", withPoolRefs("puppet"))

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -233,3 +233,96 @@ func TestPoolReconcile_UpdateExistingService(t *testing.T) {
 		t.Errorf("Service was not updated: port = %d, want 9140", svc.Spec.Ports[0].Port)
 	}
 }
+
+func TestPoolReconcile_InjectDNSAltNames(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gw"))
+	server := newServer("srv1", withPoolRefs("puppet"))
+	cert := newCertificate("production-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+
+	c := setupTestClient(pool, server, cert)
+	r := newPoolReconciler(c, true)
+
+	if err := r.injectDNSAltNames(testCtx(), pool); err != nil {
+		t.Fatalf("injectDNSAltNames: %v", err)
+	}
+
+	updatedCert := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-cert", Namespace: testNamespace}, updatedCert); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+
+	found := false
+	for _, san := range updatedCert.Spec.DNSAltNames {
+		if san == "puppet.example.com" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DNS alt name 'puppet.example.com' to be injected, got %v", updatedCert.Spec.DNSAltNames)
+	}
+}
+
+func TestPoolReconcile_InjectDNSAltNames_AlreadyPresent(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gw"))
+	server := newServer("srv1", withPoolRefs("puppet"))
+	cert := newCertificate("production-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.Spec.DNSAltNames = []string{"puppet.example.com"}
+
+	c := setupTestClient(pool, server, cert)
+	r := newPoolReconciler(c, true)
+
+	if err := r.injectDNSAltNames(testCtx(), pool); err != nil {
+		t.Fatalf("injectDNSAltNames: %v", err)
+	}
+
+	updatedCert := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-cert", Namespace: testNamespace}, updatedCert); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+
+	count := 0
+	for _, san := range updatedCert.Spec.DNSAltNames {
+		if san == "puppet.example.com" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 occurrence of DNS alt name, got %d in %v", count, updatedCert.Spec.DNSAltNames)
+	}
+}
+
+func TestPoolReconcile_InjectDNSAltNames_NoCertRef(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gw"))
+	server := newServer("srv1", withPoolRefs("puppet"))
+	server.Spec.CertificateRef = "" // no cert
+
+	c := setupTestClient(pool, server)
+	r := newPoolReconciler(c, true)
+
+	if err := r.injectDNSAltNames(testCtx(), pool); err != nil {
+		t.Fatalf("injectDNSAltNames should succeed when server has no cert ref: %v", err)
+	}
+}
+
+func TestPoolReconcile_InjectDNSAltNames_ServerNotInPool(t *testing.T) {
+	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gw"))
+	server := newServer("srv1", withPoolRefs("other-pool"))
+	cert := newCertificate("production-cert", "test-ca", openvoxv1alpha1.CertificatePhaseSigned)
+
+	c := setupTestClient(pool, server, cert)
+	r := newPoolReconciler(c, true)
+
+	if err := r.injectDNSAltNames(testCtx(), pool); err != nil {
+		t.Fatalf("injectDNSAltNames: %v", err)
+	}
+
+	// Cert should be unchanged
+	updatedCert := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-cert", Namespace: testNamespace}, updatedCert); err != nil {
+		t.Fatalf("failed to get Certificate: %v", err)
+	}
+	if len(updatedCert.Spec.DNSAltNames) != 0 {
+		t.Errorf("expected no DNS alt names injected, got %v", updatedCert.Spec.DNSAltNames)
+	}
+}

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -222,6 +222,55 @@ func TestServerReconcile_PDBDeletion(t *testing.T) {
 	}
 }
 
+func TestServerReconcile_PDBUpdate(t *testing.T) {
+	objs := append(serverPrereqs(), newServer("test-server", withPDBEnabled(true)))
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	// First reconcile creates PDB
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("first reconcile error: %v", err)
+	}
+
+	// Second reconcile updates PDB
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("second reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, pdb); err != nil {
+		t.Fatalf("PDB not found: %v", err)
+	}
+	if pdb.Spec.MinAvailable == nil {
+		t.Fatal("PDB minAvailable should be set after update")
+	}
+}
+
+func TestServerReconcile_PDBMaxUnavailable(t *testing.T) {
+	server := newServer("test-server", withPDBEnabled(true))
+	maxUnavail := intstrInt(2)
+	server.Spec.PDB.MaxUnavailable = &maxUnavail
+
+	objs := append(serverPrereqs(), server)
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, pdb); err != nil {
+		t.Fatalf("PDB not created: %v", err)
+	}
+	if pdb.Spec.MaxUnavailable == nil || pdb.Spec.MaxUnavailable.IntVal != 2 {
+		t.Errorf("expected MaxUnavailable=2, got %v", pdb.Spec.MaxUnavailable)
+	}
+	if pdb.Spec.MinAvailable != nil {
+		t.Error("MinAvailable should be nil when MaxUnavailable is set")
+	}
+}
+
 func TestServerReconcile_HPACreation(t *testing.T) {
 	objs := append(serverPrereqs(), newServer("test-server", withAutoscaling(true)))
 	c := setupTestClient(objs...)

--- a/internal/webhook/certificate_webhook_test.go
+++ b/internal/webhook/certificate_webhook_test.go
@@ -9,6 +9,30 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestCertificateValidator_Update(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+	c := setupTestClient(ca)
+	v := &CertificateValidator{Client: c}
+
+	valid := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "my-ca", Certname: "puppet"},
+	}
+	invalid := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "missing-ca", Certname: "puppet"},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), nil, valid); err != nil {
+		t.Errorf("expected no error for valid update, got %v", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, invalid); err == nil {
+		t.Error("expected error for missing CA ref update")
+	}
+}
+
 func TestCertificateValidator(t *testing.T) {
 	ca := &openvoxv1alpha1.CertificateAuthority{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},

--- a/internal/webhook/certificateauthority_webhook_test.go
+++ b/internal/webhook/certificateauthority_webhook_test.go
@@ -9,6 +9,25 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestCertificateAuthorityValidator_Update(t *testing.T) {
+	v := &CertificateAuthorityValidator{}
+	valid := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateAuthoritySpec{TTL: "5y"},
+	}
+	invalid := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateAuthoritySpec{TTL: "5x"},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), nil, valid); err != nil {
+		t.Errorf("expected no error for valid update, got %v", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, invalid); err == nil {
+		t.Error("expected error for invalid TTL update")
+	}
+}
+
 func TestCertificateAuthorityValidator(t *testing.T) {
 	t.Run("valid CA", func(t *testing.T) {
 		v := &CertificateAuthorityValidator{}

--- a/internal/webhook/config_webhook_test.go
+++ b/internal/webhook/config_webhook_test.go
@@ -9,6 +9,30 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestConfigValidator_Update(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+	c := setupTestClient(ca)
+	v := &ConfigValidator{Client: c}
+
+	valid := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.ConfigSpec{AuthorityRef: "my-ca"},
+	}
+	invalid := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.ConfigSpec{AuthorityRef: "missing-ca"},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), nil, valid); err != nil {
+		t.Errorf("expected no error for valid update, got %v", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, invalid); err == nil {
+		t.Error("expected error for missing CA ref update")
+	}
+}
+
 func TestConfigValidator(t *testing.T) {
 	ca := &openvoxv1alpha1.CertificateAuthority{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},

--- a/internal/webhook/nodeclassifier_webhook_test.go
+++ b/internal/webhook/nodeclassifier_webhook_test.go
@@ -9,6 +9,25 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestNodeClassifierValidator_Update(t *testing.T) {
+	v := &NodeClassifierValidator{}
+	valid := &openvoxv1alpha1.NodeClassifier{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.NodeClassifierSpec{URL: "https://foreman.example.com"},
+	}
+	invalid := &openvoxv1alpha1.NodeClassifier{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.NodeClassifierSpec{URL: "not-a-url"},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), nil, valid); err != nil {
+		t.Errorf("expected no error for valid update, got %v", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, invalid); err == nil {
+		t.Error("expected error for invalid URL update")
+	}
+}
+
 func TestNodeClassifierValidator(t *testing.T) {
 	t.Run("valid URL", func(t *testing.T) {
 		v := &NodeClassifierValidator{}

--- a/internal/webhook/pool_webhook_test.go
+++ b/internal/webhook/pool_webhook_test.go
@@ -9,6 +9,25 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestPoolValidator_Update(t *testing.T) {
+	v := &PoolValidator{}
+	valid := &openvoxv1alpha1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.PoolSpec{Service: openvoxv1alpha1.PoolServiceSpec{Port: 8140}},
+	}
+	invalid := &openvoxv1alpha1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.PoolSpec{Service: openvoxv1alpha1.PoolServiceSpec{Port: -1}},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), nil, valid); err != nil {
+		t.Errorf("expected no error for valid update, got %v", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, invalid); err == nil {
+		t.Error("expected error for invalid port update")
+	}
+}
+
 func TestPoolValidator(t *testing.T) {
 	t.Run("valid port", func(t *testing.T) {
 		v := &PoolValidator{}

--- a/internal/webhook/reportprocessor_webhook_test.go
+++ b/internal/webhook/reportprocessor_webhook_test.go
@@ -9,6 +9,30 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestReportProcessorValidator_Update(t *testing.T) {
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "production", Namespace: "default"},
+	}
+	c := setupTestClient(cfg)
+	v := &ReportProcessorValidator{Client: c}
+
+	valid := &openvoxv1alpha1.ReportProcessor{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.ReportProcessorSpec{ConfigRef: "production", URL: "https://puppetdb.example.com"},
+	}
+	invalid := &openvoxv1alpha1.ReportProcessor{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.ReportProcessorSpec{ConfigRef: "production", URL: "not-a-url"},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), nil, valid); err != nil {
+		t.Errorf("expected no error for valid update, got %v", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, invalid); err == nil {
+		t.Error("expected error for invalid URL update")
+	}
+}
+
 func TestReportProcessorValidator(t *testing.T) {
 	cfg := &openvoxv1alpha1.Config{
 		ObjectMeta: metav1.ObjectMeta{Name: "production", Namespace: "default"},

--- a/internal/webhook/signingpolicy_webhook_test.go
+++ b/internal/webhook/signingpolicy_webhook_test.go
@@ -9,6 +9,30 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestSigningPolicyValidator_Update(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+	c := setupTestClient(ca)
+	v := &SigningPolicyValidator{Client: c}
+
+	valid := &openvoxv1alpha1.SigningPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.SigningPolicySpec{CertificateAuthorityRef: "my-ca"},
+	}
+	invalid := &openvoxv1alpha1.SigningPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       openvoxv1alpha1.SigningPolicySpec{CertificateAuthorityRef: "missing-ca"},
+	}
+
+	if _, err := v.ValidateUpdate(context.Background(), nil, valid); err != nil {
+		t.Errorf("expected no error for valid update, got %v", err)
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, invalid); err == nil {
+		t.Error("expected error for missing CA ref update")
+	}
+}
+
 func TestSigningPolicyValidator(t *testing.T) {
 	ca := &openvoxv1alpha1.CertificateAuthority{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},


### PR DESCRIPTION
## Summary

- Improve test coverage across all relevant Go packages (addresses #336)
- Add 2,255 lines of new test code across 22 test files
- No production code changes, test-only

## Coverage Results

| Package | Before | After | Target |
|---|---|---|---|
| internal/controller | 67.4% | **76.7%** | 80% |
| internal/webhook | 84.9% | **88.5%** | 85% |
| cmd/report | 64.7% | **84.1%** | 80% |
| cmd/mock | 73.4% | **80.3%** | 80% |
| cmd/enc | 56.9% | **71.5%** | 75% |
| cmd/autosign | 73.3% | **75.6%** | 80% |
| internal/puppet | 100% | **100%** | keep |

Targets reached: cmd/report, cmd/mock, internal/webhook

## What is tested

- **cmd/enc**: TLS client (CA certs, mTLS, invalid PEM), loadFacts fallback, request body building, error parsing
- **cmd/report**: loadReportConfig, buildHTTPClient (CA/mTLS), PuppetDB transform edge cases
- **cmd/mock**: classifications file reload, invalid YAML, PDB command validation
- **cmd/autosign**: extension decoding fallback, invalid glob patterns
- **internal/controller**: certificate signing flow (submitCSR, fetchSignedCert, signCertificate), reconcileCertSigning with external CA, RBAC, TLSRoute, CRL secret management, status updates, PDB management, DNS alt name injection
- **internal/webhook**: ValidateUpdate for all webhook validators

## Remaining gaps

- internal/controller (76.7%): remaining gaps are in Reconcile main loops and HTTP-dependent paths, better covered by E2E tests
- cmd/enc (71.5%): loadFacts() reads from hardcoded path, not unit-testable without refactoring
- cmd/autosign (75.6%): only main() remains uncovered

## Test plan

- [x] All tests pass locally
- [ ] CI pipeline passes