### PR TITLE
ci: pin golangci-lint version with Renovate tracking

### DIFF
--- a/.github/workflows/_go.yaml
+++ b/.github/workflows/_go.yaml
@@ -36,7 +36,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: "v2.12.2"
 
   vulncheck:
     runs-on: ubuntu-latest

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,16 @@
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+_VERSION: \"(?<currentValue>[^\"]+)\""
       ],
       "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).github/workflows/_go\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: \"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

- Pin golangci-lint to v2.12.2 instead of `latest` for deterministic CI
- Add Renovate custom regex manager to auto-update the pinned version

Previously `version: latest` could cause non-deterministic lint failures when a new golangci-lint release introduced new rules.