### PR TITLE
test(e2e): cover Server passthrough fields and fsGroup default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,9 @@ e2e-group-base: e2e-operator-base chainsaw ## Group: base tests (stack, agent, d
 		tests/e2e/readonly-rootfs \
 		tests/e2e/code-pvc \
 		tests/e2e/autosign-policy \
-		tests/e2e/cert-rotation; \
+		tests/e2e/cert-rotation \
+		tests/e2e/server-extra-env-volumes \
+		tests/e2e/server-fsgroup; \
 	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
 .PHONY: e2e-group-enc

--- a/charts/openvox-stack/ci/server-extra-env-volumes-values.yaml
+++ b/charts/openvox-stack/ci/server-extra-env-volumes-values.yaml
@@ -1,0 +1,43 @@
+signingPolicies:
+  - name: autosign-any
+    any: true
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+    # Passthrough fields under test (secrets are created by the chainsaw test).
+    extraEnv:
+      - name: EXTRA_PLAIN
+        value: hello-from-extraenv
+    envFrom:
+      - secretRef:
+          name: server-extra-env
+    extraVolumes:
+      - name: extra-secret-vol
+        secret:
+          secretName: server-extra-files
+    extraVolumeMounts:
+      - name: extra-secret-vol
+        mountPath: /etc/puppetlabs/extra-files
+        readOnly: true
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/tests/e2e/server-extra-env-volumes/chainsaw-test.yaml
+++ b/tests/e2e/server-extra-env-volumes/chainsaw-test.yaml
@@ -1,0 +1,114 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: server-extra-env-volumes
+spec:
+  namespace: e2e-server-extra
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Create namespace and referenced secrets
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: e2e-server-extra
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: server-extra-env
+                namespace: e2e-server-extra
+              stringData:
+                EXTRA_FROM_SECRET: from-envfrom
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: server-extra-files
+                namespace: e2e-server-extra
+              stringData:
+                extra.txt: hello-file
+
+    - name: Install openvox-stack with extra env/volumes
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-server-extra "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-server-extra --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/server-extra-env-volumes-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-server-extra-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Verify extraEnv, envFrom and extraVolume on the server pod
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              set -eu
+              NS=e2e-server-extra
+              POD=$(kubectl get pods -n "${NS}" \
+                -l openvox.voxpupuli.org/server=e2e-server-extra-ca \
+                -o jsonpath='{.items[0].metadata.name}')
+              echo "pod=${POD}"
+
+              fail() { echo "ERROR: $1"; kubectl get pod "${POD}" -n "${NS}" -o yaml; exit 1; }
+
+              # extraEnv (plain value)
+              VAL=$(kubectl get pod "${POD}" -n "${NS}" \
+                -o jsonpath='{.spec.containers[?(@.name=="openvox-server")].env[?(@.name=="EXTRA_PLAIN")].value}')
+              [ "${VAL}" = "hello-from-extraenv" ] || fail "extraEnv EXTRA_PLAIN not propagated (got '${VAL}')"
+
+              # envFrom (secretRef)
+              EF=$(kubectl get pod "${POD}" -n "${NS}" \
+                -o jsonpath='{.spec.containers[?(@.name=="openvox-server")].envFrom[*].secretRef.name}')
+              echo "${EF}" | grep -qw server-extra-env || fail "envFrom secretRef not propagated (got '${EF}')"
+
+              # extraVolume
+              VOL=$(kubectl get pod "${POD}" -n "${NS}" \
+                -o jsonpath='{.spec.volumes[?(@.name=="extra-secret-vol")].secret.secretName}')
+              [ "${VOL}" = "server-extra-files" ] || fail "extraVolume not propagated (got '${VOL}')"
+
+              # extraVolumeMount
+              MNT=$(kubectl get pod "${POD}" -n "${NS}" \
+                -o jsonpath='{.spec.containers[?(@.name=="openvox-server")].volumeMounts[?(@.name=="extra-secret-vol")].mountPath}')
+              [ "${MNT}" = "/etc/puppetlabs/extra-files" ] || fail "extraVolumeMount not propagated (got '${MNT}')"
+
+              # the mounted secret is actually readable in the container
+              CONTENT=$(kubectl exec "${POD}" -n "${NS}" -c openvox-server -- cat /etc/puppetlabs/extra-files/extra.txt)
+              [ "${CONTENT}" = "hello-file" ] || fail "mounted secret content wrong (got '${CONTENT}')"
+
+              echo "OK: extraEnv, envFrom, extraVolumes and extraVolumeMounts propagated"
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              helm uninstall e2e-server-extra --namespace e2e-server-extra --wait 2>/dev/null || true
+              kubectl delete namespace e2e-server-extra --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/server-fsgroup/chainsaw-test.yaml
+++ b/tests/e2e/server-fsgroup/chainsaw-test.yaml
@@ -1,0 +1,71 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: server-fsgroup
+spec:
+  namespace: e2e-server-fsgroup
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Install openvox-stack
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-server-fsgroup "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-server-fsgroup --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/single-node-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-server-fsgroup-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Verify fsGroup and fsGroupChangePolicy on the server pod
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              set -eu
+              NS=e2e-server-fsgroup
+              POD=$(kubectl get pods -n "${NS}" \
+                -l openvox.voxpupuli.org/server=e2e-server-fsgroup-ca \
+                -o jsonpath='{.items[0].metadata.name}')
+              echo "pod=${POD}"
+
+              FSG=$(kubectl get pod "${POD}" -n "${NS}" \
+                -o jsonpath='{.spec.securityContext.fsGroup}')
+              echo "fsGroup=${FSG}"
+              [ "${FSG}" = "1001" ] || { echo "ERROR: expected fsGroup=1001"; exit 1; }
+
+              POL=$(kubectl get pod "${POD}" -n "${NS}" \
+                -o jsonpath='{.spec.securityContext.fsGroupChangePolicy}')
+              echo "fsGroupChangePolicy=${POL}"
+              [ "${POL}" = "OnRootMismatch" ] || { echo "ERROR: expected fsGroupChangePolicy=OnRootMismatch"; exit 1; }
+
+              echo "OK: fsGroup 1001 / OnRootMismatch set on managed server pod"
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              helm uninstall e2e-server-fsgroup --namespace e2e-server-fsgroup --wait 2>/dev/null || true
+              kubectl delete namespace e2e-server-fsgroup --ignore-not-found 2>/dev/null || true


### PR DESCRIPTION
## Summary

Adds two functional e2e (chainsaw) tests to the base group, closing coverage gaps for two recently merged features that so far only had unit tests.

### `server-extra-env-volumes` (covers #480)
Installs the openvox-stack with `extraEnv`, `envFrom`, `extraVolumes` and `extraVolumeMounts` set on the Server (via a new `ci/server-extra-env-volumes-values.yaml`, plus test-created secrets so the pod schedules), then asserts the reconciled Server pod actually carries:
- the plain `extraEnv` var,
- the `envFrom` secretRef,
- the secret-backed `extraVolume` + `extraVolumeMount`,
- and that the mounted secret is readable inside the `openvox-server` container.

### `server-fsgroup` (covers #486)
Installs the single-node stack and asserts managed server pods run with `securityContext.fsGroup: 1001` and `fsGroupChangePolicy: OnRootMismatch` — the default that lets the CA/server write CSI-provisioned volumes. No real CSI driver required (asserts on the pod spec).

Both tests follow the existing suite style (helm install -> assert Server `Running` -> `kubectl jsonpath` checks) and are wired into `e2e-group-base` in the Makefile.

## Testing

- YAML validated; `helm template` confirms the chart renders all four passthrough fields onto the Server CR.
- Full e2e requires the kind cluster + built images (runs in CI / `make e2e-group-base`).

## Notes

- The OpenVox 8/9 image rename (#487) is intentionally **not** in this branch, so image references use the current `openvox-server` convention. Once #487 merges, these two new tests should be updated to the `-${OPENVOX_MAJOR:-8}` convention along with the rest of the suite.
- A `-9` e2e (wiring `OPENVOX_MAJOR` through `_e2e-run.yaml`) belongs on the #487 branch and is tracked separately.