### PR TITLE
fix: wrap bare error returns in controller helpers with context

### DIFF
--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -171,11 +171,11 @@ func (r *ConfigReconciler) reconcileConfigMap(ctx context.Context, cfg *openvoxv
 			Data: data,
 		}
 		if err := controllerutil.SetControllerReference(cfg, cm, r.Scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on ConfigMap %s: %w", configMapName, err)
 		}
 		return r.Create(ctx, cm)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("getting ConfigMap %s: %w", configMapName, err)
 	}
 
 	cm.Data = data
@@ -198,11 +198,11 @@ func (r *ConfigReconciler) reconcileSecret(ctx context.Context, cfg *openvoxv1al
 			Data: data,
 		}
 		if err := controllerutil.SetControllerReference(cfg, secret, r.Scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on Secret %s: %w", name, err)
 		}
 		return r.Create(ctx, secret)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("getting Secret %s: %w", name, err)
 	}
 
 	existing.Data = data

--- a/internal/controller/config_serviceaccount.go
+++ b/internal/controller/config_serviceaccount.go
@@ -29,11 +29,11 @@ func (r *ConfigReconciler) reconcileServerServiceAccount(ctx context.Context, cf
 			AutomountServiceAccountToken: &automount,
 		}
 		if err := controllerutil.SetControllerReference(cfg, sa, r.Scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on ServiceAccount %s: %w", saName, err)
 		}
 		return r.Create(ctx, sa)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("getting ServiceAccount %s: %w", saName, err)
 	}
 	return nil
 }

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -138,11 +138,11 @@ func createOrUpdateSecret(ctx context.Context, c client.Client, scheme *runtime.
 			Data: data,
 		}
 		if err := controllerutil.SetControllerReference(owner, secret, scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on Secret %s: %w", name, err)
 		}
 		return c.Create(ctx, secret)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("getting Secret %s: %w", name, err)
 	}
 
 	secret.Data = data


### PR DESCRIPTION
## Summary
- Wrap bare `return err` with `fmt.Errorf` context in `config_serviceaccount.go`, `config_controller.go`, and `helpers.go`
- Adds resource type and name to error messages for better traceability in controller logs

Closes #373