### PR TITLE
fix: remove jruby-openssl workaround for nsComment encoding bug

### DIFF
--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -148,8 +148,7 @@ RUN printf '%s\n' \
         'INSTALL_DIR="/opt/puppetlabs/server/apps/puppetserver"' \
         'CONFIG="/etc/puppetlabs/puppetserver/conf.d"' \
         > /etc/sysconfig/puppetserver \
-    && puppetserver gem install --no-document openvox -v "${OPENVOX_VERSION}" \
-    && puppetserver gem install --no-document jruby-openssl -v 0.15.7
+    && puppetserver gem install --no-document openvox -v "${OPENVOX_VERSION}"
 
 # Patch openvoxserver-ca to skip cadir symlink and chown (fails rootless)
 RUN find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/action/setup.rb' \


### PR DESCRIPTION
## Summary

Remove the `puppetserver gem install jruby-openssl -v 0.15.7` workaround from the openvox-server Containerfile.

openvox-server 8.14.0 vendors jruby-openssl 0.16.0 (which includes the nsComment encoding fix from jruby/jruby-openssl#349). The explicit gem install is no longer needed.

**Verified in the develop image:**

```
$ puppetserver gem list jruby-openssl
jruby-openssl (0.16.0 java, 0.15.7 java, default: 0.15.4 java)

$ # vendored gems include 0.16.0:
$ ls vendored-jruby-gems/gems/ | grep openssl
jruby-openssl-0.16.0-java

$ # runtime loads 0.16.0:
$ puppetserver ruby -e 'require "jopenssl/version"; puts JOpenSSL::VERSION'
0.16.0
```

Closes #149

## Test plan

- [ ] CI image builds successfully without the workaround
- [ ] E2E tests pass (certificate signing uses the fixed code path)
