### PR TITLE
fix: quote environmentTimeout in the Config template

### DIFF
--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -25,7 +25,7 @@ spec:
   readOnlyRootFilesystem: {{ .Values.config.readOnlyRootFilesystem }}
   puppet:
     {{- with .Values.config.puppet.environmentTimeout }}
-    environmentTimeout: {{ . }}
+    environmentTimeout: {{ . | quote }}
     {{- end }}
     {{- with .Values.config.puppet.environmentPath }}
     environmentPath: {{ . }}

--- a/charts/openvox-stack/tests/config_test.yaml
+++ b/charts/openvox-stack/tests/config_test.yaml
@@ -246,3 +246,13 @@ tests:
       - equal:
           path: spec.metrics.jmx.enabled
           value: true
+
+  - it: should quote a numeric-looking environmentTimeout
+    set:
+      config:
+        puppet:
+          environmentTimeout: "0"
+    asserts:
+      - equal:
+          path: spec.puppet.environmentTimeout
+          value: "0"


### PR DESCRIPTION
spec.puppet.environmentTimeout is typed string in the CRD, but the template rendered the value unquoted. A numeric-looking timeout such as "0" reaches the API server as an integer and the Config is rejected:

  failed to create typed patch object (Kind=Config):
  .spec.puppet.environmentTimeout: expected string, got &value.valueUnstructured{Value:0}

"0" is the documented way to disable environment caching, so this is reachable from a plain values file. Quote the rendered value and add a regression test.


Sponsored by : https://obmondo.com/