### PR TITLE
chore(ci): automerge safe Renovate updates and assign release PR

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -252,6 +252,7 @@ jobs:
             --title "${{ steps.pr-content.outputs.title }}" \
             --body-file /tmp/pr_body.txt \
             --base main \
-            --head develop
+            --head develop \
+            --assignee "${{ github.repository_owner }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "platformAutomerge": false,
   "customManagers": [
     {
       "customType": "regex",
@@ -92,6 +93,61 @@
         "!OpenVoxProject/*"
       ],
       "groupName": "CI tooling"
+    },
+    {
+      "description": "Automerge CI tooling (conforma, hadolint, shellcheck, ...) minor/patch once CI is green",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchPackageNames": [
+        "!OpenVoxProject/*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge container base image updates (excludes the Go toolchain image)",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchPackageNames": [
+        "!docker.io/library/golang"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions minor/patch (majors stay manual)",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge Go module patch/digest updates (minor/major stay manual)",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Reduce the manual PR triage load by letting Renovate self-merge non-functional dependency updates once CI is green, and make sure the automated release PR is noticed.

## Changes

### `renovate.json` — automerge safe updates
Sets `platformAutomerge: false` so Renovate uses its own automerge (waits for green CI, no branch protection required). Adds package rules that automerge **only**:

- CI tooling (conforma, hadolint, shellcheck, …) — minor/patch
- Container base images (UBI) — minor/patch/digest/pin
- GitHub Actions — minor/patch
- Go modules — patch/digest

**Stays manual:** all major updates, OpenVox versions, the Go toolchain image, and Go module minor updates.

### `auto-pr.yaml` — assign the release PR
The auto-generated `develop -> main` release PR is now assigned to the repository owner on creation, so it is not missed. Updates to an existing auto-PR keep touching only the title and body — assignees are left untouched, so a deliberate re-assignment is preserved.

## Testing
- `renovate.json` validated as JSON.
- `auto-pr.yaml` validated as YAML.
- Automerge behaviour takes effect after the next Renovate run against `develop`; PR assignment applies to the next newly created release PR.