### PR TITLE
chore(deps): update ubi-minimal base images to 9.8-1782191395

### DIFF
--- a/images/openvox-mock/Containerfile
+++ b/images/openvox-mock/Containerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY cmd/mock/ cmd/mock/
 RUN CGO_ENABLED=0 go build -o /openvox-mock ./cmd/mock/
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782191395
 
 LABEL org.opencontainers.image.title="OpenVox Mock" \
       org.opencontainers.image.description="Mock ENC/Report/OpenVox DB receiver for E2E tests" \

--- a/images/openvox-operator/Containerfile
+++ b/images/openvox-operator/Containerfile
@@ -9,7 +9,7 @@ COPY internal/ internal/
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager ./cmd/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782191395
 
 LABEL org.opencontainers.image.title="OpenVox Operator" \
       org.opencontainers.image.description="OpenVox Operator for Kubernetes/OpenShift" \


### PR DESCRIPTION
Updates ubi9/ubi-minimal base images for openvox-operator and openvox-mock Containerfiles.

Picks up the remaining ubi-minimal update that Renovate added after #428 was merged.