### PR TITLE
fix(renovate): scope OpenVox versions group to OpenVoxProject deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -76,7 +76,22 @@
       "matchDatasources": [
         "github-releases"
       ],
+      "matchPackageNames": [
+        "OpenVoxProject/*"
+      ],
       "groupName": "OpenVox versions"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchPackageNames": [
+        "!OpenVoxProject/*"
+      ],
+      "groupName": "CI tooling"
     }
   ]
 }


### PR DESCRIPTION
## Problem

The `OpenVox versions` package rule matched **every** `custom.regex` + `github-releases` dependency:

```json
{
  "matchManagers": ["custom.regex"],
  "matchDatasources": ["github-releases"],
  "groupName": "OpenVox versions"
}
```

But only three of those deps are actually OpenVox. The rest are CI tooling pinned the same way (`# renovate: datasource=github-releases depName=...`):

| depName | OpenVox? |
|---|---|
| `OpenVoxProject/openvox` | yes |
| `OpenVoxProject/openvox-server` | yes |
| `OpenVoxProject/openvoxdb` | yes |
| `conforma/cli` | no |
| `golangci/golangci-lint` | no |
| `norwoodj/helm-docs` | no |
| `losisin/helm-values-schema-json` | no |

So a `conforma/cli` 0.9.44 -> 0.9.48 bump was opened as **'chore(deps): update openvox versions to v0.9.48'** (#421) - which is not an OpenVox version at all.

## Change

- Restrict `OpenVox versions` to `OpenVoxProject/*`.
- Route the remaining tooling deps into a separate `CI tooling` group, so they stay batched but correctly labeled.

## Notes

- `renovate-config-validator` reports no errors on the changed `packageRules`. (Pre-existing `managerFilePatterns` warnings come from the local validator version and are unrelated to this change.)
- After merge, #421 should re-open under the `CI tooling` group with a correct title.