### PR TITLE
fix(helm): default readOnlyRootFilesystem to true in openvox-stack

### DIFF
--- a/charts/openvox-stack/README.md
+++ b/charts/openvox-stack/README.md
@@ -59,7 +59,7 @@ helm install openvox oci://ghcr.io/slauger/charts/openvox-stack
 | config.puppet.storeBackend | string | `""` | Storage backend for stored configurations. |
 | config.puppet.storeconfigs | bool | `false` | Enable stored configurations. |
 | config.puppetdb.serverUrls | list | `[]` | PuppetDB server URLs for report storage. |
-| config.readOnlyRootFilesystem | bool | `false` | Enable read-only root filesystem for server containers. |
+| config.readOnlyRootFilesystem | bool | `true` | Enable read-only root filesystem for server containers. |
 | database.certificate.certname | string | `""` | Certificate common name for PuppetDB. Required when enabled. |
 | database.certificate.dnsAltNames | list | `[]` | Additional DNS subject alternative names. |
 | database.enabled | bool | `false` | Enable PuppetDB database deployment. |

--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -22,9 +22,7 @@ spec:
   {{- else if and .Values.database.enabled .Values.database.name }}
   databaseRef: {{ .Values.database.name }}
   {{- end }}
-  {{- if .Values.config.readOnlyRootFilesystem }}
-  readOnlyRootFilesystem: true
-  {{- end }}
+  readOnlyRootFilesystem: {{ .Values.config.readOnlyRootFilesystem }}
   puppet:
     {{- with .Values.config.puppet.environmentTimeout }}
     environmentTimeout: {{ . }}

--- a/charts/openvox-stack/tests/config_test.yaml
+++ b/charts/openvox-stack/tests/config_test.yaml
@@ -18,19 +18,20 @@ tests:
           path: spec.image.repository
           value: ghcr.io/slauger/openvox-server
 
-  - it: should set readOnlyRootFilesystem when true
-    set:
-      config:
-        readOnlyRootFilesystem: true
+  - it: should set readOnlyRootFilesystem to true by default
     asserts:
       - equal:
           path: spec.readOnlyRootFilesystem
           value: true
 
-  - it: should not set readOnlyRootFilesystem when false (default)
+  - it: should set readOnlyRootFilesystem to false when configured
+    set:
+      config:
+        readOnlyRootFilesystem: false
     asserts:
-      - isNull:
+      - equal:
           path: spec.readOnlyRootFilesystem
+          value: false
 
   - it: should use databaseRef when database is enabled and no serverUrls
     set:

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -9,7 +9,7 @@ config:
   name: ""
   # @schema description: Enable read-only root filesystem for server containers.
   # -- Enable read-only root filesystem for server containers.
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
   image:
     # @schema description: OpenVox Server image repository.
     # -- OpenVox Server image repository.


### PR DESCRIPTION
## Summary

- Change `readOnlyRootFilesystem` default from `false` to `true` in the openvox-stack Helm chart, matching the CRD default
- Fix template to always render the field, so users can explicitly opt out with `false`
- Previously, setting `readOnlyRootFilesystem: false` in values was silently ignored (the field was omitted from the Config CR, and the CRD default of `true` applied anyway)

**Breaking change:** Existing deployments that relied on the Helm chart's `false` default were already getting `true` behavior from the CRD default. This PR makes the documented default match reality.

## Test plan

- [x] Helm unit tests pass (110/110)
- [ ] Verify E2E readonly-rootfs test still passes
- [ ] Verify new deployments with default values get read-only root filesystem
- [ ] Verify setting `config.readOnlyRootFilesystem: false` explicitly disables it
