### PR TITLE
feat: add Conforma supply chain policy validation

### DIFF
--- a/.conforma/policy.yaml
+++ b/.conforma/policy.yaml
@@ -1,0 +1,14 @@
+sources:
+  - name: supply-chain-security
+    policy:
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
+    config:
+      include:
+        - '@minimal'
+        - '@github'
+    data:
+      rule_data:
+        allowed_registry_prefixes:
+          - "registry.access.redhat.com/"
+          - "registry.redhat.io/"

--- a/.conforma/policy.yaml
+++ b/.conforma/policy.yaml
@@ -1,14 +1,13 @@
 sources:
   - name: supply-chain-security
     policy:
-      - github.com/conforma/policy//policy/lib
-      - github.com/conforma/policy//policy/release
+      - github.com/conforma/policy//policy/lib?ref=v1.0.22
+      - github.com/conforma/policy//policy/release?ref=v1.0.22
     config:
       include:
         - '@minimal'
         - '@github'
-    data:
-      rule_data:
-        allowed_registry_prefixes:
-          - "registry.access.redhat.com/"
-          - "registry.redhat.io/"
+    ruleData:
+      allowed_registry_prefixes:
+        - "registry.access.redhat.com/"
+        - "registry.redhat.io/"

--- a/.github/workflows/_conforma-validate.yaml
+++ b/.github/workflows/_conforma-validate.yaml
@@ -1,0 +1,60 @@
+name: Conforma Validate
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Full image reference (registry/owner/name:tag)'
+        required: true
+        type: string
+      digest:
+        description: 'Image manifest digest (sha256:...)'
+        required: true
+        type: string
+      strict:
+        description: 'Fail on policy violations'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    env:
+      # renovate: datasource=github-releases depName=conforma/cli
+      EC_VERSION: "0.9.37"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install ec CLI
+        run: |
+          cd /tmp
+          curl -sSLO "https://github.com/conforma/cli/releases/download/v${EC_VERSION}/ec_linux_amd64"
+          curl -sSLO "https://github.com/conforma/cli/releases/download/v${EC_VERSION}/ec_linux_amd64.sha256"
+          sha256sum --check ec_linux_amd64.sha256
+          chmod +x ec_linux_amd64
+          sudo mv ec_linux_amd64 /usr/local/bin/ec
+
+      - name: Login to ghcr.io
+        run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Validate image with Conforma
+        run: |
+          ARGS=(
+            validate image
+            --image "${{ inputs.image }}@${{ inputs.digest }}"
+            --policy .conforma/policy.yaml
+            --certificate-identity-regexp "https://github.com/${{ github.repository }}/"
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+            --show-successes
+            --output yaml
+          )
+          if [[ "${{ inputs.strict }}" == "true" ]]; then
+            ARGS+=(--strict)
+          fi
+          ec "${ARGS[@]}"

--- a/.github/workflows/_container-build.yaml
+++ b/.github/workflows/_container-build.yaml
@@ -48,6 +48,9 @@ on:
       image:
         description: 'Full image reference'
         value: ${{ jobs.manifest.outputs.image }}
+      digest:
+        description: 'Image manifest digest'
+        value: ${{ jobs.manifest.outputs.digest }}
 
 jobs:
   prepare:
@@ -152,6 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.result.outputs.image }}
+      digest: ${{ steps.result.outputs.digest }}
     permissions:
       packages: write
       id-token: write
@@ -199,4 +203,8 @@ jobs:
       - name: Set output
         id: result
         run: |
-          echo "image=ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ needs.prepare.outputs.version }}" >> $GITHUB_OUTPUT
+          IMAGE="ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}"
+          VERSION="${{ needs.prepare.outputs.version }}"
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "image=${IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,42 @@ jobs:
       latest: true
       image_tag: ${{ needs.semantic-release.outputs.new-release-version }}
 
+  validate-openvox-operator:
+    needs: [semantic-release, openvox-operator]
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    uses: ./.github/workflows/_conforma-validate.yaml
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    with:
+      image: ${{ needs.openvox-operator.outputs.image }}
+      digest: ${{ needs.openvox-operator.outputs.digest }}
+
+  validate-openvox-server:
+    needs: [semantic-release, openvox-server]
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    uses: ./.github/workflows/_conforma-validate.yaml
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    with:
+      image: ${{ needs.openvox-server.outputs.image }}
+      digest: ${{ needs.openvox-server.outputs.digest }}
+
+  validate-openvox-db:
+    needs: [semantic-release, openvox-db]
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    uses: ./.github/workflows/_conforma-validate.yaml
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    with:
+      image: ${{ needs.openvox-db.outputs.image }}
+      digest: ${{ needs.openvox-db.outputs.digest }}
+
   helm-charts:
     needs: [semantic-release, openvox-operator, openvox-server, openvox-db]
     if: needs.semantic-release.outputs.new-release-published == 'true'

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ All container images are:
 - **Signed** with [cosign](https://docs.sigstore.dev/cosign/) keyless signing (Sigstore OIDC)
 - **Attested** with [SLSA provenance](https://slsa.dev/) via `docker/build-push-action`
 - **SBOM** generated and attached to each image
+- **Validated** with [Conforma](https://github.com/conforma) policies (base image registries, signatures, SBOM, provenance)
 
 Verify image signatures:
 

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/).github/workflows/_helm\\.yaml$/"
+        "/(^|/).github/workflows/_helm\\.yaml$/",
+        "/(^|/).github/workflows/_conforma-validate\\.yaml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+_VERSION: \"(?<currentValue>[^\"]+)\""


### PR DESCRIPTION
## Summary

- Add Conforma (`ec` CLI) policy validation for container images in the release pipeline
- Validates base image registries, cosign signatures, SBOM, and SLSA provenance attestations
- Uses `@minimal` and `@github` policy collections (excludes Tekton-specific policies)
- Initial rollout in non-blocking mode (`strict: false`)

## Changes

- **`.conforma/policy.yaml`**: Policy config with allowed registry prefixes (`registry.access.redhat.com/`, `registry.redhat.io/`)
- **`_conforma-validate.yaml`**: Reusable workflow - installs checksummed `ec` binary, validates image against policy
- **`_container-build.yaml`**: Exposes image manifest `digest` as workflow output
- **`release.yaml`**: Adds three validation jobs (operator, server, db) running parallel to helm-charts
- **`renovate.json`**: Tracks `ec` CLI version via custom regex manager

## Notes

- CVE policy rules are included but will only produce warnings until a vulnerability scanner (Trivy/Grype) is added as a follow-up
- Validation runs parallel to helm-charts packaging and does not gate the release yet
- To enable strict mode later, set `strict: true` in the release.yaml validation jobs

Closes #155, closes #156, closes #158, closes #159