### PR TITLE
docs: clarify where the CA private key is stored and who signs CSRs

### DIFF
--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -4,14 +4,14 @@ This guide explains how the operator bootstraps a Certificate Authority, signs c
 
 ## Scope: what the operator manages
 
-The operator's certificate lifecycle (the `Certificate` CRD and the signing strategies below) covers **infrastructure certificates only** -- the CA server's own certificate and the certificates of compile servers managed by the operator. These are the certs the operator needs in order to stand up and wire together the Puppet infrastructure.
+The operator's certificate lifecycle (the `Certificate` CRD and the signing strategies below) covers **infrastructure certificates only**: the CA server's own certificate and the certificates of compile servers managed by the operator. These are the certs the operator needs in order to stand up and wire together the infrastructure.
 
-**Puppet agent / managed node certificates are not part of the operator's lifecycle.** When a normal Puppet agent submits a CSR, it is handled by the CA server pod exactly as in a standard Puppet deployment:
+**Agent and managed node certificates are not part of the operator's lifecycle.** When a node submits a CSR, it is handled by the CA server pod exactly as in a standard deployment:
 
 - If a [SigningPolicy](../reference/signingpolicy.md) matches the CSR, the `openvox-autosign` script in the CA pod auto-signs it at request time.
 - Otherwise the CSR waits for manual signing (`puppetserver ca sign --certname <certname>`) or an external autosign mechanism.
 
-The operator does not create a `Certificate` resource per node, does not track node CSRs, and does not reconcile agent certificate renewal or revocation -- Puppetserver in the CA pod owns that flow end to end. You only create `Certificate` resources for infrastructure components; agents follow the normal Puppet enrollment path against the CA server.
+The operator does not create a `Certificate` resource per node, does not track node CSRs, and does not reconcile agent certificate renewal or revocation; Puppetserver in the CA pod owns that flow end to end. You only create `Certificate` resources for infrastructure components. Agents follow the normal enrollment path against the CA server.
 
 ## CA Bootstrap
 
@@ -50,9 +50,9 @@ The setup Job:
 The Job is idempotent: if the CA is already initialized on the PVC, it skips setup and only ensures the Secrets exist.
 
 !!! note "Where the CA private key actually lives"
-    The `{ca}-ca-key` Secret is never mounted as a volume into any pod -- not even the CA server pod. It exists solely so the key material can be exported/backed up via the Kubernetes API.
+    The `{ca}-ca-key` Secret is never mounted as a volume into any pod, not even the CA server pod. It exists solely so the key material can be exported/backed up via the Kubernetes API.
 
-    The CA private key is, however, present inside the running CA server pod: it lives as a file on the `{ca}-data` PVC (under `/etc/puppetlabs/puppetserver/ca`), which the CA pod mounts. **Puppetserver in the CA pod performs the actual cryptographic signing** using that key -- the operator never signs CSRs itself and never has access to the CA private key. When the operator "signs" a CSR (Strategy 2 below), it merely authenticates to the CA HTTP API via mTLS and asks Puppetserver to sign; the private key never leaves the CA pod.
+    The CA private key is, however, present inside the running CA server pod: it lives as a file on the `{ca}-data` PVC (under `/etc/puppetlabs/puppetserver/ca`), which the CA pod mounts. **Puppetserver in the CA pod performs the actual cryptographic signing** using that key; the operator never signs CSRs itself and never has access to the CA private key. When the operator "signs" a CSR (Strategy 2 below), it merely authenticates to the CA HTTP API via mTLS and asks Puppetserver to sign; the private key never leaves the CA pod.
 
 ### Operator Signing Certificate
 
@@ -63,7 +63,7 @@ Once the operator-signing Certificate is itself `Signed`, the controller:
 1. Sets `status.signingSecretName` on the CertificateAuthority to the resulting TLS Secret name (`{ca}-operator-signing-tls`)
 2. Sets the `OperatorSigningReady` condition to `True`
 
-From this point on, the Certificate controller uses this Secret for mTLS-authenticated CSR signing against the CA HTTP API (see Strategy 2 below). The operator never reuses the CA server's own certificate for signing -- the operator signing cert is rotated independently and can be revoked without disrupting CA traffic.
+From this point on, the Certificate controller uses this Secret for mTLS-authenticated CSR signing against the CA HTTP API (see Strategy 2 below). The operator never reuses the CA server's own certificate for signing; the operator signing cert is rotated independently and can be revoked without disrupting CA traffic.
 
 External CAs do not get an operator-signing Certificate: they manage their own signing credentials externally.
 
@@ -152,7 +152,7 @@ The `Certificate` CRD's `csrExtensions` field lets you embed Puppet CSR extensio
 | Field | Purpose |
 |---|---|
 | `ppCliAuth: true` | Adds `pp_cli_auth=true`, granting the certificate authority to call the CA signing endpoint. Used by the auto-managed operator-signing cert. |
-| `ppRole` | Sets `pp_role` -- often consumed by ENC or trusted facts. |
+| `ppRole` | Sets `pp_role`, often consumed by ENC or trusted facts. |
 | `ppEnvironment` | Sets `pp_environment`. |
 | `customExtensions` | Map of arbitrary `pp_*` extension names to string values. |
 

--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -9,7 +9,7 @@ The operator's certificate lifecycle (the `Certificate` CRD and the signing stra
 **Agent and managed node certificates are not part of the operator's lifecycle.** When a node submits a CSR, it is handled by the CA server pod exactly as in a standard deployment:
 
 - If a [SigningPolicy](../reference/signingpolicy.md) matches the CSR, the `openvox-autosign` script in the CA pod auto-signs it at request time.
-- Otherwise the CSR waits for manual signing (`puppetserver ca sign --certname <certname>`) or an external autosign mechanism.
+- Otherwise the CSR waits for manual signing or an external autosign mechanism.
 
 The operator does not create a `Certificate` resource per node, does not track node CSRs, and does not reconcile agent certificate renewal or revocation; Puppetserver in the CA pod owns that flow end to end. You only create `Certificate` resources for infrastructure components. Agents follow the normal enrollment path against the CA server.
 
@@ -137,13 +137,7 @@ Polling for a signed certificate uses exponential backoff to avoid hammering the
 | 6-9 | 2m |
 | 10+ | 5m |
 
-The attempt counter is stored as the annotation `openvox.voxpupuli.org/csr-poll-attempts` on the pending Secret `{cert}-tls-pending`. Manual resolution from the CA pod:
-
-```bash
-puppetserver ca sign --certname <certname>
-```
-
-The controller picks up the signed certificate on the next poll cycle.
+The attempt counter is stored as the annotation `openvox.voxpupuli.org/csr-poll-attempts` on the pending Secret `{cert}-tls-pending`. To resolve manually, sign the pending CSR on the CA server (for example via a matching [SigningPolicy](../reference/signingpolicy.md) or the CA's signing API). The controller picks up the signed certificate on the next poll cycle.
 
 ### CSR Extensions
 

--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -2,6 +2,17 @@
 
 This guide explains how the operator bootstraps a Certificate Authority, signs certificates, and distributes CRLs.
 
+## Scope: what the operator manages
+
+The operator's certificate lifecycle (the `Certificate` CRD and the signing strategies below) covers **infrastructure certificates only** -- the CA server's own certificate and the certificates of compile servers managed by the operator. These are the certs the operator needs in order to stand up and wire together the Puppet infrastructure.
+
+**Puppet agent / managed node certificates are not part of the operator's lifecycle.** When a normal Puppet agent submits a CSR, it is handled by the CA server pod exactly as in a standard Puppet deployment:
+
+- If a [SigningPolicy](../reference/signingpolicy.md) matches the CSR, the `openvox-autosign` script in the CA pod auto-signs it at request time.
+- Otherwise the CSR waits for manual signing (`puppetserver ca sign --certname <certname>`) or an external autosign mechanism.
+
+The operator does not create a `Certificate` resource per node, does not track node CSRs, and does not reconcile agent certificate renewal or revocation -- Puppetserver in the CA pod owns that flow end to end. You only create `Certificate` resources for infrastructure components; agents follow the normal Puppet enrollment path against the CA server.
+
 ## CA Bootstrap
 
 When a CertificateAuthority resource is created, the operator runs a setup Job that initializes the CA on a PVC:

--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -32,11 +32,16 @@ The setup Job:
 1. Runs `puppetserver ca setup` on the PVC to generate the CA key pair and self-signed certificate
 2. Exports three Secrets via the Kubernetes API:
     - **`{ca}-ca`** - public CA certificate (`ca_crt.pem`), mounted in all pods
-    - **`{ca}-ca-key`** - CA private key (`ca_key.pem`), never mounted in pods
+    - **`{ca}-ca-key`** - CA private key (`ca_key.pem`), never mounted as a volume in any pod (see note below)
     - **`{ca}-ca-crl`** - certificate revocation list, mounted in non-CA pods
 3. If a Certificate resource already exists for the CA server, the Job also signs and exports its TLS Secret
 
 The Job is idempotent: if the CA is already initialized on the PVC, it skips setup and only ensures the Secrets exist.
+
+!!! note "Where the CA private key actually lives"
+    The `{ca}-ca-key` Secret is never mounted as a volume into any pod -- not even the CA server pod. It exists solely so the key material can be exported/backed up via the Kubernetes API.
+
+    The CA private key is, however, present inside the running CA server pod: it lives as a file on the `{ca}-data` PVC (under `/etc/puppetlabs/puppetserver/ca`), which the CA pod mounts. **Puppetserver in the CA pod performs the actual cryptographic signing** using that key -- the operator never signs CSRs itself and never has access to the CA private key. When the operator "signs" a CSR (Strategy 2 below), it merely authenticates to the CA HTTP API via mTLS and asks Puppetserver to sign; the private key never leaves the CA pod.
 
 ### Operator Signing Certificate
 
@@ -166,7 +171,7 @@ Non-CA pods mount the CRL Secret as a **directory volume** (without SubPath), wh
 | Secret | Contents | Created By | Mounted In |
 |--------|----------|------------|------------|
 | `{ca}-ca` | `ca_crt.pem` | CA setup Job | All pods (trust chain) |
-| `{ca}-ca-key` | `ca_key.pem` | CA setup Job | Never (API access only) |
+| `{ca}-ca-key` | `ca_key.pem` | CA setup Job | Never as a volume (API export/backup only; CA pod reads the key from the `{ca}-data` PVC) |
 | `{ca}-ca-crl` | `ca_crl.pem` | CA setup Job, then operator refresh | Non-CA pods (directory mount) |
 | `{cert}-tls` | `cert.pem`, `key.pem` | CA setup Job or Certificate controller | Server pods (SSL) |
 | `{cert}-tls-pending` | `key.pem` | Certificate controller | Never (temporary, deleted after signing) |

--- a/docs/reference/certificate.md
+++ b/docs/reference/certificate.md
@@ -53,16 +53,12 @@ When the CA does not immediately sign the CSR (e.g. autosigning is disabled), th
 
 | Attempts | Interval |
 |---|---|
-| 0--2 | 5s |
-| 3--5 | 30s |
-| 6--9 | 2m |
+| 0-2 | 5s |
+| 3-5 | 30s |
+| 6-9 | 2m |
 | 10+ | 5m |
 
-The poll attempt count is tracked via the annotation `openvox.voxpupuli.org/csr-poll-attempts` on the pending Secret `{name}-tls-pending`. To resolve manually, sign the CSR on the CA and the controller will pick it up on the next poll:
-
-```bash
-puppetserver ca sign --certname <certname>
-```
+The poll attempt count is tracked via the annotation `openvox.voxpupuli.org/csr-poll-attempts` on the pending Secret `{name}-tls-pending`. To resolve manually, sign the pending CSR on the CA server (for example via a matching [SigningPolicy](signingpolicy.md) or the CA's signing API); the controller picks it up on the next poll.
 
 ## CSR Extensions
 


### PR DESCRIPTION
## Summary

Two related clarifications to the Certificate Signing guide. Docs-only, no behaviour change.

### 1. Where the CA private key lives / who signs

The guide described the `{ca}-ca-key` Secret as "never mounted in pods". Taken literally that reads as though the CA private key is not present in any pod at all, which is misleading: the key does live inside the running CA server pod.

- The `{ca}-ca-key` bullet now says the Secret is never mounted **as a volume** in any pod, and points to a new note.
- A new admonition explains that the Secret exists only for API export/backup, while the CA private key lives as a file on the `{ca}-data` PVC (`/etc/puppetlabs/puppetserver/ca`) that the CA pod mounts. **Puppetserver in the CA pod performs the actual signing;** the operator never signs CSRs itself and never has access to the CA private key -- for Strategy 2 it only authenticates to the CA HTTP API via mTLS and asks Puppetserver to sign.
- The Secrets Overview table row for `{ca}-ca-key` reflects the same clarification.

### 2. Scope: agent/node certs are outside the operator lifecycle

New 'Scope' section clarifying that the operator's `Certificate` CRD and signing strategies cover **infrastructure certificates only** (CA server + operator-managed compile servers). Puppet agent / managed node certificates are **not** part of the operator's lifecycle -- they follow the standard Puppet enrollment path handled by the CA server pod:

- `SigningPolicy` autosign via `openvox-autosign`, or
- manual `puppetserver ca sign`, or
- external autosign.

The operator does not create a `Certificate` per node and does not track node CSRs, renewal, or revocation.

## Why

The previous phrasing invited two reasonable questions: "but the CA pod signs CSRs, so the key must be mounted somewhere" and "are node certs managed by the operator?". This PR answers both explicitly.