### PR TITLE
docs: fix code image environment path in OCI/PVC examples

### DIFF
--- a/docs/concepts/code-deployment.md
+++ b/docs/concepts/code-deployment.md
@@ -16,8 +16,18 @@ Create a `Containerfile` that copies your Puppet environments into the image:
 
 ```dockerfile
 FROM scratch
-COPY environments/ /etc/puppetlabs/code/environments/
+COPY environments/ /
 ```
+
+The operator mounts the image at the configured `environmentPath` (default `/etc/puppetlabs/code/environments`). Kubernetes maps the **root of the image** to that mount path, so your environment directories must live at the root of the image, one directory per environment:
+
+```
+/                 (image root, mounted at /etc/puppetlabs/code/environments)
+  production/
+  staging/
+```
+
+Do **not** nest the environments under `/etc/puppetlabs/code/environments/` inside the image. That path would be duplicated at runtime (`/etc/puppetlabs/code/environments/etc/puppetlabs/code/environments/production`) and Puppet server would not find any environment.
 
 Build and push:
 
@@ -26,7 +36,7 @@ docker build -t ghcr.io/example/puppet-code:v1.0.0 -f Containerfile .
 docker push ghcr.io/example/puppet-code:v1.0.0
 ```
 
-A typical control repository layout:
+A typical control repository layout, where `COPY environments/ /` copies the contents of `environments/` (the `production/`, `staging/`, ... directories) to the image root:
 
 ```
 control-repo/
@@ -178,7 +188,7 @@ spec:
     claimName: puppet-code
 ```
 
-The PVC must contain the environments directory at `/etc/puppetlabs/code/environments`.
+Like the image volume, the PVC is mounted at the configured `environmentPath` (default `/etc/puppetlabs/code/environments`), so its root must contain the environment directories directly (`production/`, `staging/`, ...), not a nested `etc/puppetlabs/code/environments/` path.
 
 | Setup | Access Mode | Requirement |
 |---|---|---|


### PR DESCRIPTION
## Summary

The `docs/concepts/code-deployment.md` `Containerfile` example copied Puppet environments into `/etc/puppetlabs/code/environments/` **inside the image**. Because Kubernetes maps the **root** of an OCI image volume (and a PVC) to the mount path, and the operator mounts it at `environmentPath` (default `/etc/puppetlabs/code/environments`), that path was duplicated at runtime (`/etc/puppetlabs/code/environments/etc/puppetlabs/code/environments/production`), leaving Puppet server with no discoverable environments.

## Changes

- Fix the `Containerfile` example to `COPY environments/ /`, matching the tested `images/openvox-e2e-code` fixture.
- Document the mount semantics: the image/volume root maps to `environmentPath`, so environment directories must live at the root.
- Add an explicit warning against nesting environments under `/etc/puppetlabs/code/environments/` in the image.
- Clarify the PVC section with the same root-mount semantics.