### PR TITLE
fix(webhook): give ValidatingWebhookConfiguration a descriptive name

### DIFF
--- a/charts/openvox-operator/templates/webhook-configuration.yaml
+++ b/charts/openvox-operator/templates/webhook-configuration.yaml
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: {{ include "openvox-operator.fullname" . }}
+  name: {{ include "openvox-operator.fullname" . }}-validating-webhook-configuration
   {{- if .Values.webhook.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "openvox-operator.fullname" . }}-webhook

--- a/charts/openvox-operator/tests/webhook-configuration_test.yaml
+++ b/charts/openvox-operator/tests/webhook-configuration_test.yaml
@@ -16,6 +16,9 @@ tests:
           of: ValidatingWebhookConfiguration
       - isAPIVersion:
           of: admissionregistration.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-openvox-operator-validating-webhook-configuration
 
   - it: should have cert-manager inject-ca-from annotation
     set:


### PR DESCRIPTION
## Problem

The `e2e-webhooks-cm / e2e-test (webhook-smoke)` job fails on its very first step:

```
| webhook-smoke | ValidatingWebhookConfiguration exists | ASSERT | ERROR
        === ERROR
        actual resource not found
--- FAIL: chainsaw/webhook-smoke (301.14s)
```

The chart renders the `ValidatingWebhookConfiguration` with the bare release fullname (`openvox-operator`), while the smoke test asserts a resource named `openvox-operator-validating-webhook-configuration`. The names never matched, so the assertion polled for the full 5-minute assert timeout and then failed with `actual resource not found`.

This is a pre-existing mismatch (present since the webhook chart template and the smoke test were both introduced), not a regression. The other webhook validation tests pass because they exercise the webhook indirectly (apply an invalid CR, expect rejection) and never reference the webhook configuration by name.

## Change

- Name the resource `{fullname}-validating-webhook-configuration`, consistent with the existing `{fullname}-webhook` Service suffix and aligned with the e2e expectation.
- Add a `metadata.name` assertion to the helm unittest so the name is locked down going forward.

## Notes / safety

- The cert-manager `inject-ca-from` annotation references the **Service** (`{fullname}-webhook`), not the webhook config name, so CA injection is unaffected.
- No Go/operator code references the webhook configuration by name.
- All 46 chart unittests pass (`helm unittest charts/openvox-operator`).
- This renames a cluster-scoped resource; on `helm upgrade` of an existing install Helm replaces the old-named config with the new one.