### PR TITLE
chore: pin Go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/slauger/openvox-operator
 
 go 1.26.4
 
+toolchain go1.26.5
+
 require (
 	github.com/prometheus/client_golang v1.23.2
 	gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
Pins the build toolchain to `go1.26.5` via a `toolchain` directive in `go.mod`.

## Why
CI `govulncheck` reports **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`), present in `crypto/tls@go1.26.4` and fixed in `go1.26.5`. Builds pull their Go version from `go.mod` via `actions/setup-go` (`go-version-file: go.mod`), so the language directive `go 1.26.4` was pinning the vulnerable standard library even though the `golang` container images already track 1.26.5.

## Approach
- Keep the `go` directive at `1.26.4` as the language/compat floor.
- Add `toolchain go1.26.5` so builds (and `govulncheck`) run on the patched standard library.

This split also lets Renovate manage future toolchain patch bumps, which it does not do for a bare `go` directive. A redundant toolchain equal to the `go` directive would be stripped by `go mod tidy`, hence the floor stays at 1.26.4.

## Verification
- `go build ./...` green on go1.26.5
- `go tool govulncheck ./...` -> No vulnerabilities found
- `go mod tidy` produces no `go.sum` drift