### PR TITLE
ci: allow govulncheck to fail without blocking the pipeline

### DIFF
--- a/.github/workflows/_go.yaml
+++ b/.github/workflows/_go.yaml
@@ -41,6 +41,7 @@ jobs:
 
   vulncheck:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Adds continue-on-error: true to the vulncheck job in the Go CI workflow.

govulncheck findings in upstream dependencies were blocking unrelated PRs. With this change, vulncheck still runs and reports findings, but no longer fails the pipeline.