### PR TITLE
test(e2e): raise cert-rotation renewal wait timeout to 6m

### DIFF
--- a/tests/e2e/cert-rotation/chainsaw-test.yaml
+++ b/tests/e2e/cert-rotation/chainsaw-test.yaml
@@ -73,7 +73,10 @@ spec:
     - name: Wait for Certificate renewal to complete
       try:
         - script:
-            timeout: 3m
+            # The two retry loops below can each take up to 120s (60 x 2s),
+            # so the step must allow more than their combined 4m worst case to
+            # avoid being killed mid-retry on a slow runner.
+            timeout: 6m
             content: |
               echo "Waiting for Certificate to enter Renewing phase..."
               for i in $(seq 1 60); do


### PR DESCRIPTION
## Problem

The `cert-rotation` E2E test intermittently fails with `signal: killed` and no
assertion error — most recently in the manual `develop` run
[#30913353222](https://github.com/slauger/openvox-operator/actions/runs/30913353222)
(11/12 tests green, only `cert-rotation` failed).

The failing step **"Wait for Certificate renewal to complete"** wraps two
sequential retry loops inside a single `script` step:

| | Budget |
|---|---|
| Wrapping step `timeout` | **3m (180s)** |
| Loop 1 (`→ Renewing`) | up to 60 x 2s = **120s** |
| Loop 2 (`→ Signed`) | up to 60 x 2s = **120s** |
| Loops combined (worst case) | **240s (4m)** |

The step allows 3m, but its own retry loops can legitimately need up to 4m. On a
slow/loaded runner the step is killed mid-retry before the loops finish —
exactly the observed `signal: killed` with no assertion failure.

The certificate renewal round-trip is real work (mTLS request to the CA
puppetserver, CSR generation, Secret update, and a Server pod rollout because the
SSL Secret changes), so on a cold `kind` cluster it can approach the 3m cap.

## Verification that this is not an operator regression

The operator's renewal logic is correct for this scenario: the renewal cooldown
guard (`minRenewalCooldown`) hangs on the `last-renewal-time` annotation, which
is only set on an actual renewal (`certificate_signing.go`), not on initial
signing. So after a fresh install the cooldown does not suppress the first
renewal, and patching `renewBefore: 99999d` triggers `Renewing` on the next
reconcile as intended. The failure is purely the test's timeout budget.

## Fix

Raise the step `timeout` from `3m` to `6m`, so it comfortably exceeds the loops'
own 4m worst-case retry budget, and add a comment documenting why. No change to
the retry logic or assertions.
