### PR TITLE
test(e2e): apply CRDs before installing the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,8 +234,15 @@ e2e-cleanup-full: e2e-cleanup ## Full cleanup including CRDs (use between test g
 	@echo "Removing CRDs..."
 	@kubectl get crds -o name | grep 'openvox\.voxpupuli\.org' | xargs -r kubectl delete --ignore-not-found 2>/dev/null || true
 
+# Helm only installs CRDs from crds/ on the first install and never upgrades them
+# on `helm upgrade`. On the persistent E2E cluster that means new CRD fields never
+# reach the API server, so apply them explicitly (server-side handles the large CRDs).
+.PHONY: e2e-crds
+e2e-crds: ## Apply/update operator CRDs (Helm does not upgrade CRDs on upgrade).
+	kubectl apply --server-side --force-conflicts -f charts/openvox-operator/crds/
+
 .PHONY: e2e-operator-base
-e2e-operator-base: e2e-cleanup ## Install operator: webhooks=false, gatewayAPI=false.
+e2e-operator-base: e2e-cleanup e2e-crds ## Install operator: webhooks=false, gatewayAPI=false.
 	helm upgrade --install openvox-operator charts/openvox-operator \
 		--namespace $(NAMESPACE) --create-namespace \
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
@@ -249,7 +256,7 @@ e2e-operator-base: e2e-cleanup ## Install operator: webhooks=false, gatewayAPI=f
 		-n $(NAMESPACE) --timeout=2m
 
 .PHONY: e2e-operator-gateway
-e2e-operator-gateway: e2e-cleanup ## Install operator: webhooks=false, gatewayAPI=true.
+e2e-operator-gateway: e2e-cleanup e2e-crds ## Install operator: webhooks=false, gatewayAPI=true.
 	helm upgrade --install openvox-operator charts/openvox-operator \
 		--namespace $(NAMESPACE) --create-namespace \
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \
@@ -263,7 +270,7 @@ e2e-operator-gateway: e2e-cleanup ## Install operator: webhooks=false, gatewayAP
 		-n $(NAMESPACE) --timeout=2m
 
 .PHONY: e2e-operator-webhooks-cm
-e2e-operator-webhooks-cm: e2e-cleanup ## Install operator: webhooks=true, cert-manager.
+e2e-operator-webhooks-cm: e2e-cleanup e2e-crds ## Install operator: webhooks=true, cert-manager.
 	helm upgrade --install openvox-operator charts/openvox-operator \
 		--namespace $(NAMESPACE) --create-namespace \
 		--set image.repository=$(IMAGE_REGISTRY)/openvox-operator \


### PR DESCRIPTION
## Problem

The `server-extra-env-volumes` E2E test (added in #488) fails on the persistent
E2E cluster with the live Server CRD dropping the new fields:

```
Warning: unknown field "spec.envFrom"
Warning: unknown field "spec.extraEnv"
Warning: unknown field "spec.extraVolumeMounts"
Warning: unknown field "spec.extraVolumes"
...
ERROR: extraEnv EXTRA_PLAIN not propagated (got '')
```

### Root cause — not a bug in #480

The operator code and CRDs on `develop` are correct. The failure is a gap in the
E2E setup:

1. The E2E cluster is **persistent** (`e2e-setup` connects via `E2E_KUBECONFIG`),
   not a fresh cluster per run.
2. `e2e-cleanup` **deliberately keeps CRDs**
   (`## Remove operator and all E2E test namespaces (keeps CRDs).`).
3. `e2e-operator-*` installs via `helm upgrade --install`, and **Helm installs
   CRDs from `crds/` only on the first install — it never upgrades them** on
   subsequent `helm upgrade`.

So the Server CRD on the cluster predated #480's `extraEnv` / `envFrom` /
`extraVolumes` / `extraVolumeMounts` fields, and the API server silently dropped
them. Any future new CRD field would hit the same wall. (`server-fsgroup` passed
because it only exercises pre-existing `securityContext` fields.)

Deleting CRDs in cleanup was considered and rejected: on a persistent cluster a
CRD delete cascades to every CR of that type across all namespaces and stalls on
finalizers once the operator is uninstalled — the exact Terminating-namespace
problem `e2e-cleanup` already works around.

## Fix

Add an `e2e-crds` target that applies the operator CRDs **server-side**, and make
the three `e2e-operator-*` targets depend on it. Ordering (verified with
`make -n e2e-operator-base`): cleanup → apply CRDs → install operator.

```
e2e-operator-base: e2e-cleanup e2e-crds
```

```make
e2e-crds:
	kubectl apply --server-side --force-conflicts -f charts/openvox-operator/crds/
```

Server-side apply is used because the generated CRDs are large and client-side
apply can exceed the annotation size limit. This is additive and idempotent — no
cascading deletes, no finalizer hangs.

## Verification

- One-off `kubectl apply --server-side -f charts/openvox-operator/crds/` against
  the E2E cluster made all four fields appear on the live Server CRD
  (`spec.extraEnv: array`, etc.), and a re-run of `server-extra-env-volumes`
  passed — confirming #480 works and the CRD was the only blocker.
- `make -n e2e-operator-base` shows the CRD apply runs after cleanup and before
  the Helm install.
