### PR TITLE
fix(charts): default image tag to chart appVersion instead of latest

### DIFF
--- a/charts/openvox-operator/README.md
+++ b/charts/openvox-operator/README.md
@@ -43,7 +43,7 @@ To deploy a complete OpenVox stack after installing the operator, use the
 | image.digest | string | `""` | Image digest. Takes precedence over tag. |
 | image.pullPolicy | string | `"Always"` | Image pull policy. |
 | image.repository | string | `"ghcr.io/slauger/openvox-operator"` | Image repository. |
-| image.tag | string | `"latest"` | Image tag. Ignored if digest is set. |
+| image.tag | string | `""` | Image tag. Defaults to the chart appVersion. Ignored if digest is set. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries. |
 | leaderElect | bool | `true` | Enable leader election for controller manager. |
 | metrics.enabled | bool | `true` | Enable the metrics endpoint. |

--- a/charts/openvox-operator/templates/NOTES.txt
+++ b/charts/openvox-operator/templates/NOTES.txt
@@ -2,7 +2,7 @@ The OpenVox Operator has been installed.
 
   Release:   {{ .Release.Name }}
   Namespace: {{ .Release.Namespace }}
-  Image:     {{ .Values.image.repository }}:{{ .Values.image.tag }}
+  Image:     {{ if .Values.image.digest }}{{ .Values.image.repository }}@{{ .Values.image.digest }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}
 
 The operator is now watching for OpenVox CRDs in all namespaces.
 

--- a/charts/openvox-operator/tests/deployment_test.yaml
+++ b/charts/openvox-operator/tests/deployment_test.yaml
@@ -13,11 +13,20 @@ tests:
           path: spec.replicas
           value: 1
 
-  - it: should use tag-based image by default
+  - it: should default the image tag to the chart appVersion
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/slauger/openvox-operator:latest"
+          value: "ghcr.io/slauger/openvox-operator:0.0.0"
+
+  - it: should use an explicit image tag when set
+    set:
+      image:
+        tag: v1.2.3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/slauger/openvox-operator:v1.2.3"
 
   - it: should use digest-based image when digest is set
     set:

--- a/charts/openvox-operator/values.schema.json
+++ b/charts/openvox-operator/values.schema.json
@@ -37,7 +37,7 @@
                     "type": "string"
                 },
                 "tag": {
-                    "description": "Image tag. Ignored if digest is set.",
+                    "description": "Image tag. Defaults to the chart appVersion. Ignored if digest is set.",
                     "type": "string"
                 }
             }

--- a/charts/openvox-operator/values.yaml
+++ b/charts/openvox-operator/values.yaml
@@ -9,9 +9,9 @@ image:
   # @schema description: Image repository.
   # -- Image repository.
   repository: ghcr.io/slauger/openvox-operator
-  # @schema description: Image tag. Ignored if digest is set.
-  # -- Image tag. Ignored if digest is set.
-  tag: latest
+  # @schema description: Image tag. Defaults to the chart appVersion. Ignored if digest is set.
+  # -- Image tag. Defaults to the chart appVersion. Ignored if digest is set.
+  tag: ""
   # @schema type:string;pattern:^sha256:[a-f0-9]{64}$
   # -- Image digest. Takes precedence over tag.
   digest: "" # @schema hidden

--- a/charts/openvox-stack/README.md
+++ b/charts/openvox-stack/README.md
@@ -49,7 +49,7 @@ helm install openvox oci://ghcr.io/slauger/charts/openvox-stack
 | config.image.pullPolicy | string | `"Always"` | Image pull policy. |
 | config.image.pullSecrets | list | `[]` | Image pull secrets. |
 | config.image.repository | string | `"ghcr.io/slauger/openvox-server"` | OpenVox Server image repository. |
-| config.image.tag | string | `"latest"` | Image tag. |
+| config.image.tag | string | `""` | Image tag. Defaults to the chart appVersion. |
 | config.name | string | `""` | Config resource name. Defaults to release name. |
 | config.puppet.environmentPath | string | `""` | Path to Puppet environments. |
 | config.puppet.environmentTimeout | string | `""` | Environment timeout setting. |
@@ -65,7 +65,7 @@ helm install openvox oci://ghcr.io/slauger/charts/openvox-stack
 | database.enabled | bool | `false` | Enable PuppetDB database deployment. |
 | database.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | database.image.repository | string | `"ghcr.io/slauger/openvox-db"` | OpenVox DB image repository. |
-| database.image.tag | string | `"latest"` | Image tag. |
+| database.image.tag | string | `""` | Image tag. Defaults to the chart appVersion. |
 | database.javaArgs | string | `""` | JVM arguments for PuppetDB. |
 | database.name | string | `""` | Database resource name. Required when enabled. |
 | database.postgres.credentialsSecretRef | string | `""` | Name of Secret containing PostgreSQL credentials. Required when enabled. |

--- a/charts/openvox-stack/templates/NOTES.txt
+++ b/charts/openvox-stack/templates/NOTES.txt
@@ -4,7 +4,7 @@ The OpenVox stack has been deployed.
   Namespace: {{ .Release.Namespace }}
   Config:    {{ include "openvox-stack.configName" . }}
   CA:        {{ include "openvox-stack.caName" . }}
-  Image:     {{ .Values.config.image.repository }}:{{ .Values.config.image.tag }}
+  Image:     {{ .Values.config.image.repository }}:{{ .Values.config.image.tag | default .Chart.AppVersion }}
 
 Resources created:
 

--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -9,7 +9,7 @@ spec:
   {{- end }}
   image:
     repository: {{ .Values.config.image.repository }}
-    tag: {{ .Values.config.image.tag | quote }}
+    tag: {{ .Values.config.image.tag | default .Chart.AppVersion | quote }}
     pullPolicy: {{ .Values.config.image.pullPolicy }}
     {{- with .Values.config.image.pullSecrets }}
     pullSecrets:

--- a/charts/openvox-stack/templates/database.yaml
+++ b/charts/openvox-stack/templates/database.yaml
@@ -32,7 +32,7 @@ spec:
   certificateRef: {{ .Values.database.name }}
   image:
     repository: {{ .Values.database.image.repository }}
-    tag: {{ .Values.database.image.tag | quote }}
+    tag: {{ .Values.database.image.tag | default .Chart.AppVersion | quote }}
     pullPolicy: {{ .Values.database.image.pullPolicy }}
   postgres:
     host: {{ .Values.database.postgres.host }}

--- a/charts/openvox-stack/tests/config_test.yaml
+++ b/charts/openvox-stack/tests/config_test.yaml
@@ -17,6 +17,19 @@ tests:
       - equal:
           path: spec.image.repository
           value: ghcr.io/slauger/openvox-server
+      - equal:
+          path: spec.image.tag
+          value: "0.0.0"
+
+  - it: should use an explicit image tag when set
+    set:
+      config:
+        image:
+          tag: v1.2.3
+    asserts:
+      - equal:
+          path: spec.image.tag
+          value: v1.2.3
 
   - it: should set readOnlyRootFilesystem to true by default
     asserts:

--- a/charts/openvox-stack/tests/database_test.yaml
+++ b/charts/openvox-stack/tests/database_test.yaml
@@ -104,6 +104,12 @@ tests:
           path: metadata.name
           value: my-puppetdb
       - equal:
+          path: spec.image.repository
+          value: ghcr.io/slauger/openvox-db
+      - equal:
+          path: spec.image.tag
+          value: "0.0.0"
+      - equal:
           path: spec.certificateRef
           value: my-puppetdb
       - equal:

--- a/charts/openvox-stack/values.schema.json
+++ b/charts/openvox-stack/values.schema.json
@@ -78,7 +78,7 @@
                             "type": "string"
                         },
                         "tag": {
-                            "description": "Image tag.",
+                            "description": "Image tag. Defaults to the chart appVersion.",
                             "type": "string"
                         }
                     }
@@ -172,7 +172,7 @@
                             "type": "string"
                         },
                         "tag": {
-                            "description": "Image tag.",
+                            "description": "Image tag. Defaults to the chart appVersion.",
                             "type": "string"
                         }
                     }

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -14,9 +14,9 @@ config:
     # @schema description: OpenVox Server image repository.
     # -- OpenVox Server image repository.
     repository: ghcr.io/slauger/openvox-server
-    # @schema description: Image tag.
-    # -- Image tag.
-    tag: latest
+    # @schema description: Image tag. Defaults to the chart appVersion.
+    # -- Image tag. Defaults to the chart appVersion.
+    tag: ""
     # @schema enum:[Always, IfNotPresent, Never]
     # @schema description: Image pull policy.
     # -- Image pull policy.
@@ -200,9 +200,9 @@ database:
     # @schema description: OpenVox DB image repository.
     # -- OpenVox DB image repository.
     repository: ghcr.io/slauger/openvox-db
-    # @schema description: Image tag.
-    # -- Image tag.
-    tag: latest
+    # @schema description: Image tag. Defaults to the chart appVersion.
+    # -- Image tag. Defaults to the chart appVersion.
+    tag: ""
     # @schema enum:[Always, IfNotPresent, Never]
     # @schema description: Image pull policy.
     # -- Image pull policy.


### PR DESCRIPTION
## Summary

Both the `openvox-operator` and `openvox-stack` charts shipped `tag: latest` as the default. A versioned chart install (e.g. chart `0.9.6`) therefore ran a floating `latest` image, which breaks reproducible GitOps pinning and rollbacks — the running version can change underneath you with no chart/git change recording it.

This defaults the image tag to the chart's `appVersion`, which the release workflow already injects into `Chart.yaml` at package time. Installing chart `0.9.6` now pins the matching `0.9.6` images out of the box.

## Changes

- `openvox-operator`: `values.yaml` `image.tag: latest` → `""`. The template already falls back to `.Chart.AppVersion` (previously dead code, since `latest` is a set value and the `default` never applied).
- `openvox-stack`: `values.yaml` `config.image.tag` and `database.image.tag` → `""`; templates now render `| default .Chart.AppVersion`.
- NOTES.txt in both charts reflect the effective tag (and digest precedence for the operator).
- Unit tests, README (helm-docs) and `values.schema.json` regenerated.

## Precedence unchanged

- Explicit `image.tag` still overrides (user pin wins).
- The operator `image.digest` escape hatch still takes precedence over the tag.

## Notes

- No release-workflow change required — the existing `appVersion` injection in `Chart.yaml` is enough now that the templates consume it.
- Installing straight from the source tree renders `appVersion: 0.0.0` → `:0.0.0`; there you override `image.tag`. The released charts pin correctly.
- Image tags are published unprefixed (`0.9.6`, not `v0.9.6`).

Addresses the `tag: latest` default raised in #478. The version-tag part of #478 is a non-issue (tags exist, just without the `v` prefix); digest support for `openvox-stack` is intentionally out of scope here (it would need a CRD/controller field, since server/db images run through the operator's CRD).