### PR TITLE
fix: bump Go to 1.26.3 and regenerate CRD manifests

### DIFF
--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: certificateauthorities.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: certificates.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: configs.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: databases.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_nodeclassifiers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_nodeclassifiers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodeclassifiers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_pools.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_pools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: pools.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_reportprocessors.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_reportprocessors.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: reportprocessors.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: servers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_signingpolicies.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_signingpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: signingpolicies.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificateauthorities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: certificateauthorities.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: certificates.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: configs.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_databases.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_databases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: databases.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_nodeclassifiers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_nodeclassifiers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nodeclassifiers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_pools.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_pools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: pools.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_reportprocessors.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_reportprocessors.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: reportprocessors.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: servers.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/config/crd/bases/openvox.voxpupuli.org_signingpolicies.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_signingpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: signingpolicies.openvox.voxpupuli.org
 spec:
   group: openvox.voxpupuli.org

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slauger/openvox-operator
 
-go 1.26.2
+go 1.26.3
 
 require (
 	gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Summary

- Bump Go version from 1.26.2 to 1.26.3 in go.mod to fix two standard library vulnerabilities:
  - GO-2026-4971: Panic in Dial and LookupPort when handling NUL byte on Windows (net)
  - GO-2026-4918: Infinite loop in HTTP/2 transport with bad SETTINGS_MAX_FRAME_SIZE (net/http)
- Regenerate CRD manifests to match updated controller-gen output

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all unit tests pass
- [x] `make manifests` output committed
- [ ] CI checks
