### PR TITLE
fix: set renewal cooldown before status/secret to prevent double renewal

### DIFF
--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -469,20 +469,6 @@ func (r *CertificateReconciler) reconcileCertRenewal(ctx context.Context, cert *
 	r.Recorder.Eventf(cert, nil, corev1.EventTypeNormal, EventReasonCertificateRenewed, "Reconcile",
 		"Certificate renewed successfully in Secret %s/%s-tls", cert.Namespace, cert.Name)
 
-	// Record renewal time and reset expiry warnings for the new cert.
-	// If the patch fails, requeue with cooldown interval to avoid a tight
-	// re-renewal loop (the cooldown annotation would be missing).
-	patch := client.MergeFrom(cert.DeepCopy())
-	if cert.Annotations == nil {
-		cert.Annotations = make(map[string]string)
-	}
-	cert.Annotations[AnnotationLastRenewalTime] = r.Clock.Now().UTC().Format(time.RFC3339)
-	delete(cert.Annotations, AnnotationExpiryWarned)
-	if patchErr := r.Patch(ctx, cert, patch); patchErr != nil {
-		logger.Error(patchErr, "failed to update renewal annotations, requeueing with cooldown")
-		return ctrl.Result{RequeueAfter: minRenewalCooldown}, nil
-	}
-
 	logger.Info("certificate renewed successfully", "certname", cert.Spec.Certname)
 	return r.scheduleRenewalCheck(ctx, cert)
 }
@@ -613,6 +599,20 @@ func (r *CertificateReconciler) renewCertificate(ctx context.Context, cert *open
 	pemBlock, _ := pem.Decode(body)
 	if pemBlock == nil || pemBlock.Type != "CERTIFICATE" {
 		return fmt.Errorf("renewal response is not a valid PEM certificate")
+	}
+
+	// Set the renewal cooldown annotation BEFORE updating status or Secret.
+	// This prevents a concurrent reconcile from seeing Signed + no cooldown
+	// and triggering a second renewal that would overwrite the Secret with
+	// a different key, causing a cert/key mismatch.
+	patch := client.MergeFrom(cert.DeepCopy())
+	if cert.Annotations == nil {
+		cert.Annotations = make(map[string]string)
+	}
+	cert.Annotations[AnnotationLastRenewalTime] = r.Clock.Now().UTC().Format(time.RFC3339)
+	delete(cert.Annotations, AnnotationExpiryWarned)
+	if err := r.Patch(ctx, cert, patch); err != nil {
+		return fmt.Errorf("setting renewal cooldown annotation: %w", err)
 	}
 
 	// Update Certificate status to Signed BEFORE updating the TLS Secret.


### PR DESCRIPTION
## Summary
- Root cause of #347: during certificate renewal, the cooldown annotation was written AFTER the status and secret updates
- A concurrent reconcile could see `Signed` status with no cooldown annotation and trigger a second renewal
- The second renewal generates a different key pair and overwrites the TLS secret, causing a **cert/key mismatch**
- This breaks TLS handshakes and the Server pod never becomes ready

### The race

```
Reconcile A: renewCertificate() -> writes Secret (cert+keyB) -> sets Signed -> [gap] -> writes cooldown
Reconcile B:                       (triggered by Secret change) -> sees Signed, no cooldown -> triggers renewal!
Reconcile B: renewCertificate() -> writes Secret (cert+keyC) -> MISMATCH with keyB hash in pod annotation
```

### The fix

Move cooldown annotation + status update + secret update into `renewCertificate()` in this order:
1. Set cooldown annotation (prevents concurrent renewal)
2. Set status to Signed (Server sees correct phase)
3. Update TLS Secret (triggers Server watcher)

Fixes #347

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/controller/` passes
- [ ] CI lint + tests pass
- [ ] E2E cert-rotation test passes