### PR TITLE
feat: split E2E tests into individual matrix jobs

### DIFF
--- a/.github/workflows/_e2e-run.yaml
+++ b/.github/workflows/_e2e-run.yaml
@@ -7,8 +7,12 @@ on:
         description: 'Image tag to use for E2E tests'
         required: true
         type: string
-      group:
-        description: 'Test group to run (base, enc, gateway, webhooks-cm)'
+      operator:
+        description: 'Operator variant to install (base, gateway, webhooks-cm)'
+        required: true
+        type: string
+      tests:
+        description: 'JSON array of test names to run'
         required: true
         type: string
 
@@ -33,12 +37,17 @@ jobs:
       - name: Cleanup previous run
         run: make e2e-cleanup
 
-      - name: Verify cluster connectivity
-        run: kubectl get nodes
+      - name: Install operator (${{ inputs.operator }})
+        run: make e2e-operator-${{ inputs.operator }} IMAGE_TAG=${{ inputs.image_tag }}
 
   e2e-test:
     needs: [e2e-setup]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        test: ${{ fromJson(inputs.tests) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -55,5 +64,22 @@ jobs:
           chmod 600 ~/.kube/config
           kubectl version --short 2>/dev/null || kubectl version
 
-      - name: Run ${{ inputs.group }} test group
-        run: make e2e-group-${{ inputs.group }} IMAGE_TAG=${{ inputs.image_tag }}
+      - name: Run ${{ matrix.test }}
+        run: make e2e-run-test TEST=${{ matrix.test }} IMAGE_TAG=${{ inputs.image_tag }}
+
+  e2e-cleanup:
+    needs: [e2e-test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.E2E_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Cleanup
+        run: make e2e-cleanup

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,8 @@ jobs:
     uses: ./.github/workflows/_e2e-run.yaml
     with:
       image_tag: ${{ inputs.image_tag }}
-      group: base
+      operator: base
+      tests: '["single-node","multi-server","agent-basic","agent-broken","agent-idempotent","agent-concurrent","agent-report","database-cnpg","readonly-rootfs","code-pvc","autosign-policy","cert-rotation"]'
     secrets: inherit
 
   e2e-enc:
@@ -22,7 +23,8 @@ jobs:
     uses: ./.github/workflows/_e2e-run.yaml
     with:
       image_tag: ${{ inputs.image_tag }}
-      group: enc
+      operator: base
+      tests: '["agent-enc","agent-full"]'
     secrets: inherit
 
   e2e-gateway:
@@ -30,7 +32,8 @@ jobs:
     uses: ./.github/workflows/_e2e-run.yaml
     with:
       image_tag: ${{ inputs.image_tag }}
-      group: gateway
+      operator: gateway
+      tests: '["pool-gateway"]'
     secrets: inherit
 
   e2e-webhooks-cm:
@@ -38,5 +41,6 @@ jobs:
     uses: ./.github/workflows/_e2e-run.yaml
     with:
       image_tag: ${{ inputs.image_tag }}
-      group: webhooks-cm
+      operator: webhooks-cm
+      tests: '["webhook-validation-server","webhook-validation-config","webhook-validation-database","webhook-smoke"]'
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -277,6 +277,11 @@ e2e-operator-webhooks-cm: e2e-cleanup ## Install operator: webhooks=true, cert-m
 	kubectl wait --for=condition=Available deployment/openvox-operator \
 		-n $(NAMESPACE) --timeout=2m
 
+.PHONY: e2e-run-test
+e2e-run-test: chainsaw ## Run a single E2E test. Usage: make e2e-run-test TEST=single-node
+	$(E2E_CHAINSAW) tests/e2e/$(TEST); \
+	EXIT=$$?; kubectl get namespaces -o name | grep '^namespace/e2e-' | xargs -r kubectl delete --timeout=120s --ignore-not-found 2>/dev/null || true; exit $$EXIT
+
 .PHONY: e2e-group-base
 e2e-group-base: e2e-operator-base chainsaw ## Group: base tests (stack, agent, database).
 	$(E2E_CHAINSAW) \


### PR DESCRIPTION
## Summary
- Run each E2E test as a separate matrix job with `max-parallel: 1`
- Better visibility: each test shows as its own job in the GitHub Actions UI
- No more timeouts from one slow/flaky test killing the entire group
- New `make e2e-run-test TEST=<name>` target for running single tests locally
- Cleanup job runs `if: always()` to ensure cluster is cleaned up

Relates to #347

## Test plan
- [ ] Trigger E2E workflow and verify each test shows as individual job
- [ ] Verify jobs run sequentially (max-parallel: 1)
- [ ] Verify failed test does not block other tests (fail-fast: false)
- [ ] Verify cleanup job runs even on failure