### PR TITLE
refactor: migrate from deprecated scheme.Builder to runtime.SchemeBuilder

### DIFF
--- a/api/v1alpha1/certificate_types.go
+++ b/api/v1alpha1/certificate_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -116,5 +117,8 @@ const (
 )
 
 func init() {
-	SchemeBuilder.Register(&Certificate{}, &CertificateList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &Certificate{}, &CertificateList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/certificateauthority_types.go
+++ b/api/v1alpha1/certificateauthority_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -172,5 +173,8 @@ const (
 )
 
 func init() {
-	SchemeBuilder.Register(&CertificateAuthority{}, &CertificateAuthorityList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &CertificateAuthority{}, &CertificateAuthorityList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -389,5 +390,8 @@ type PuppetDBSpec struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Config{}, &ConfigList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &Config{}, &ConfigList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -156,5 +157,8 @@ const (
 )
 
 func init() {
-	SchemeBuilder.Register(&Database{}, &DatabaseList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &Database{}, &DatabaseList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -4,8 +4,9 @@
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -13,7 +14,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "openvox.voxpupuli.org", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionResource scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/api/v1alpha1/nodeclassifier_types.go
+++ b/api/v1alpha1/nodeclassifier_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -173,5 +174,8 @@ const (
 )
 
 func init() {
-	SchemeBuilder.Register(&NodeClassifier{}, &NodeClassifierList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &NodeClassifier{}, &NodeClassifierList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/pool_types.go
+++ b/api/v1alpha1/pool_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -117,5 +118,8 @@ type PoolStatus struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Pool{}, &PoolList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &Pool{}, &PoolList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/reportprocessor_types.go
+++ b/api/v1alpha1/reportprocessor_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -144,5 +145,8 @@ const (
 )
 
 func init() {
-	SchemeBuilder.Register(&ReportProcessor{}, &ReportProcessorList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &ReportProcessor{}, &ReportProcessorList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -200,5 +201,8 @@ const (
 )
 
 func init() {
-	SchemeBuilder.Register(&Server{}, &ServerList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &Server{}, &ServerList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/signingpolicy_types.go
+++ b/api/v1alpha1/signingpolicy_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +kubebuilder:object:root=true
@@ -116,5 +117,8 @@ const (
 )
 
 func init() {
-	SchemeBuilder.Register(&SigningPolicy{}, &SigningPolicyList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(GroupVersion, &SigningPolicy{}, &SigningPolicyList{})
+		return nil
+	})
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 


### PR DESCRIPTION
## Summary
- Replace `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` with `k8s.io/apimachinery/pkg/runtime.SchemeBuilder` as recommended by the upstream deprecation notice
- Removes the `controller-runtime` dependency from the API package
- Fixes the `SA1019` staticcheck lint failure in #333

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI lint (`golangci-lint`) passes
- [ ] CI tests pass