### PR TITLE
feat: support running OpenVox 8 and 9 in parallel (matrix build + image rename)

### DIFF
--- a/.github/workflows/_conforma-validate.yaml
+++ b/.github/workflows/_conforma-validate.yaml
@@ -8,9 +8,10 @@ on:
         required: true
         type: string
       digest:
-        description: 'Image manifest digest (sha256:...)'
-        required: true
+        description: 'Image manifest digest (sha256:...). If empty, the tag in image is resolved by ec.'
+        required: false
         type: string
+        default: ''
       strict:
         description: 'Fail on policy violations'
         required: false
@@ -46,9 +47,13 @@ jobs:
 
       - name: Validate image with Conforma
         run: |
+          IMAGE_REF="${{ inputs.image }}"
+          if [[ -n "${{ inputs.digest }}" ]]; then
+            IMAGE_REF="${{ inputs.image }}@${{ inputs.digest }}"
+          fi
           ARGS=(
             validate image
-            --image "${{ inputs.image }}@${{ inputs.digest }}"
+            --image "${IMAGE_REF}"
             --policy .conforma/policy.yaml
             --certificate-identity-regexp "https://github.com/${{ github.repository }}/"
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/.github/workflows/_container-build.yaml
+++ b/.github/workflows/_container-build.yaml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: ''
+      allow_failure:
+        description: 'Do not fail the workflow if the build/manifest fails (best-effort, e.g. pre-release majors)'
+        required: false
+        type: boolean
+        default: false
       sign:
         description: 'Sign images with cosign keyless signing'
         required: false
@@ -142,6 +147,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build and push
+        continue-on-error: ${{ inputs.allow_failure }}
         uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
@@ -158,6 +164,7 @@ jobs:
   manifest:
     if: inputs.push
     needs: [prepare, build]
+    continue-on-error: ${{ inputs.allow_failure }}
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.result.outputs.image }}

--- a/.github/workflows/_container-build.yaml
+++ b/.github/workflows/_container-build.yaml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      build_args:
+        description: 'Build-time arguments passed to docker build (one KEY=VALUE per line)'
+        required: false
+        type: string
+        default: ''
       sign:
         description: 'Sign images with cosign keyless signing'
         required: false
@@ -143,6 +148,7 @@ jobs:
           file: ${{ inputs.dockerfile }}
           platforms: ${{ matrix.platform }}
           push: ${{ inputs.push }}
+          build-args: ${{ inputs.build_args }}
           provenance: true
           sbom: true
           tags: ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ needs.prepare.outputs.version }}-${{ steps.platform.outputs.suffix }}

--- a/.github/workflows/_e2e-run.yaml
+++ b/.github/workflows/_e2e-run.yaml
@@ -15,6 +15,11 @@ on:
         description: 'JSON array of test names to run'
         required: true
         type: string
+      openvox_major:
+        description: 'OpenVox major for the content images under test (8 or 9)'
+        required: false
+        type: string
+        default: '8'
 
 concurrency:
   group: e2e
@@ -65,7 +70,7 @@ jobs:
           kubectl version --short 2>/dev/null || kubectl version
 
       - name: Run ${{ matrix.test }}
-        run: make e2e-run-test TEST=${{ matrix.test }} IMAGE_TAG=${{ inputs.image_tag }}
+        run: make e2e-run-test TEST=${{ matrix.test }} IMAGE_TAG=${{ inputs.image_tag }} OPENVOX_MAJOR=${{ inputs.openvox_major }}
 
   e2e-cleanup:
     needs: [e2e-test]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-server-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
@@ -97,6 +98,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-db-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
@@ -133,6 +135,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-agent-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-agent/Containerfile
       context: 'images/openvox-agent'
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,18 @@ jobs:
   shellcheck:
     uses: ./.github/workflows/_shellcheck.yaml
 
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Build OpenVox version matrix
+        id: matrix
+        run: |
+          echo "matrix=$(yq -o=json -I=0 '{"include": .include}' images/openvox-versions.yaml)" >> "$GITHUB_OUTPUT"
+
   openvox-operator:
     needs: go
     uses: ./.github/workflows/_container-build.yaml
@@ -51,7 +63,10 @@ jobs:
       image_tag: develop
 
   openvox-server:
-    needs: shellcheck
+    needs: [shellcheck, prepare]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -59,14 +74,21 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-server
+      image_name: openvox-server-${{ matrix.major }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       image_tag: develop
+      build_args: |
+        OPENVOXSERVER_VERSION=${{ matrix.server }}
+        OPENVOXDB_TERMINI_VERSION=${{ matrix.termini }}
+        OPENVOX_VERSION=${{ matrix.openvox }}
 
   openvox-db:
-    needs: shellcheck
+    needs: [shellcheck, prepare]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -74,11 +96,13 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-db
+      image_name: openvox-db-${{ matrix.major }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       image_tag: develop
+      build_args: |
+        OPENVOXDB_VERSION=${{ matrix.db }}
 
   openvox-e2e-code:
     needs: shellcheck
@@ -97,7 +121,10 @@ jobs:
       sign: false
 
   openvox-agent:
-    needs: shellcheck
+    needs: [shellcheck, prepare]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -105,11 +132,14 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-agent
+      image_name: openvox-agent-${{ matrix.major }}
       dockerfile: images/openvox-agent/Containerfile
       context: 'images/openvox-agent'
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       image_tag: develop
+      build_args: |
+        OPENVOX_AGENT_VERSION=${{ matrix.agent }}
+        OPENVOX_MAJOR=${{ matrix.major }}
       sign: false
 
   openvox-mock:

--- a/.github/workflows/e2e-images.yaml
+++ b/.github/workflows/e2e-images.yaml
@@ -19,6 +19,18 @@ env:
   IMAGE_TAG: ${{ inputs.image_tag || github.ref_name }}
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Build OpenVox version matrix
+        id: matrix
+        run: |
+          echo "matrix=$(yq -o=json -I=0 '{"include": .include}' images/openvox-versions.yaml)" >> "$GITHUB_OUTPUT"
+
   openvox-operator:
     uses: ./.github/workflows/_container-build.yaml
     permissions:
@@ -34,6 +46,10 @@ jobs:
       image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   openvox-server:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -41,11 +57,15 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-server
+      image_name: openvox-server-${{ matrix.major }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
       push: true
       image_tag: ${{ inputs.image_tag || github.ref_name }}
+      build_args: |
+        OPENVOXSERVER_VERSION=${{ matrix.server }}
+        OPENVOXDB_TERMINI_VERSION=${{ matrix.termini }}
+        OPENVOX_VERSION=${{ matrix.openvox }}
 
   openvox-e2e-code:
     uses: ./.github/workflows/_container-build.yaml
@@ -63,6 +83,10 @@ jobs:
       sign: false
 
   openvox-agent:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -70,14 +94,21 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-agent
+      image_name: openvox-agent-${{ matrix.major }}
       dockerfile: images/openvox-agent/Containerfile
       context: 'images/openvox-agent'
       push: true
       image_tag: ${{ inputs.image_tag || github.ref_name }}
+      build_args: |
+        OPENVOX_AGENT_VERSION=${{ matrix.agent }}
+        OPENVOX_MAJOR=${{ matrix.major }}
       sign: false
 
   openvox-db:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -85,11 +116,13 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-db
+      image_name: openvox-db-${{ matrix.major }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'
       push: true
       image_tag: ${{ inputs.image_tag || github.ref_name }}
+      build_args: |
+        OPENVOXDB_VERSION=${{ matrix.db }}
 
   openvox-mock:
     uses: ./.github/workflows/_container-build.yaml

--- a/.github/workflows/e2e-images.yaml
+++ b/.github/workflows/e2e-images.yaml
@@ -58,6 +58,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-server-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
       push: true
@@ -95,6 +96,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-agent-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-agent/Containerfile
       context: 'images/openvox-agent'
       push: true
@@ -117,6 +119,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-db-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'
       push: true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: 'develop'
+      openvox_major:
+        description: 'OpenVox major to test against (8 = default/stable, 9 = beta; requires the -9 images to exist)'
+        required: false
+        type: string
+        default: '8'
 
 jobs:
   e2e-base:
@@ -15,6 +20,7 @@ jobs:
     with:
       image_tag: ${{ inputs.image_tag }}
       operator: base
+      openvox_major: ${{ inputs.openvox_major }}
       tests: '["single-node","multi-server","agent-basic","agent-broken","agent-idempotent","agent-concurrent","agent-report","database-cnpg","readonly-rootfs","code-pvc","autosign-policy","cert-rotation"]'
     secrets: inherit
 
@@ -24,6 +30,7 @@ jobs:
     with:
       image_tag: ${{ inputs.image_tag }}
       operator: base
+      openvox_major: ${{ inputs.openvox_major }}
       tests: '["agent-enc","agent-full"]'
     secrets: inherit
 
@@ -33,6 +40,7 @@ jobs:
     with:
       image_tag: ${{ inputs.image_tag }}
       operator: gateway
+      openvox_major: ${{ inputs.openvox_major }}
       tests: '["pool-gateway"]'
     secrets: inherit
 
@@ -42,5 +50,6 @@ jobs:
     with:
       image_tag: ${{ inputs.image_tag }}
       operator: webhooks-cm
+      openvox_major: ${{ inputs.openvox_major }}
       tests: '["webhook-validation-server","webhook-validation-config","webhook-validation-database","webhook-smoke"]'
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -236,6 +236,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Download chart artifacts
         uses: actions/download-artifact@v8
         with:
@@ -248,3 +251,21 @@ jobs:
         run: |
           VERSION="${{ needs.semantic-release.outputs.new-release-version }}"
           gh release upload "v${VERSION}" *.tgz
+
+      - name: Append OpenVox component versions to release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          VERSION="${{ needs.semantic-release.outputs.new-release-version }}"
+          ROWS=$(yq -r '.include[] | "| " + .major + " | " + .server + " | " + .db + " | " + .agent + " |"' images/openvox-versions.yaml)
+          BODY=$(gh release view "v${VERSION}" --json body -q .body)
+          {
+            printf '%s\n\n' "${BODY}"
+            printf '## OpenVox component versions\n\n'
+            printf 'Content images shipped with this release. Major 8 is the default and the only one tagged `:latest`; major 9 is a pre-release.\n\n'
+            printf '| Major | openvox-server | openvox-db | openvox-agent |\n'
+            printf '|---|---|---|---|\n'
+            printf '%s\n' "${ROWS}"
+          } > release-notes.md
+          gh release edit "v${VERSION}" --notes-file release-notes.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,6 +89,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-server-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
       push: true
@@ -113,6 +114,7 @@ jobs:
       attestations: write
     with:
       image_name: openvox-db-${{ matrix.major }}
+      allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'
       push: true
@@ -133,35 +135,30 @@ jobs:
       image: ${{ needs.openvox-operator.outputs.image }}
       digest: ${{ needs.openvox-operator.outputs.digest }}
 
+  # Only the default major (8) is conforma-validated: it is the released,
+  # :latest-tagged image. Major 9 is a best-effort pre-release build.
   validate-openvox-server:
-    needs: [semantic-release, prepare, openvox-server]
+    needs: [semantic-release, openvox-server]
     if: needs.semantic-release.outputs.new-release-published == 'true'
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_conforma-validate.yaml
     permissions:
       contents: read
       id-token: write
       packages: read
     with:
-      # Matrixed build job outputs collapse to a single value, so reconstruct the
-      # per-major image reference; ec resolves the tag to a digest itself.
-      image: ghcr.io/${{ github.repository_owner }}/openvox-server-${{ matrix.major }}:${{ needs.semantic-release.outputs.new-release-version }}
+      # ec resolves the tag to a digest itself.
+      image: ghcr.io/${{ github.repository_owner }}/openvox-server-8:${{ needs.semantic-release.outputs.new-release-version }}
 
   validate-openvox-db:
-    needs: [semantic-release, prepare, openvox-db]
+    needs: [semantic-release, openvox-db]
     if: needs.semantic-release.outputs.new-release-published == 'true'
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_conforma-validate.yaml
     permissions:
       contents: read
       id-token: write
       packages: read
     with:
-      image: ghcr.io/${{ github.repository_owner }}/openvox-db-${{ matrix.major }}:${{ needs.semantic-release.outputs.new-release-version }}
+      image: ghcr.io/${{ github.repository_owner }}/openvox-db-8:${{ needs.semantic-release.outputs.new-release-version }}
 
   helm-charts:
     needs: [semantic-release, openvox-operator, openvox-server, openvox-db]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  prepare:
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Build OpenVox version matrix
+        id: matrix
+        run: |
+          echo "matrix=$(yq -o=json -I=0 '{"include": .include}' images/openvox-versions.yaml)" >> "$GITHUB_OUTPUT"
+
   openvox-operator:
     needs: semantic-release
     if: needs.semantic-release.outputs.new-release-published == 'true'
@@ -62,8 +76,11 @@ jobs:
       image_tag: ${{ needs.semantic-release.outputs.new-release-version }}
 
   openvox-server:
-    needs: semantic-release
+    needs: [semantic-release, prepare]
     if: needs.semantic-release.outputs.new-release-published == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -71,16 +88,23 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-server
+      image_name: openvox-server-${{ matrix.major }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
       push: true
-      latest: true
+      latest: ${{ matrix.latest }}
       image_tag: ${{ needs.semantic-release.outputs.new-release-version }}
+      build_args: |
+        OPENVOXSERVER_VERSION=${{ matrix.server }}
+        OPENVOXDB_TERMINI_VERSION=${{ matrix.termini }}
+        OPENVOX_VERSION=${{ matrix.openvox }}
 
   openvox-db:
-    needs: semantic-release
+    needs: [semantic-release, prepare]
     if: needs.semantic-release.outputs.new-release-published == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_container-build.yaml
     permissions:
       contents: read
@@ -88,12 +112,14 @@ jobs:
       id-token: write
       attestations: write
     with:
-      image_name: openvox-db
+      image_name: openvox-db-${{ matrix.major }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'
       push: true
-      latest: true
+      latest: ${{ matrix.latest }}
       image_tag: ${{ needs.semantic-release.outputs.new-release-version }}
+      build_args: |
+        OPENVOXDB_VERSION=${{ matrix.db }}
 
   validate-openvox-operator:
     needs: [semantic-release, openvox-operator]
@@ -108,28 +134,34 @@ jobs:
       digest: ${{ needs.openvox-operator.outputs.digest }}
 
   validate-openvox-server:
-    needs: [semantic-release, openvox-server]
+    needs: [semantic-release, prepare, openvox-server]
     if: needs.semantic-release.outputs.new-release-published == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_conforma-validate.yaml
     permissions:
       contents: read
       id-token: write
       packages: read
     with:
-      image: ${{ needs.openvox-server.outputs.image }}
-      digest: ${{ needs.openvox-server.outputs.digest }}
+      # Matrixed build job outputs collapse to a single value, so reconstruct the
+      # per-major image reference; ec resolves the tag to a digest itself.
+      image: ghcr.io/${{ github.repository_owner }}/openvox-server-${{ matrix.major }}:${{ needs.semantic-release.outputs.new-release-version }}
 
   validate-openvox-db:
-    needs: [semantic-release, openvox-db]
+    needs: [semantic-release, prepare, openvox-db]
     if: needs.semantic-release.outputs.new-release-published == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     uses: ./.github/workflows/_conforma-validate.yaml
     permissions:
       contents: read
       id-token: write
       packages: read
     with:
-      image: ${{ needs.openvox-db.outputs.image }}
-      digest: ${{ needs.openvox-db.outputs.digest }}
+      image: ghcr.io/${{ github.repository_owner }}/openvox-db-${{ matrix.major }}:${{ needs.semantic-release.outputs.new-release-version }}
 
   helm-charts:
     needs: [semantic-release, openvox-operator, openvox-server, openvox-db]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMG ?= ghcr.io/slauger/openvox-operator:latest
-OPENVOX_SERVER_IMG ?= ghcr.io/slauger/openvox-server:latest
+OPENVOX_SERVER_IMG ?= ghcr.io/slauger/openvox-server-8:latest
 OPENVOX_E2E_CODE_IMG ?= ghcr.io/slauger/openvox-e2e-code:latest
-OPENVOX_AGENT_IMG ?= ghcr.io/slauger/openvox-agent:latest
+OPENVOX_AGENT_IMG ?= ghcr.io/slauger/openvox-agent-8:latest
 OPENVOX_MOCK_IMG ?= ghcr.io/slauger/openvox-mock:latest
 NAMESPACE ?= openvox-system
 IMAGE_REGISTRY ?= ghcr.io/slauger
@@ -64,14 +64,14 @@ IMAGE_TAG ?= $(shell git describe --always)
 .PHONY: local-build
 local-build: ## Build all images for local development (Docker Desktop K8s).
 	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-operator:$(IMAGE_TAG) -f images/openvox-operator/Containerfile .
-	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-server:$(IMAGE_TAG) -f images/openvox-server/Containerfile .
+	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-server-8:$(IMAGE_TAG) -f images/openvox-server/Containerfile .
 	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-e2e-code:latest -f images/openvox-e2e-code/Containerfile .
-	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-agent:latest -f images/openvox-agent/Containerfile images/openvox-agent/
+	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-agent-8:latest -f images/openvox-agent/Containerfile images/openvox-agent/
 	$(CONTAINER_TOOL) build -t ghcr.io/slauger/openvox-mock:latest -f images/openvox-mock/Containerfile .
 	@echo "Built ghcr.io/slauger/openvox-operator:$(IMAGE_TAG)"
-	@echo "Built ghcr.io/slauger/openvox-server:$(IMAGE_TAG)"
+	@echo "Built ghcr.io/slauger/openvox-server-8:$(IMAGE_TAG)"
 	@echo "Built ghcr.io/slauger/openvox-e2e-code:latest"
-	@echo "Built ghcr.io/slauger/openvox-agent:latest"
+	@echo "Built ghcr.io/slauger/openvox-agent-8:latest"
 	@echo "Built ghcr.io/slauger/openvox-mock:latest"
 
 .PHONY: local-deploy
@@ -88,7 +88,7 @@ STACK_VALUES ?= charts/openvox-stack/values.yaml
 # configure helm to pull that specific image from the registry.
 ifeq ($(origin IMAGE_TAG),command line)
 HELM_SET ?= --set image.repository=$(IMAGE_REGISTRY)/openvox-operator --set image.tag=$(IMAGE_TAG) --set image.pullPolicy=Always
-STACK_HELM_SET ?= --set config.image.repository=$(IMAGE_REGISTRY)/openvox-server --set config.image.tag=$(IMAGE_TAG) --set config.image.pullPolicy=Always
+STACK_HELM_SET ?= --set config.image.repository=$(IMAGE_REGISTRY)/openvox-server-8 --set config.image.tag=$(IMAGE_TAG) --set config.image.pullPolicy=Always
 endif
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ OPENVOX_AGENT_IMG ?= ghcr.io/slauger/openvox-agent-8:latest
 OPENVOX_MOCK_IMG ?= ghcr.io/slauger/openvox-mock:latest
 NAMESPACE ?= openvox-system
 IMAGE_REGISTRY ?= ghcr.io/slauger
+# OpenVox major selects the content image variant (-8 / -9) for e2e tests.
+OPENVOX_MAJOR ?= 8
 CONTAINER_TOOL ?= $(shell which podman 2>/dev/null || which docker 2>/dev/null)
 CONTROLLER_GEN = go tool controller-gen
 GOVULNCHECK = go tool govulncheck
@@ -183,7 +185,7 @@ $(CHAINSAW):
 	curl -sSfL "https://github.com/kyverno/chainsaw/releases/download/$(CHAINSAW_VERSION)/chainsaw_$${OS}_$${ARCH}.tar.gz" | tar xz -C $(LOCALBIN) chainsaw
 	@chmod +x $(CHAINSAW)
 
-E2E_CHAINSAW = IMAGE_TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) $(CHAINSAW) test --config tests/e2e/chainsaw-config.yaml
+E2E_CHAINSAW = IMAGE_TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) OPENVOX_MAJOR=$(OPENVOX_MAJOR) $(CHAINSAW) test --config tests/e2e/chainsaw-config.yaml
 
 
 .PHONY: e2e-setup

--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ major, the **tag** stays the operator release version.
 | Server | `ghcr.io/slauger/openvox-server-8` | `ghcr.io/slauger/openvox-server-9` |
 | DB | `ghcr.io/slauger/openvox-db-8` | `ghcr.io/slauger/openvox-db-9` |
 
+The exact OpenVox versions baked into each image are pinned in
+[`images/openvox-versions.yaml`](images/openvox-versions.yaml) (kept current by Renovate),
+and every operator release lists the shipped component versions in its GitHub release notes.
+
 The operator defaults to OpenVox 8 everywhere (chart values, CRD defaults, samples) and
 only the `-8` images are tagged `:latest`. To opt a Config into OpenVox 9, set the image
 repository explicitly:

--- a/README.md
+++ b/README.md
@@ -202,6 +202,32 @@ helm install production \
   --set database.postgres.credentialsSecretRef=pg-cluster-app
 ```
 
+## OpenVox 8 and 9
+
+The content images are published per OpenVox major: the image **name** encodes the
+major, the **tag** stays the operator release version.
+
+| Image | OpenVox 8 (default) | OpenVox 9 (beta) |
+|---|---|---|
+| Server | `ghcr.io/slauger/openvox-server-8` | `ghcr.io/slauger/openvox-server-9` |
+| DB | `ghcr.io/slauger/openvox-db-8` | `ghcr.io/slauger/openvox-db-9` |
+
+The operator defaults to OpenVox 8 everywhere (chart values, CRD defaults, samples) and
+only the `-8` images are tagged `:latest`. To opt a Config into OpenVox 9, set the image
+repository explicitly:
+
+```yaml
+spec:
+  image:
+    repository: ghcr.io/slauger/openvox-server-8   # or -9 for OpenVox 9 (beta)
+```
+
+> **OpenVox 9 is a pre-release** (Jetty 12, JRuby 10, Java 17 dropped). The `-9` images
+> track 9.x betas, are never tagged `:latest`, and are not recommended for production yet.
+
+> **Migration:** the previously published unsuffixed images (`openvox-server`,
+> `openvox-db`) are no longer built. Update any hand-pinned references to the `-8` variants.
+
 ## Local Development
 
 The `local-build` and `local-deploy` targets build all container images locally and deploy the operator via Helm with `pullPolicy: Never`. This works with clusters that have direct access to the local image store (e.g. Docker Desktop Kubernetes via kubeadm).

--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -323,7 +323,7 @@ type PodSecurityContextSpec struct {
 // ImageSpec defines the container image reference.
 type ImageSpec struct {
 	// Repository is the container image repository.
-	// +kubebuilder:default="ghcr.io/slauger/openvox-server"
+	// +kubebuilder:default="ghcr.io/slauger/openvox-server-8"
 	Repository string `json:"repository,omitempty"`
 
 	// Tag is the container image tag.

--- a/charts/openvox-operator/Chart.yaml
+++ b/charts/openvox-operator/Chart.yaml
@@ -26,9 +26,9 @@ annotations:
     - name: openvox-operator
       image: ghcr.io/slauger/openvox-operator:latest
     - name: openvox-server
-      image: ghcr.io/slauger/openvox-server:latest
+      image: ghcr.io/slauger/openvox-server-8:latest
     - name: openvox-db
-      image: ghcr.io/slauger/openvox-db:latest
+      image: ghcr.io/slauger/openvox-db-8:latest
   artifacthub.io/links: |
     - name: Documentation
       url: https://slauger.github.io/openvox-operator/

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -125,7 +125,7 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   repository:
-                    default: ghcr.io/slauger/openvox-server
+                    default: ghcr.io/slauger/openvox-server-8
                     description: Repository is the container image repository.
                     type: string
                   tag:

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
@@ -90,7 +90,7 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   repository:
-                    default: ghcr.io/slauger/openvox-server
+                    default: ghcr.io/slauger/openvox-server-8
                     description: Repository is the container image repository.
                     type: string
                   tag:

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -1067,7 +1067,7 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   repository:
-                    default: ghcr.io/slauger/openvox-server
+                    default: ghcr.io/slauger/openvox-server-8
                     description: Repository is the container image repository.
                     type: string
                   tag:

--- a/charts/openvox-stack/Chart.yaml
+++ b/charts/openvox-stack/Chart.yaml
@@ -22,9 +22,9 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/images: |
     - name: openvox-server
-      image: ghcr.io/slauger/openvox-server:latest
+      image: ghcr.io/slauger/openvox-server-8:latest
     - name: openvox-db
-      image: ghcr.io/slauger/openvox-db:latest
+      image: ghcr.io/slauger/openvox-db-8:latest
   artifacthub.io/links: |
     - name: Documentation
       url: https://slauger.github.io/openvox-operator/

--- a/charts/openvox-stack/README.md
+++ b/charts/openvox-stack/README.md
@@ -48,7 +48,7 @@ helm install openvox oci://ghcr.io/slauger/charts/openvox-stack
 | config.code.imagePullSecret | string | `""` | Pull secret for the code init container. |
 | config.image.pullPolicy | string | `"Always"` | Image pull policy. |
 | config.image.pullSecrets | list | `[]` | Image pull secrets. |
-| config.image.repository | string | `"ghcr.io/slauger/openvox-server"` | OpenVox Server image repository. |
+| config.image.repository | string | `"ghcr.io/slauger/openvox-server-8"` | OpenVox Server image repository. |
 | config.image.tag | string | `""` | Image tag. Defaults to the chart appVersion. |
 | config.name | string | `""` | Config resource name. Defaults to release name. |
 | config.puppet.environmentPath | string | `""` | Path to Puppet environments. |
@@ -64,7 +64,7 @@ helm install openvox oci://ghcr.io/slauger/charts/openvox-stack
 | database.certificate.dnsAltNames | list | `[]` | Additional DNS subject alternative names. |
 | database.enabled | bool | `false` | Enable PuppetDB database deployment. |
 | database.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
-| database.image.repository | string | `"ghcr.io/slauger/openvox-db"` | OpenVox DB image repository. |
+| database.image.repository | string | `"ghcr.io/slauger/openvox-db-8"` | OpenVox DB image repository. |
 | database.image.tag | string | `""` | Image tag. Defaults to the chart appVersion. |
 | database.javaArgs | string | `""` | JVM arguments for PuppetDB. |
 | database.name | string | `""` | Database resource name. Required when enabled. |

--- a/charts/openvox-stack/tests/config_test.yaml
+++ b/charts/openvox-stack/tests/config_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: RELEASE-NAME-ca
       - equal:
           path: spec.image.repository
-          value: ghcr.io/slauger/openvox-server
+          value: ghcr.io/slauger/openvox-server-8
       - equal:
           path: spec.image.tag
           value: "0.0.0"

--- a/charts/openvox-stack/tests/database_test.yaml
+++ b/charts/openvox-stack/tests/database_test.yaml
@@ -105,7 +105,7 @@ tests:
           value: my-puppetdb
       - equal:
           path: spec.image.repository
-          value: ghcr.io/slauger/openvox-db
+          value: ghcr.io/slauger/openvox-db-8
       - equal:
           path: spec.image.tag
           value: "0.0.0"

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -13,7 +13,7 @@ config:
   image:
     # @schema description: OpenVox Server image repository.
     # -- OpenVox Server image repository.
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     # @schema description: Image tag. Defaults to the chart appVersion.
     # -- Image tag. Defaults to the chart appVersion.
     tag: ""
@@ -199,7 +199,7 @@ database:
   image:
     # @schema description: OpenVox DB image repository.
     # -- OpenVox DB image repository.
-    repository: ghcr.io/slauger/openvox-db
+    repository: ghcr.io/slauger/openvox-db-8
     # @schema description: Image tag. Defaults to the chart appVersion.
     # -- Image tag. Defaults to the chart appVersion.
     tag: ""
@@ -290,7 +290,7 @@ servers:
     # javaArgs: "-Xms512m -Xmx1024m"
     # maxActiveInstances: 2
     # image:
-    #   repository: ghcr.io/slauger/openvox-server
+    #   repository: ghcr.io/slauger/openvox-server-8
     #   tag: custom
     # code:
     #   image: ghcr.io/slauger/openvox-e2e-code:latest

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -125,7 +125,7 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   repository:
-                    default: ghcr.io/slauger/openvox-server
+                    default: ghcr.io/slauger/openvox-server-8
                     description: Repository is the container image repository.
                     type: string
                   tag:

--- a/config/crd/bases/openvox.voxpupuli.org_databases.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_databases.yaml
@@ -90,7 +90,7 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   repository:
-                    default: ghcr.io/slauger/openvox-server
+                    default: ghcr.io/slauger/openvox-server-8
                     description: Repository is the container image repository.
                     type: string
                   tag:

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -1067,7 +1067,7 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   repository:
-                    default: ghcr.io/slauger/openvox-server
+                    default: ghcr.io/slauger/openvox-server-8
                     description: Repository is the container image repository.
                     type: string
                   tag:

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   authorityRef: production-ca
   image:
+    # Image name encodes the OpenVox major: -8 (default) or -9 (beta, never :latest).
     repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
   # Use databaseRef to auto-resolve the PuppetDB URL from a Database CR.

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   authorityRef: production-ca
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
   # Use databaseRef to auto-resolve the PuppetDB URL from a Database CR.
   # Mutually exclusive with puppetdb.serverUrls.

--- a/config/samples/database.yaml
+++ b/config/samples/database.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   certificateRef: production-db-cert
   image:
-    repository: ghcr.io/slauger/openvox-db
+    repository: ghcr.io/slauger/openvox-db-8
     tag: latest
     pullPolicy: IfNotPresent
   postgres:

--- a/docs/concepts/code-deployment.md
+++ b/docs/concepts/code-deployment.md
@@ -57,7 +57,7 @@ metadata:
   name: production
 spec:
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
   code:
     image: ghcr.io/example/puppet-code:v1.0.0
@@ -180,7 +180,7 @@ metadata:
   name: production
 spec:
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
   code:
     claimName: puppet-code

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -70,7 +70,7 @@ spec:
   authorityRef: production-ca
   databaseRef: production-db   # operator reads Database.status.url
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
 ```
 

--- a/docs/concepts/external-node-classification.md
+++ b/docs/concepts/external-node-classification.md
@@ -135,7 +135,7 @@ spec:
   authorityRef: production-ca
   nodeClassifierRef: pe-classifier
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
 ```
 

--- a/docs/concepts/report-processing.md
+++ b/docs/concepts/report-processing.md
@@ -106,7 +106,7 @@ metadata:
 spec:
   authorityRef: production-ca
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
 ```
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -12,7 +12,7 @@ metadata:
 spec:
   authorityRef: lab-ca
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
 ---
 apiVersion: openvox.voxpupuli.org/v1alpha1
@@ -73,7 +73,7 @@ spec:
   authorityRef: production-ca
   databaseRef: production-db
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
   puppet:
     environmentTimeout: unlimited
@@ -155,7 +155,7 @@ metadata:
 spec:
   certificateRef: production-db-cert
   image:
-    repository: ghcr.io/slauger/openvox-db
+    repository: ghcr.io/slauger/openvox-db-8
     tag: latest
   postgres:
     host: pg-rw.openvox.svc        # CloudNativePG read/write Service

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -74,7 +74,7 @@ This guide sets up an OpenVox Server deployment. Choose between the Helm chart (
     spec:
       authorityRef: lab-ca
       image:
-        repository: ghcr.io/slauger/openvox-server
+        repository: ghcr.io/slauger/openvox-server-8
         tag: "8.12.1"
     ---
     apiVersion: openvox.voxpupuli.org/v1alpha1

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -24,7 +24,7 @@ spec:
 ```
 
 !!! note "Choosing an OpenVox major (8 or 9)"
-    The content images are published per OpenVox major — the image name encodes the
+    The content images are published per OpenVox major - the image name encodes the
     major (`openvox-server-8` / `openvox-server-9`), the tag stays the operator release
     version. The default is `openvox-server-8`. To opt a Config into OpenVox 9, set
     `spec.image.repository: ghcr.io/slauger/openvox-server-9`. OpenVox 9 is a pre-release

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -12,7 +12,7 @@ metadata:
 spec:
   authorityRef: production-ca
   image:
-    repository: ghcr.io/slauger/openvox-server
+    repository: ghcr.io/slauger/openvox-server-8
     tag: "8.12.1"
   puppet:
     environmentTimeout: "0"
@@ -22,6 +22,15 @@ spec:
     serverUrls:
       - "https://openvoxdb.example.com:8081"
 ```
+
+!!! note "Choosing an OpenVox major (8 or 9)"
+    The content images are published per OpenVox major — the image name encodes the
+    major (`openvox-server-8` / `openvox-server-9`), the tag stays the operator release
+    version. The default is `openvox-server-8`. To opt a Config into OpenVox 9, set
+    `spec.image.repository: ghcr.io/slauger/openvox-server-9`. OpenVox 9 is a pre-release
+    (Jetty 12, JRuby 10, Java 17 dropped), never tagged `:latest`, and not recommended
+    for production yet. The previously published unsuffixed images (`openvox-server`,
+    `openvox-db`) are no longer built.
 
 ## Spec
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -30,7 +30,9 @@ spec:
     `spec.image.repository: ghcr.io/slauger/openvox-server-9`. OpenVox 9 is a pre-release
     (Jetty 12, JRuby 10, Java 17 dropped), never tagged `:latest`, and not recommended
     for production yet. The previously published unsuffixed images (`openvox-server`,
-    `openvox-db`) are no longer built.
+    `openvox-db`) are no longer built. The exact OpenVox versions baked into each image
+    are pinned in `images/openvox-versions.yaml`, and every operator release lists the
+    shipped component versions in its GitHub release notes.
 
 ## Spec
 

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -12,7 +12,7 @@ metadata:
 spec:
   certificateRef: production-db-cert
   image:
-    repository: ghcr.io/slauger/openvox-db
+    repository: ghcr.io/slauger/openvox-db-8
     tag: latest
     pullPolicy: IfNotPresent
   postgres:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -52,7 +52,7 @@ These types are reused across multiple CRDs.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `repository` | string | `ghcr.io/slauger/openvox-server` | Container image repository |
+| `repository` | string | `ghcr.io/slauger/openvox-server-8` | Container image repository |
 | `tag` | string | `latest` | Container image tag |
 | `pullPolicy` | string | `IfNotPresent` | Image pull policy |
 | `pullSecrets` | []LocalObjectReference | - | Image pull secrets |

--- a/images/openvox-agent/Containerfile
+++ b/images/openvox-agent/Containerfile
@@ -6,14 +6,19 @@
 # Run:
 #   podman run --rm openvox-agent:latest agent --test --server puppet
 
-# renovate: datasource=github-releases depName=OpenVoxProject/openvox
+# OpenVox versions are the single source of truth in images/openvox-versions.yaml
+# and injected as build-args by CI. The defaults below are a fallback for standalone
+# local builds and pin the stable 8.x line.
 ARG OPENVOX_AGENT_VERSION=8.28.1
+# OPENVOX_MAJOR selects the release repo (openvox${OPENVOX_MAJOR}-release-el-9).
+ARG OPENVOX_MAJOR=8
 
 FROM registry.access.redhat.com/ubi9/ubi:9.8-1785807559
 
 ARG OPENVOX_AGENT_VERSION
+ARG OPENVOX_MAJOR
 
-RUN rpm -Uvh https://yum.voxpupuli.org/openvox8-release-el-9.noarch.rpm \
+RUN rpm -Uvh https://yum.voxpupuli.org/openvox${OPENVOX_MAJOR}-release-el-9.noarch.rpm \
     && dnf install -y --setopt=install_weak_deps=False openvox-agent-${OPENVOX_AGENT_VERSION} \
     && dnf clean all
 

--- a/images/openvox-db/Containerfile
+++ b/images/openvox-db/Containerfile
@@ -8,7 +8,9 @@
 # Run:
 #   podman run --rm openvox-db:latest
 
-# renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
+# OpenVox versions are the single source of truth in images/openvox-versions.yaml
+# and injected as build-args by CI. The default below is a fallback for standalone
+# local builds and pins the stable 8.x line.
 ARG OPENVOXDB_VERSION=8.15.0
 
 ################################################################################

--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -8,11 +8,11 @@
 # Run:
 #   podman run --rm openvox-server:latest
 
-# renovate: datasource=github-releases depName=OpenVoxProject/openvox-server
+# OpenVox versions are the single source of truth in images/openvox-versions.yaml
+# and injected as build-args by CI. The defaults below are a fallback for standalone
+# local builds and pin the stable 8.x line.
 ARG OPENVOXSERVER_VERSION=8.15.2
-# renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
 ARG OPENVOXDB_TERMINI_VERSION=8.15.0
-# renovate: datasource=github-releases depName=OpenVoxProject/openvox
 ARG OPENVOX_VERSION=8.28.1
 ################################################################################
 # Stage: base — JRE + minimal runtime deps (no Ruby)

--- a/images/openvox-versions.yaml
+++ b/images/openvox-versions.yaml
@@ -1,0 +1,36 @@
+# Single source of truth for the OpenVox versions baked into the content images.
+#
+# The image name encodes the OpenVox major (openvox-server-8 / openvox-server-9),
+# the image tag stays the operator release version. CI/release/e2e workflows read
+# this file (yq -o=json '.include') to build the per-major matrix and pass the
+# versions as build-args to the Containerfiles.
+#
+# Renovate keeps the pins current: the "8" entry tracks the stable 8.x line, the
+# "9" entry tracks 9.x pre-releases. The two majors bump independently in separate
+# grouped PRs (see renovate.json). Major 8 is the default and the only one tagged
+# :latest; major 9 is built and pushed but never :latest and never the default.
+include:
+  - major: "8"
+    latest: true
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvox-server
+    server: 8.15.2
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
+    termini: 8.15.0
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvox
+    openvox: 8.28.1
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
+    db: 8.15.0
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvox
+    agent: 8.28.1
+  - major: "9"
+    latest: false
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvox-server
+    server: 9.0.0-beta2
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
+    termini: 9.0.0-beta1
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvox
+    openvox: 9.0.0-beta1
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
+    db: 9.0.0-beta1
+    # renovate: datasource=github-releases depName=OpenVoxProject/openvox
+    agent: 9.0.0-beta1

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -216,7 +216,7 @@ func TestCAReconcile_JobCreation(t *testing.T) {
 	}
 
 	container := job.Spec.Template.Spec.Containers[0]
-	expectedImage := "ghcr.io/slauger/openvox-server:latest"
+	expectedImage := "ghcr.io/slauger/openvox-server-8:latest"
 	if container.Image != expectedImage {
 		t.Errorf("expected image %q, got %q", expectedImage, container.Image)
 	}

--- a/internal/controller/certificateauthority_job_test.go
+++ b/internal/controller/certificateauthority_job_test.go
@@ -170,7 +170,7 @@ func TestBuildCASetupJob(t *testing.T) {
 		}
 
 		container := spec.Containers[0]
-		expectedImage := "ghcr.io/slauger/openvox-server:latest"
+		expectedImage := "ghcr.io/slauger/openvox-server-8:latest"
 		if container.Image != expectedImage {
 			t.Errorf("expected image %q, got %q", expectedImage, container.Image)
 		}

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -86,7 +86,7 @@ func TestResolveImage(t *testing.T) {
 	cfg := &openvoxv1alpha1.Config{
 		Spec: openvoxv1alpha1.ConfigSpec{
 			Image: openvoxv1alpha1.ImageSpec{
-				Repository: "ghcr.io/slauger/openvox-server",
+				Repository: "ghcr.io/slauger/openvox-server-8",
 				Tag:        "latest",
 			},
 		},
@@ -102,7 +102,7 @@ func TestResolveImage(t *testing.T) {
 			server: &openvoxv1alpha1.Server{
 				Spec: openvoxv1alpha1.ServerSpec{},
 			},
-			want: "ghcr.io/slauger/openvox-server:latest",
+			want: "ghcr.io/slauger/openvox-server-8:latest",
 		},
 		{
 			name: "server tag override",
@@ -113,7 +113,7 @@ func TestResolveImage(t *testing.T) {
 					},
 				},
 			},
-			want: "ghcr.io/slauger/openvox-server:v8.12.1",
+			want: "ghcr.io/slauger/openvox-server-8:v8.12.1",
 		},
 		{
 			name: "server repository override only",

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -81,7 +81,7 @@ func newConfig(name string, opts ...configOption) *openvoxv1alpha1.Config {
 		Spec: openvoxv1alpha1.ConfigSpec{
 			ReadOnlyRootFilesystem: true,
 			Image: openvoxv1alpha1.ImageSpec{
-				Repository: "ghcr.io/slauger/openvox-server",
+				Repository: "ghcr.io/slauger/openvox-server-8",
 				Tag:        "latest",
 				PullPolicy: corev1.PullIfNotPresent,
 			},
@@ -497,7 +497,7 @@ func newDatabase(name string, opts ...databaseOption) *openvoxv1alpha1.Database 
 		Spec: openvoxv1alpha1.DatabaseSpec{
 			CertificateRef: "production-db-cert",
 			Image: openvoxv1alpha1.ImageSpec{
-				Repository: "ghcr.io/slauger/openvox-db",
+				Repository: "ghcr.io/slauger/openvox-db-8",
 				Tag:        "latest",
 				PullPolicy: corev1.PullIfNotPresent,
 			},

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,16 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/(^|/)openvox-versions\\.yaml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\n\\s*\\w+:\\s*(?<currentValue>\\S+)"
+      ],
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/(^|/).github/workflows/_helm\\.yaml$/",
         "/(^|/).github/workflows/_conforma-validate\\.yaml$/"
       ],
@@ -79,7 +89,24 @@
       "matchPackageNames": [
         "OpenVoxProject/*"
       ],
-      "groupName": "OpenVox versions"
+      "matchCurrentValue": "/^8\\./",
+      "allowedVersions": "<9.0.0",
+      "groupName": "OpenVox 8 versions"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchPackageNames": [
+        "OpenVoxProject/*"
+      ],
+      "matchCurrentValue": "/^9\\./",
+      "allowedVersions": ">=9.0.0",
+      "ignoreUnstable": false,
+      "groupName": "OpenVox 9 versions"
     },
     {
       "matchManagers": [

--- a/tests/e2e/agent-basic/chainsaw-test.yaml
+++ b/tests/e2e/agent-basic/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install openvox-stack
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-agent-basic "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-basic --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -68,7 +70,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-broken/chainsaw-test.yaml
+++ b/tests/e2e/agent-broken/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install openvox-stack
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-agent-broken "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-broken --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -57,7 +59,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-concurrent/chainsaw-test.yaml
+++ b/tests/e2e/agent-concurrent/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install openvox-stack
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-agent-concurrent "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-concurrent --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -57,7 +59,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:
@@ -84,7 +86,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:
@@ -111,7 +113,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-enc/chainsaw-test.yaml
+++ b/tests/e2e/agent-enc/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Deploy mock server
       try:
@@ -73,7 +75,7 @@ spec:
               helm upgrade --install e2e-agent-enc "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-enc --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-enc-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -109,7 +111,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-full/chainsaw-test.yaml
+++ b/tests/e2e/agent-full/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Deploy mock server
       try:
@@ -73,7 +75,7 @@ spec:
               helm upgrade --install e2e-agent-full "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-full --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-full-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -109,7 +111,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-idempotent/chainsaw-test.yaml
+++ b/tests/e2e/agent-idempotent/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install openvox-stack
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-agent-idempotent "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-idempotent --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-basic-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -57,7 +59,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:
@@ -92,7 +94,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/agent-report/chainsaw-test.yaml
+++ b/tests/e2e/agent-report/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Deploy mock server
       try:
@@ -70,7 +72,7 @@ spec:
               helm upgrade --install e2e-agent-report "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-agent-report --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/agent-report-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -125,7 +127,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/autosign-policy/chainsaw-test.yaml
+++ b/tests/e2e/autosign-policy/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install openvox-stack
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-autosign-policy "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-autosign-policy --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/autosign-policy-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -57,7 +59,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:
@@ -98,7 +100,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/cert-rotation/chainsaw-test.yaml
+++ b/tests/e2e/cert-rotation/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install openvox-stack
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-cert-rotation "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-cert-rotation --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/cert-rotation-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}

--- a/tests/e2e/code-pvc/chainsaw-test.yaml
+++ b/tests/e2e/code-pvc/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Create PVC and populate with Puppet code
       try:
@@ -78,7 +80,7 @@ spec:
               helm upgrade --install e2e-code-pvc "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-code-pvc --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/code-pvc-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always
       catch:
@@ -113,7 +115,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/database-cnpg/chainsaw-test.yaml
+++ b/tests/e2e/database-cnpg/chainsaw-test.yaml
@@ -38,10 +38,10 @@ spec:
               helm upgrade --install openvox-stack-db "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-database-cnpg --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/database-cnpg-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
-                --set database.image.repository=${IMAGE_REGISTRY}/openvox-db \
+                --set database.image.repository=${IMAGE_REGISTRY}/openvox-db-${OPENVOX_MAJOR:-8} \
                 --set database.image.tag=latest \
                 --set database.image.pullPolicy=Always
       catch:

--- a/tests/e2e/external-ca/chainsaw-test.yaml
+++ b/tests/e2e/external-ca/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install Stack A (CA provider)
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-ext-ca-a "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-ext-ca-a --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/external-ca-stack-a-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -77,7 +79,7 @@ spec:
               helm upgrade --install e2e-ext-ca-b "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-ext-ca-b \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/external-ca-stack-b-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -126,7 +128,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/metrics/chainsaw-test.yaml
+++ b/tests/e2e/metrics/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
               helm upgrade --install openvox-stack-metrics "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-metrics --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/single-node-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always
       catch:

--- a/tests/e2e/multi-server/chainsaw-test.yaml
+++ b/tests/e2e/multi-server/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
               helm upgrade --install openvox-stack-multi "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-multi-server --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/multi-server-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always
       catch:

--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
               helm upgrade --install openvox-stack-gw "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-pool-gateway --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/pool-gateway-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always
       catch:

--- a/tests/e2e/readonly-rootfs/chainsaw-test.yaml
+++ b/tests/e2e/readonly-rootfs/chainsaw-test.yaml
@@ -9,6 +9,8 @@ spec:
       value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
     - name: imageTag
       value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install openvox-stack
       try:
@@ -21,7 +23,7 @@ spec:
               helm upgrade --install e2e-readonly-rootfs "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-readonly-rootfs --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/readonly-rootfs-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set config.code.image=${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}
@@ -71,7 +73,7 @@ spec:
                     restartPolicy: Never
                     containers:
                       - name: puppet-agent
-                        image: (join('', [$registry, '/openvox-agent:', $imageTag]))
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
                         imagePullPolicy: Always
                         command: ["sh", "-c"]
                         args:

--- a/tests/e2e/single-node/chainsaw-test.yaml
+++ b/tests/e2e/single-node/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
               helm upgrade --install openvox-stack-single "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-single-node --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/single-node-values.yaml" \
-                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always
       catch:

--- a/tests/e2e/webhook-validation-config/chainsaw-test.yaml
+++ b/tests/e2e/webhook-validation-config/chainsaw-test.yaml
@@ -27,7 +27,7 @@ spec:
                 name: wh-config-valid
               spec:
                 image:
-                  repository: ghcr.io/slauger/openvox-server
+                  repository: ghcr.io/slauger/openvox-server-8
                   tag: latest
                 authorityRef: wh-config-ca
 
@@ -44,7 +44,7 @@ spec:
                 namespace: e2e-webhook-val-config
               spec:
                 image:
-                  repository: ghcr.io/slauger/openvox-server
+                  repository: ghcr.io/slauger/openvox-server-8
                   tag: latest
                 authorityRef: does-not-exist
               EOF
@@ -67,7 +67,7 @@ spec:
                 namespace: e2e-webhook-val-config
               spec:
                 image:
-                  repository: ghcr.io/slauger/openvox-server
+                  repository: ghcr.io/slauger/openvox-server-8
                   tag: latest
                 databaseRef: some-db
                 puppetdb:

--- a/tests/e2e/webhook-validation-database/chainsaw-test.yaml
+++ b/tests/e2e/webhook-validation-database/chainsaw-test.yaml
@@ -46,7 +46,7 @@ spec:
               spec:
                 certificateRef: wh-db-cert
                 image:
-                  repository: ghcr.io/slauger/openvox-db
+                  repository: ghcr.io/slauger/openvox-db-8
                   tag: latest
                 postgres:
                   host: pg-cluster-rw
@@ -65,7 +65,7 @@ spec:
                 namespace: e2e-webhook-val-db
               spec:
                 image:
-                  repository: ghcr.io/slauger/openvox-db
+                  repository: ghcr.io/slauger/openvox-db-8
                   tag: latest
                 postgres:
                   host: pg-cluster-rw
@@ -91,7 +91,7 @@ spec:
               spec:
                 certificateRef: wh-db-cert
                 image:
-                  repository: ghcr.io/slauger/openvox-db
+                  repository: ghcr.io/slauger/openvox-db-8
                   tag: latest
                 postgres:
                   credentialsSecretRef: wh-db-pg-creds
@@ -116,7 +116,7 @@ spec:
               spec:
                 certificateRef: wh-db-cert
                 image:
-                  repository: ghcr.io/slauger/openvox-db
+                  repository: ghcr.io/slauger/openvox-db-8
                   tag: latest
                 postgres:
                   host: pg-cluster-rw
@@ -141,7 +141,7 @@ spec:
               spec:
                 certificateRef: wh-db-cert
                 image:
-                  repository: ghcr.io/slauger/openvox-db
+                  repository: ghcr.io/slauger/openvox-db-8
                   tag: latest
                 postgres:
                   host: pg-cluster-rw

--- a/tests/e2e/webhook-validation-server/chainsaw-test.yaml
+++ b/tests/e2e/webhook-validation-server/chainsaw-test.yaml
@@ -32,7 +32,7 @@ spec:
                 name: wh-server-config
               spec:
                 image:
-                  repository: ghcr.io/slauger/openvox-server
+                  repository: ghcr.io/slauger/openvox-server-8
                   tag: latest
                 authorityRef: wh-server-ca
         - apply:


### PR DESCRIPTION
## Summary

Implements #472: build and publish the OpenVox content images (`openvox-server`, `openvox-db`, `openvox-agent`) for **OpenVox 8 and 9 in parallel**. The image **name** now encodes the OpenVox major (`-8` / `-9`), the **tag** stays the operator release version.

OpenVox 8 stays the default everywhere and is the only major tagged `:latest`. OpenVox 9 (currently 9.0.0-beta) is built and pushed but never `:latest` and never the default. The follow-up RFC (decoupling the content images from the operator) is intentionally out of scope.

## What changed (per commit)

1. **`images/openvox-versions.yaml`** — single source of truth for both majors; Renovate custom manager + per-major package rules (`^8.` vs `^9.`, pre-releases enabled for 9.x) so the majors bump independently.
2. **Containerfiles** — parameterized; `# renovate:` annotations dropped (source of truth moved), `ARG` defaults kept as a standalone-build fallback; agent gets `ARG OPENVOX_MAJOR` for the release RPM.
3. **`_container-build.yaml`** — new `build_args` input wired into `docker/build-push-action`.
4. **ci / release / e2e-images workflows** — a `prepare` job reads the versions file (`yq -o=json '.include'`) and emits a per-major matrix; server/db/agent build once per major (`fail-fast: false`), only major 8 → `:latest`. Release conforma-validate is matrixed over both majors (`_conforma-validate.yaml` digest input is now optional).
5. **Image reference defaults → `-8`** — ImageSpec default (+ regenerated CRDs), openvox-stack chart values & unittests, samples, Makefile vars/targets/`STACK_HELM_SET`, and Go unit tests.
6. **E2E chainsaw** — `OPENVOX_MAJOR` selects the image variant (helm `--set` uses `${OPENVOX_MAJOR:-8}`; agent image asserts via a new `major` chainsaw binding); Makefile forwards `OPENVOX_MAJOR` (default 8).
7. **Docs + README** — image-naming / major-selection section, v9 beta note, migration note; inline examples updated to `-8`.

## Version seeds (Renovate keeps current)

| | server | openvoxdb | openvox |
|---|---|---|---|
| 8 (default, latest) | 8.15.2 | 8.15.0 | 8.28.1 |
| 9 (beta, never latest) | 9.0.0-beta2 | 9.0.0-beta1 | 9.0.0-beta1 |

## ⚠️ Breaking change (migration note for release notes)

The previously published **unsuffixed** images (`openvox-server`, `openvox-db`) are **no longer built**. Hand-pinned references must move to the `-8` variants. No transition alias is published (by design).

## Testing

- `go build`, `go vet`, `gofmt`, `go test ./internal/...` — green
- `helm lint` + `helm unittest` (111 tests) — green
- `openvox-versions.yaml` matrix output verified with `yq -o=json '.include'`; all workflow + chainsaw YAML validated; actionlint clean of new findings
- v9 is **wired only** (matrix + parameterization); v9 build correctness (JRuby 10 / Jetty 12 / ca-patch) is left to CI/manual e2e as agreed

Refs #472