### PR TITLE
Release v0.9.2

### DIFF
--- a/.conforma/policy.yaml
+++ b/.conforma/policy.yaml
@@ -5,7 +5,6 @@ sources:
       - github.com/conforma/policy//policy/release?ref=v1.0.22
     config:
       include:
-        - '@minimal'
         - '@github'
     ruleData:
       allowed_registry_prefixes:


### PR DESCRIPTION
Merge develop into main for release.

Includes fix for Conforma validation: removed @minimal policy set (expects Tekton PipelineRun attestations) and added manifest-level build provenance attestations.