### PR TITLE
fix: mount writable code volume when no code source is configured

### DIFF
--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -325,6 +325,19 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 					},
 				})
 			}
+		} else {
+			// No external code source configured: mount a writable emptyDir at the
+			// environment path so Puppetserver can bootstrap its default environment
+			// (environments/production) on startup. Without this, a read-only root
+			// filesystem prevents creating the directory and the pod crash-loops.
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      "code",
+				MountPath: cfg.Spec.Puppet.EnvironmentPath,
+			})
+			volumes = append(volumes, corev1.Volume{
+				Name:         "code",
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			})
 		}
 	}
 

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -172,9 +172,54 @@ func TestBuildPodSpec_NoCodeVolume(t *testing.T) {
 
 	podSpec := testBuildPodSpec(server, cfg)
 
+	// Without a code source, a writable emptyDir is mounted at the environment
+	// path so Puppetserver can bootstrap its default environment under a
+	// read-only root filesystem.
+	var codeVol *corev1.Volume
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == "code" {
+			codeVol = &podSpec.Volumes[i]
+			break
+		}
+	}
+	if codeVol == nil {
+		t.Fatal("code volume not found")
+	}
+	if codeVol.EmptyDir == nil {
+		t.Error("code volume should be an emptyDir when no code spec is set")
+	}
+	if codeVol.Image != nil || codeVol.PersistentVolumeClaim != nil {
+		t.Error("code volume should not reference an image or PVC when no code spec is set")
+	}
+
+	var codeMount *corev1.VolumeMount
+	for i := range podSpec.Containers[0].VolumeMounts {
+		if podSpec.Containers[0].VolumeMounts[i].Name == "code" {
+			codeMount = &podSpec.Containers[0].VolumeMounts[i]
+			break
+		}
+	}
+	if codeMount == nil {
+		t.Fatal("code volume mount not found")
+	}
+	if codeMount.MountPath != cfg.Spec.Puppet.EnvironmentPath {
+		t.Errorf("expected code mount path %q, got %q", cfg.Spec.Puppet.EnvironmentPath, codeMount.MountPath)
+	}
+	if codeMount.ReadOnly {
+		t.Error("code emptyDir mount should be writable (not read-only)")
+	}
+}
+
+func TestBuildPodSpec_NoCodeVolume_CAOnly(t *testing.T) {
+	cfg := newConfig("production") // no code spec
+	// CA-only pod (server:false) does not compile catalogs, so no code volume.
+	server := newServer("test-server", withServerRole(false), withCA(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
 	for _, v := range podSpec.Volumes {
 		if v.Name == "code" {
-			t.Error("pod should not have code volume when no code spec is set")
+			t.Error("CA-only pod should not have a code volume")
 		}
 	}
 }


### PR DESCRIPTION
## Problem

With `readOnlyRootFilesystem` enabled (now the default since #441), Puppetserver could not create its default environment at `/etc/puppetlabs/code/environments/production` on startup:

```
File[/etc/puppetlabs/code/environments/production]: change from 'absent' to 'directory' failed:
Read-only file system - /etc/puppetlabs/code/environments/production
```

The operator mounts writable emptyDirs for `/tmp`, `/var/log`, cache, ssl etc., but a volume was only mounted at the code path when a code source (image or PVC) was configured via `config.code`. Without a code source, `server:true` pods crash-looped and the `Server` stayed `Pending`.

This is why the `single-node` E2E test (and the `agent-*` tests, which also have no `config.code`) failed, while `readonly-rootfs` and `code-pvc` passed.

## Fix

For `server:true` pods without a code source, always mount a writable `emptyDir` at the environment path, mirroring the code-source mount point but read-write. CA-only pods remain unaffected.

## Verification

- Reproduced the failure locally (docker-desktop): server pod in `CrashLoopBackOff`, `Server` `Pending`.
- With the fix: server pod `1/1 Ready`, `Server` -> `Running`, `production` environment created.
- Local chainsaw `single-node` test: `--- PASS: chainsaw/single-node` (previously a 5-minute assert timeout).
- Unit tests updated (`TestBuildPodSpec_NoCodeVolume`, added `TestBuildPodSpec_NoCodeVolume_CAOnly`); full controller suite green.