### PR TITLE
fix: resolve mkdocs strict mode build warnings

### DIFF
--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -35,7 +35,7 @@ Autosigning is configured via [SigningPolicy](signingpolicy.md) resources that r
 
 ### ExternalCASpec
 
-Configures an external CA running outside the cluster. When set, the operator delegates CSR signing and CRL fetching to the external CA URL instead of managing its own CA infrastructure. See the [External CA guide](../guides/ca-import.md#option-b-external-ca-ongoing-delegation) for step-by-step setup instructions.
+Configures an external CA running outside the cluster. When set, the operator delegates CSR signing and CRL fetching to the external CA URL instead of managing its own CA infrastructure. See the [External CA guide](../guides/ca-import.md#external-ca-ongoing-delegation) for step-by-step setup instructions.
 
 !!! warning "Mutual exclusivity"
     `spec.external` and custom `spec.storage` are mutually exclusive. A CEL validation rule rejects resources that set both. External CAs do not need local storage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,9 +79,6 @@ nav:
       - Mock Server: development/mock-server.md
   - Reference:
       - Overview: reference/index.md
-      - openvox-operator: ../charts/openvox-operator/README.md
-      - openvox-stack: ../charts/openvox-stack/README.md
-      - openvox-db-postgres: ../charts/openvox-db-postgres/README.md
       - Helper Binaries: reference/binaries.md
       - Config: reference/config.md
       - CertificateAuthority: reference/certificateauthority.md


### PR DESCRIPTION
## Summary

- Remove chart README references (`../charts/*/README.md`) from mkdocs nav -- these files are outside the docs directory and not suitable for mkdocs (generated by helm-docs, different style)
- Fix broken anchor link in `certificateauthority.md`: `#option-b-external-ca-ongoing-delegation` -> `#external-ca-ongoing-delegation`

Fixes the docs build failure: https://github.com/slauger/openvox-operator/actions/runs/26846857973

## Test plan

- [ ] Docs CI workflow passes with `mkdocs build --strict`