### PR TITLE
fix: default environmentPath for code volume mount

### DIFF
--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -105,6 +105,15 @@ func TestConfigReconcile_PuppetConfRendering(t *testing.T) {
 			contains: []string{"environmentpath = /custom/code/environments"},
 		},
 		{
+			// Regression for #463: an empty environmentPath must still emit the
+			// default so puppet.conf and the code volume mountPath stay consistent.
+			name: "default environmentPath when unset",
+			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				Reports: "puppetdb",
+			})},
+			contains: []string{"environmentpath = /etc/puppetlabs/code/environments"},
+		},
+		{
 			name: "custom hieraConfig",
 			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
 				HieraConfig: "/etc/puppetlabs/custom/hiera.yaml",

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -21,9 +21,7 @@ func (r *ConfigReconciler) renderPuppetConf(ctx context.Context, cfg *openvoxv1a
 	sb.WriteString("rundir = /var/run/puppetlabs\n")
 	sb.WriteString("manage_internal_file_permissions = false\n")
 
-	if cfg.Spec.Puppet.EnvironmentPath != "" {
-		fmt.Fprintf(&sb, "environmentpath = %s\n", cfg.Spec.Puppet.EnvironmentPath)
-	}
+	fmt.Fprintf(&sb, "environmentpath = %s\n", resolveEnvironmentPath(cfg))
 
 	if cfg.Spec.Puppet.HieraConfig != "" {
 		fmt.Fprintf(&sb, "hiera_config = %s\n", cfg.Spec.Puppet.HieraConfig)

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -169,6 +169,23 @@ func caInternalServiceName(caName string) string {
 	return fmt.Sprintf("%s-internal", caName)
 }
 
+// defaultEnvironmentPath is the fallback puppet environmentpath used when
+// spec.puppet.environmentPath is unset. It mirrors the kubebuilder default on
+// PuppetSpec.EnvironmentPath, which is not applied by the API server when the
+// whole spec.puppet object is omitted (nested defaults require the parent object
+// to be present). Resolving it here keeps hand-written Configs from rendering an
+// empty volume mountPath, which the Kubernetes API rejects.
+const defaultEnvironmentPath = "/etc/puppetlabs/code/environments"
+
+// resolveEnvironmentPath returns the configured puppet environmentpath, falling
+// back to defaultEnvironmentPath when unset.
+func resolveEnvironmentPath(cfg *openvoxv1alpha1.Config) string {
+	if cfg.Spec.Puppet.EnvironmentPath != "" {
+		return cfg.Spec.Puppet.EnvironmentPath
+	}
+	return defaultEnvironmentPath
+}
+
 // resolveCode determines the code source for a Server.
 // Priority: Server override > Config default.
 func resolveCode(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) *openvoxv1alpha1.CodeSpec {

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -296,7 +296,7 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 		if code := resolveCode(server, cfg); code != nil {
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      "code",
-				MountPath: cfg.Spec.Puppet.EnvironmentPath,
+				MountPath: resolveEnvironmentPath(cfg),
 				ReadOnly:  true,
 			})
 			switch {
@@ -332,7 +332,7 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 			// filesystem prevents creating the directory and the pod crash-loops.
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      "code",
-				MountPath: cfg.Spec.Puppet.EnvironmentPath,
+				MountPath: resolveEnvironmentPath(cfg),
 			})
 			volumes = append(volumes, corev1.Volume{
 				Name:         "code",

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -143,6 +143,32 @@ func TestBuildPodSpec_CodeVolumeImage(t *testing.T) {
 	t.Error("code volume not found")
 }
 
+// TestBuildPodSpec_CodeVolumeDefaultsMountPath is a regression test for #463:
+// when spec.code is set but spec.puppet.environmentPath is empty (e.g. a
+// hand-written Config that omits the whole spec.puppet block, so the CRD default
+// is never applied), the code volume must still render a valid mountPath rather
+// than "", which the Kubernetes API rejects.
+func TestBuildPodSpec_CodeVolumeDefaultsMountPath(t *testing.T) {
+	cfg := newConfig("production", withCodeImage("ghcr.io/slauger/puppet-code:v1.0"))
+	cfg.Spec.Puppet.EnvironmentPath = ""
+	server := newServer("test-server", withServerRole(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	found := false
+	for _, vm := range podSpec.Containers[0].VolumeMounts {
+		if vm.Name == "code" {
+			found = true
+			if vm.MountPath != defaultEnvironmentPath {
+				t.Errorf("expected code mountPath %q, got %q", defaultEnvironmentPath, vm.MountPath)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("code volume mount not found")
+	}
+}
+
 func TestBuildPodSpec_CodeVolumePVC(t *testing.T) {
 	cfg := newConfig("production", withCodePVC("puppet-code-pvc"))
 	server := newServer("test-server", withServerRole(true))


### PR DESCRIPTION
## Summary

Fixes #463.

When a `Config` sets `spec.code` (OCI code image or PVC) but omits `spec.puppet.environmentPath`, the operator rendered a Server `Deployment` whose code volume had an **empty `mountPath`**. The Kubernetes API rejects such a Deployment, so it is never created and the `Server` stays stuck in `WaitingForCert` indefinitely — with the real cause only visible in the operator log.

### Root cause

`PuppetSpec.EnvironmentPath` carries a `+kubebuilder:default`, but the API server does **not** apply nested defaults when the entire `spec.puppet` object is omitted (defaulting requires the parent object to be present). Hand-written Configs therefore render `mountPath: ""`. The `openvox-stack` Helm chart masks the bug because it always templates a `puppet.environmentPath`.

### Fix

Resolve the environment path at render time via a shared `resolveEnvironmentPath()` helper that falls back to `/etc/puppetlabs/code/environments` (matching the documented default). It is now used for both:

- the code volume `mountPath` (image, PVC, and emptyDir cases) in `server_deployment.go`, and
- the `environmentpath` line in the generated `puppet.conf`,

so mount path and Puppet config stay consistent.

### Tests

- `TestBuildPodSpec_CodeVolumeDefaultsMountPath` — regression test: `code` set, `environmentPath` empty ⇒ mountPath defaults instead of being `""`.
- `puppet.conf` rendering: added a case asserting `environmentpath` is emitted with the default when unset.

All existing controller tests pass.