### PR TITLE
fix(ci): use @github policy set for Conforma validation

### DIFF
--- a/.conforma/policy.yaml
+++ b/.conforma/policy.yaml
@@ -5,7 +5,6 @@ sources:
       - github.com/conforma/policy//policy/release?ref=v1.0.22
     config:
       include:
-        - '@minimal'
         - '@github'
     ruleData:
       allowed_registry_prefixes:


### PR DESCRIPTION
The `@minimal` policy set expects Tekton PipelineRun attestations (`attestation_type.pipelinerun_attestation_found`) which do not exist in GitHub Actions builds. It also checks per-platform image attestations in Sigstore format, while `docker/build-push-action` attaches provenance as inline OCI manifests.

Removes `@minimal` and keeps only `@github`, which validates:
- GitHub-native build provenance attestations (from `actions/attest-build-provenance`)
- Cosign keyless signatures
- Image signature verification

This fixes the Conforma validation failures in the release pipeline.