### PR TITLE
fix: idiomatic error handling in CA RBAC and PVC reconcilers

### DIFF
--- a/internal/controller/certificateauthority_pvc.go
+++ b/internal/controller/certificateauthority_pvc.go
@@ -46,9 +46,11 @@ func (r *CertificateAuthorityReconciler) reconcileCAPVC(ctx context.Context, ca 
 		}
 
 		if err := controllerutil.SetControllerReference(ca, pvc, r.Scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on PVC %s: %w", pvcName, err)
 		}
 		return r.Create(ctx, pvc)
+	} else if err != nil {
+		return fmt.Errorf("getting PVC %s: %w", pvcName, err)
 	}
-	return err
+	return nil
 }

--- a/internal/controller/certificateauthority_rbac.go
+++ b/internal/controller/certificateauthority_rbac.go
@@ -55,12 +55,13 @@ func (r *CertificateAuthorityReconciler) ensureCAServiceAccount(ctx context.Cont
 			},
 		}
 		if err := controllerutil.SetControllerReference(owner, sa, r.Scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on ServiceAccount %s: %w", name, err)
 		}
 		return r.Create(ctx, sa)
-	} else {
-		return err
+	} else if err != nil {
+		return fmt.Errorf("getting ServiceAccount %s: %w", name, err)
 	}
+	return nil
 }
 
 func (r *CertificateAuthorityReconciler) ensureCARole(ctx context.Context, name, namespace string, labels map[string]string, resourceNames []string, owner *openvoxv1alpha1.CertificateAuthority) error {
@@ -88,11 +89,11 @@ func (r *CertificateAuthorityReconciler) ensureCARole(ctx context.Context, name,
 			},
 		}
 		if err := controllerutil.SetControllerReference(owner, role, r.Scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on Role %s: %w", name, err)
 		}
 		return r.Create(ctx, role)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("getting Role %s: %w", name, err)
 	}
 
 	role.Rules = []rbacv1.PolicyRule{
@@ -135,11 +136,11 @@ func (r *CertificateAuthorityReconciler) ensureCARoleBinding(ctx context.Context
 			},
 		}
 		if err := controllerutil.SetControllerReference(owner, rb, r.Scheme); err != nil {
-			return err
+			return fmt.Errorf("setting owner reference on RoleBinding %s: %w", name, err)
 		}
 		return r.Create(ctx, rb)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("getting RoleBinding %s: %w", name, err)
 	}
 
 	rb.Subjects = []rbacv1.Subject{


### PR DESCRIPTION
## Summary

- Fix unidiomatisches `else { return err }` in `ensureCAServiceAccount` zu `else if err != nil`
- Wrap bare error returns mit `fmt.Errorf` Context in `certificateauthority_rbac.go` und `certificateauthority_pvc.go`

Closes #396