### PR TITLE
fix(ci): strip dist/ prefix from conforma cli sha256 checksum

### DIFF
--- a/.github/workflows/_conforma-validate.yaml
+++ b/.github/workflows/_conforma-validate.yaml
@@ -36,6 +36,7 @@ jobs:
           cd /tmp
           curl -sSLO "https://github.com/conforma/cli/releases/download/v${EC_VERSION}/ec_linux_amd64"
           curl -sSLO "https://github.com/conforma/cli/releases/download/v${EC_VERSION}/ec_linux_amd64.sha256"
+          sed -i 's|dist/||' ec_linux_amd64.sha256
           sha256sum --check ec_linux_amd64.sha256
           chmod +x ec_linux_amd64
           sudo mv ec_linux_amd64 /usr/local/bin/ec


### PR DESCRIPTION
conforma/cli v0.9.44 changed its sha256 checksum file to reference `dist/ec_linux_amd64` instead of `ec_linux_amd64`, causing the release pipeline to fail with:

```
sha256sum: dist/ec_linux_amd64: No such file or directory
dist/ec_linux_amd64: FAILED open or read
```

Strips the `dist/` prefix from the checksum file before verification.

Fixes https://github.com/slauger/openvox-operator/actions/runs/27648962439/job/81768284488