### PR TITLE
fix(ci): pass --strict=false explicitly to ec validate

### DIFF
--- a/.github/workflows/_conforma-validate.yaml
+++ b/.github/workflows/_conforma-validate.yaml
@@ -57,5 +57,7 @@ jobs:
           )
           if [[ "${{ inputs.strict }}" == "true" ]]; then
             ARGS+=(--strict)
+          else
+            ARGS+=(--strict=false)
           fi
           ec "${ARGS[@]}"


### PR DESCRIPTION
The `ec` CLI defaults to `--strict=true`, causing a non-zero exit code even when the workflow input `strict` is `false`. The workflow only added `--strict` when true but never passed `--strict=false` explicitly.

This caused the Conforma validation to fail the release pipeline even though strict mode was not enabled, because the per-platform provenance/SBOM sub-manifests in the multi-arch manifest index have no Sigstore attestations (they are attached as inline OCI manifests by `docker/build-push-action`).