### PR TITLE
fix: add cosign registry login for Helm chart signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,9 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.2
 
       - name: Login to ghcr.io
-        run: echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: |
+          echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ github.token }}" | cosign login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Inject version into Chart.yaml
         run: |


### PR DESCRIPTION
## Summary

- Add `cosign login ghcr.io` alongside `helm registry login` in the helm-charts release job
- Cosign needs its own registry authentication to push signature blobs - the Helm login does not share credentials

Fixes the `UNAUTHORIZED: unauthenticated` error during chart signing.

## Test plan

- [ ] Release workflow completes successfully with chart signing