### PR TITLE
feat: code list, custom autosign/ENC commands, and autosign policy rollout fix

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -72,10 +72,14 @@ type ConfigSpec struct {
 	// +optional
 	NodeClassifierRef string `json:"nodeClassifierRef,omitempty"`
 
-	// Code defines the Puppet code source for all Servers in this Config.
-	// Only applied to Servers with server=true.
+	// Code defines the Puppet code sources for all Servers in this Config.
+	// Only applied to Servers with server=true. A single entry without environment
+	// or mountPath is mounted as the whole environments tree at environmentpath;
+	// with more than one entry each must set a unique environment or a mountPath.
+	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:XValidation:rule="size(self) <= 1 || self.all(e, (has(e.environment) && e.environment != '') || (has(e.mountPath) && e.mountPath != ''))",message="with more than one code entry, each entry must set either environment or mountPath"
 	// +optional
-	Code *CodeSpec `json:"code,omitempty"`
+	Code []CodeSpec `json:"code,omitempty"`
 
 	// ReadOnlyRootFilesystem enables read-only root filesystem on all Server pods.
 	// When true, all writable paths are backed by emptyDir volumes and
@@ -232,19 +236,31 @@ type GraphiteSpec struct {
 	UpdateIntervalSeconds int32 `json:"updateIntervalSeconds,omitempty"`
 }
 
-// CodeSpec defines the source of Puppet code to mount into Server pods.
-// Either ClaimName (PVC) or Image (OCI image volume) may be set, not both.
+// CodeSpec defines one source of Puppet code to mount into Server pods.
+// Either ClaimName (PVC) or Image (OCI image volume) must be set, not both.
+//
+// The mount target is chosen by Environment or MountPath (mutually exclusive):
+//   - Environment mounts at <environmentpath>/<environment> (a Puppet environment).
+//   - MountPath mounts at an absolute path, which must be under the Puppet codedir
+//     (/etc/puppetlabs/code) -- use this for the global modules dir or hieradata.
+//   - Neither: the source is mounted as the whole environments tree at
+//     environmentpath. This is only valid for a single-entry code list.
+//
 // +kubebuilder:validation:XValidation:rule="!(has(self.image) && size(self.image) > 0 && has(self.claimName) && size(self.claimName) > 0)",message="image and claimName are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="(has(self.image) && size(self.image) > 0) || (has(self.claimName) && size(self.claimName) > 0)",message="either image or claimName must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.environment) && size(self.environment) > 0 && has(self.mountPath) && size(self.mountPath) > 0)",message="environment and mountPath are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!has(self.mountPath) || size(self.mountPath) == 0 || self.mountPath.startsWith('/etc/puppetlabs/code')",message="mountPath must be under the Puppet codedir (/etc/puppetlabs/code)"
 type CodeSpec struct {
 	// ClaimName references an existing PVC containing Puppet code.
 	// Mutually exclusive with Image.
+	// +kubebuilder:validation:MaxLength=253
 	// +optional
 	ClaimName string `json:"claimName,omitempty"`
 
 	// Image is an OCI image reference containing Puppet code.
 	// Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
 	// Mutually exclusive with ClaimName.
+	// +kubebuilder:validation:MaxLength=512
 	// +optional
 	Image string `json:"image,omitempty"`
 
@@ -256,6 +272,21 @@ type CodeSpec struct {
 	// ImagePullSecret references a Secret for pulling from private registries.
 	// +optional
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
+
+	// Environment mounts this source as a single Puppet environment at
+	// <environmentpath>/<environment>. Mutually exclusive with MountPath.
+	// Environment values must be unique across the code list.
+	// +kubebuilder:validation:MaxLength=253
+	// +optional
+	Environment string `json:"environment,omitempty"`
+
+	// MountPath mounts this source at an absolute path, which must be under the
+	// Puppet codedir (/etc/puppetlabs/code). Use it for targets that are not a
+	// single environment, such as the global modules directory or hieradata.
+	// Mutually exclusive with Environment.
+	// +kubebuilder:validation:MaxLength=512
+	// +optional
+	MountPath string `json:"mountPath,omitempty"`
 }
 
 // ConfigPhase represents the current lifecycle phase.

--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -398,6 +398,25 @@ type PuppetSpec struct {
 	// ExtraConfig adds additional puppet.conf entries to specific INI sections.
 	// +optional
 	ExtraConfig *PuppetExtraConfig `json:"extraConfig,omitempty"`
+
+	// AutosignCommand overrides the built-in autosign binary with a custom
+	// executable. When set, puppet.conf points autosign at this path and the
+	// operator disables the SigningPolicy-driven flow (the policy Secret is no
+	// longer mounted). Puppet passes the certname as an argument and the CSR on
+	// stdin; the value must be an absolute path to an executable already present in
+	// the server image or mounted via the Server's extraVolumes. Leave unset to use
+	// the built-in binary driven by SigningPolicy resources.
+	// +optional
+	AutosignCommand string `json:"autosignCommand,omitempty"`
+
+	// ExternalNodesCommand overrides the built-in ENC binary with a custom
+	// executable. When set, puppet.conf sets node_terminus=exec with this path and
+	// the operator disables the NodeClassifier-driven flow (the ENC Secret is no
+	// longer mounted). The value must be an absolute path to an executable already
+	// present in the server image or mounted via the Server's extraVolumes. Leave
+	// unset to use the built-in binary driven by a NodeClassifier resource.
+	// +optional
+	ExternalNodesCommand string `json:"externalNodesCommand,omitempty"`
 }
 
 // PuppetExtraConfig holds additional puppet.conf entries per INI section.

--- a/api/v1alpha1/config_validation_test.go
+++ b/api/v1alpha1/config_validation_test.go
@@ -34,31 +34,80 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "code with image only accepted",
 			mutate: func(c *Config) {
-				c.Spec.Code = &CodeSpec{Image: "registry.example.com/code:latest"}
+				c.Spec.Code = []CodeSpec{{Image: "registry.example.com/code:latest"}}
 			},
 		},
 		{
 			name: "code with claimName only accepted",
 			mutate: func(c *Config) {
-				c.Spec.Code = &CodeSpec{ClaimName: "my-pvc"}
+				c.Spec.Code = []CodeSpec{{ClaimName: "my-pvc"}}
 			},
 		},
 		{
 			name: "code with both image and claimName rejected",
 			mutate: func(c *Config) {
-				c.Spec.Code = &CodeSpec{
+				c.Spec.Code = []CodeSpec{{
 					Image:     "registry.example.com/code:latest",
 					ClaimName: "my-pvc",
-				}
+				}}
 			},
 			wantErr: "image and claimName are mutually exclusive",
 		},
 		{
 			name: "code with neither image nor claimName rejected",
 			mutate: func(c *Config) {
-				c.Spec.Code = &CodeSpec{}
+				c.Spec.Code = []CodeSpec{{}}
 			},
 			wantErr: "either image or claimName must be set",
+		},
+		{
+			name: "code entry with environment accepted",
+			mutate: func(c *Config) {
+				c.Spec.Code = []CodeSpec{{Image: "registry.example.com/code:latest", Environment: "production"}}
+			},
+		},
+		{
+			name: "code entry with mountPath under codedir accepted",
+			mutate: func(c *Config) {
+				c.Spec.Code = []CodeSpec{{Image: "registry.example.com/code:latest", MountPath: "/etc/puppetlabs/code/modules"}}
+			},
+		},
+		{
+			name: "code entry with environment and mountPath rejected",
+			mutate: func(c *Config) {
+				c.Spec.Code = []CodeSpec{{
+					Image:       "registry.example.com/code:latest",
+					Environment: "production",
+					MountPath:   "/etc/puppetlabs/code/modules",
+				}}
+			},
+			wantErr: "environment and mountPath are mutually exclusive",
+		},
+		{
+			name: "code entry with mountPath outside codedir rejected",
+			mutate: func(c *Config) {
+				c.Spec.Code = []CodeSpec{{Image: "registry.example.com/code:latest", MountPath: "/opt/puppet/code"}}
+			},
+			wantErr: "mountPath must be under the Puppet codedir",
+		},
+		{
+			name: "multiple code entries with targets accepted",
+			mutate: func(c *Config) {
+				c.Spec.Code = []CodeSpec{
+					{Image: "registry.example.com/prod:latest", Environment: "production"},
+					{ClaimName: "modules", MountPath: "/etc/puppetlabs/code/modules"},
+				}
+			},
+		},
+		{
+			name: "multiple code entries without targets rejected",
+			mutate: func(c *Config) {
+				c.Spec.Code = []CodeSpec{
+					{Image: "registry.example.com/a:latest"},
+					{Image: "registry.example.com/b:latest"},
+				}
+			},
+			wantErr: "each entry must set either environment or mountPath",
 		},
 		{
 			name: "valid compileMode jit",

--- a/api/v1alpha1/server_types.go
+++ b/api/v1alpha1/server_types.go
@@ -89,9 +89,14 @@ type ServerSpec struct {
 	// +optional
 	MaxActiveInstances int32 `json:"maxActiveInstances,omitempty"`
 
-	// Code overrides the Config's code volume for this Server.
+	// Code overrides the Config's code volumes for this Server (replace, not merge).
+	// A single entry without environment or mountPath is mounted as the whole
+	// environments tree; with more than one entry each must set a unique environment
+	// or a mountPath.
+	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:XValidation:rule="size(self) <= 1 || self.all(e, (has(e.environment) && e.environment != '') || (has(e.mountPath) && e.mountPath != ''))",message="with more than one code entry, each entry must set either environment or mountPath"
 	// +optional
-	Code *CodeSpec `json:"code,omitempty"`
+	Code []CodeSpec `json:"code,omitempty"`
 
 	// TopologySpreadConstraints controls how pods are spread across topology domains.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -472,8 +472,8 @@ func (in *ConfigSpec) DeepCopyInto(out *ConfigSpec) {
 	}
 	if in.Code != nil {
 		in, out := &in.Code, &out.Code
-		*out = new(CodeSpec)
-		**out = **in
+		*out = make([]CodeSpec, len(*in))
+		copy(*out, *in)
 	}
 }
 
@@ -1662,8 +1662,8 @@ func (in *ServerSpec) DeepCopyInto(out *ServerSpec) {
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.Code != nil {
 		in, out := &in.Code, &out.Code
-		*out = new(CodeSpec)
-		**out = **in
+		*out = make([]CodeSpec, len(*in))
+		copy(*out, *in)
 	}
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -201,6 +201,16 @@ spec:
               puppet:
                 description: Puppet defines shared puppet.conf settings.
                 properties:
+                  autosignCommand:
+                    description: |-
+                      AutosignCommand overrides the built-in autosign binary with a custom
+                      executable. When set, puppet.conf points autosign at this path and the
+                      operator disables the SigningPolicy-driven flow (the policy Secret is no
+                      longer mounted). Puppet passes the certname as an argument and the CSR on
+                      stdin; the value must be an absolute path to an executable already present in
+                      the server image or mounted via the Server's extraVolumes. Leave unset to use
+                      the built-in binary driven by SigningPolicy resources.
+                    type: string
                   environmentPath:
                     default: /etc/puppetlabs/code/environments
                     description: EnvironmentPath is the path to puppet environments.
@@ -209,6 +219,15 @@ spec:
                     description: |-
                       EnvironmentTimeout controls how long puppet caches environments.
                       When unset, Puppet's default (0 = no caching) is used.
+                    type: string
+                  externalNodesCommand:
+                    description: |-
+                      ExternalNodesCommand overrides the built-in ENC binary with a custom
+                      executable. When set, puppet.conf sets node_terminus=exec with this path and
+                      the operator disables the NodeClassifier-driven flow (the ENC Secret is no
+                      longer mounted). The value must be an absolute path to an executable already
+                      present in the server image or mounted via the Server's extraVolumes. Leave
+                      unset to use the built-in binary driven by a NodeClassifier resource.
                     type: string
                   extraConfig:
                     description: ExtraConfig adds additional puppet.conf entries to

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -62,36 +62,78 @@ spec:
                 type: string
               code:
                 description: |-
-                  Code defines the Puppet code source for all Servers in this Config.
-                  Only applied to Servers with server=true.
-                properties:
-                  claimName:
-                    description: |-
-                      ClaimName references an existing PVC containing Puppet code.
-                      Mutually exclusive with Image.
-                    type: string
-                  image:
-                    description: |-
-                      Image is an OCI image reference containing Puppet code.
-                      Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
-                      Mutually exclusive with ClaimName.
-                    type: string
-                  imagePullPolicy:
-                    default: IfNotPresent
-                    description: ImagePullPolicy defines when to pull the code image.
-                    type: string
-                  imagePullSecret:
-                    description: ImagePullSecret references a Secret for pulling from
-                      private registries.
-                    type: string
-                type: object
+                  Code defines the Puppet code sources for all Servers in this Config.
+                  Only applied to Servers with server=true. A single entry without environment
+                  or mountPath is mounted as the whole environments tree at environmentpath;
+                  with more than one entry each must set a unique environment or a mountPath.
+                items:
+                  description: |-
+                    CodeSpec defines one source of Puppet code to mount into Server pods.
+                    Either ClaimName (PVC) or Image (OCI image volume) must be set, not both.
+
+                    The mount target is chosen by Environment or MountPath (mutually exclusive):
+                      - Environment mounts at <environmentpath>/<environment> (a Puppet environment).
+                      - MountPath mounts at an absolute path, which must be under the Puppet codedir
+                        (/etc/puppetlabs/code) -- use this for the global modules dir or hieradata.
+                      - Neither: the source is mounted as the whole environments tree at
+                        environmentpath. This is only valid for a single-entry code list.
+                  properties:
+                    claimName:
+                      description: |-
+                        ClaimName references an existing PVC containing Puppet code.
+                        Mutually exclusive with Image.
+                      maxLength: 253
+                      type: string
+                    environment:
+                      description: |-
+                        Environment mounts this source as a single Puppet environment at
+                        <environmentpath>/<environment>. Mutually exclusive with MountPath.
+                        Environment values must be unique across the code list.
+                      maxLength: 253
+                      type: string
+                    image:
+                      description: |-
+                        Image is an OCI image reference containing Puppet code.
+                        Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
+                        Mutually exclusive with ClaimName.
+                      maxLength: 512
+                      type: string
+                    imagePullPolicy:
+                      default: IfNotPresent
+                      description: ImagePullPolicy defines when to pull the code image.
+                      type: string
+                    imagePullSecret:
+                      description: ImagePullSecret references a Secret for pulling
+                        from private registries.
+                      type: string
+                    mountPath:
+                      description: |-
+                        MountPath mounts this source at an absolute path, which must be under the
+                        Puppet codedir (/etc/puppetlabs/code). Use it for targets that are not a
+                        single environment, such as the global modules directory or hieradata.
+                        Mutually exclusive with Environment.
+                      maxLength: 512
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: image and claimName are mutually exclusive
+                    rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
+                      && size(self.claimName) > 0)'
+                  - message: either image or claimName must be set
+                    rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
+                      && size(self.claimName) > 0)
+                  - message: environment and mountPath are mutually exclusive
+                    rule: '!(has(self.environment) && size(self.environment) > 0 &&
+                      has(self.mountPath) && size(self.mountPath) > 0)'
+                  - message: mountPath must be under the Puppet codedir (/etc/puppetlabs/code)
+                    rule: '!has(self.mountPath) || size(self.mountPath) == 0 || self.mountPath.startsWith(''/etc/puppetlabs/code'')'
+                maxItems: 64
+                type: array
                 x-kubernetes-validations:
-                - message: image and claimName are mutually exclusive
-                  rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
-                    && size(self.claimName) > 0)'
-                - message: either image or claimName must be set
-                  rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
-                    && size(self.claimName) > 0)
+                - message: with more than one code entry, each entry must set either
+                    environment or mountPath
+                  rule: size(self) <= 1 || self.all(e, (has(e.environment) && e.environment
+                    != '') || (has(e.mountPath) && e.mountPath != ''))
               databaseRef:
                 description: |-
                   DatabaseRef references a Database whose status.URL is used for puppetdb.conf.

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -1008,35 +1008,79 @@ spec:
                   is mounted into the Server pods.
                 type: string
               code:
-                description: Code overrides the Config's code volume for this Server.
-                properties:
-                  claimName:
-                    description: |-
-                      ClaimName references an existing PVC containing Puppet code.
-                      Mutually exclusive with Image.
-                    type: string
-                  image:
-                    description: |-
-                      Image is an OCI image reference containing Puppet code.
-                      Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
-                      Mutually exclusive with ClaimName.
-                    type: string
-                  imagePullPolicy:
-                    default: IfNotPresent
-                    description: ImagePullPolicy defines when to pull the code image.
-                    type: string
-                  imagePullSecret:
-                    description: ImagePullSecret references a Secret for pulling from
-                      private registries.
-                    type: string
-                type: object
+                description: |-
+                  Code overrides the Config's code volumes for this Server (replace, not merge).
+                  A single entry without environment or mountPath is mounted as the whole
+                  environments tree; with more than one entry each must set a unique environment
+                  or a mountPath.
+                items:
+                  description: |-
+                    CodeSpec defines one source of Puppet code to mount into Server pods.
+                    Either ClaimName (PVC) or Image (OCI image volume) must be set, not both.
+
+                    The mount target is chosen by Environment or MountPath (mutually exclusive):
+                      - Environment mounts at <environmentpath>/<environment> (a Puppet environment).
+                      - MountPath mounts at an absolute path, which must be under the Puppet codedir
+                        (/etc/puppetlabs/code) -- use this for the global modules dir or hieradata.
+                      - Neither: the source is mounted as the whole environments tree at
+                        environmentpath. This is only valid for a single-entry code list.
+                  properties:
+                    claimName:
+                      description: |-
+                        ClaimName references an existing PVC containing Puppet code.
+                        Mutually exclusive with Image.
+                      maxLength: 253
+                      type: string
+                    environment:
+                      description: |-
+                        Environment mounts this source as a single Puppet environment at
+                        <environmentpath>/<environment>. Mutually exclusive with MountPath.
+                        Environment values must be unique across the code list.
+                      maxLength: 253
+                      type: string
+                    image:
+                      description: |-
+                        Image is an OCI image reference containing Puppet code.
+                        Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
+                        Mutually exclusive with ClaimName.
+                      maxLength: 512
+                      type: string
+                    imagePullPolicy:
+                      default: IfNotPresent
+                      description: ImagePullPolicy defines when to pull the code image.
+                      type: string
+                    imagePullSecret:
+                      description: ImagePullSecret references a Secret for pulling
+                        from private registries.
+                      type: string
+                    mountPath:
+                      description: |-
+                        MountPath mounts this source at an absolute path, which must be under the
+                        Puppet codedir (/etc/puppetlabs/code). Use it for targets that are not a
+                        single environment, such as the global modules directory or hieradata.
+                        Mutually exclusive with Environment.
+                      maxLength: 512
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: image and claimName are mutually exclusive
+                    rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
+                      && size(self.claimName) > 0)'
+                  - message: either image or claimName must be set
+                    rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
+                      && size(self.claimName) > 0)
+                  - message: environment and mountPath are mutually exclusive
+                    rule: '!(has(self.environment) && size(self.environment) > 0 &&
+                      has(self.mountPath) && size(self.mountPath) > 0)'
+                  - message: mountPath must be under the Puppet codedir (/etc/puppetlabs/code)
+                    rule: '!has(self.mountPath) || size(self.mountPath) == 0 || self.mountPath.startsWith(''/etc/puppetlabs/code'')'
+                maxItems: 64
+                type: array
                 x-kubernetes-validations:
-                - message: image and claimName are mutually exclusive
-                  rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
-                    && size(self.claimName) > 0)'
-                - message: either image or claimName must be set
-                  rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
-                    && size(self.claimName) > 0)
+                - message: with more than one code entry, each entry must set either
+                    environment or mountPath
+                  rule: size(self) <= 1 || self.all(e, (has(e.environment) && e.environment
+                    != '') || (has(e.mountPath) && e.mountPath != ''))
               configRef:
                 description: ConfigRef references the Config this Server belongs to.
                 type: string

--- a/charts/openvox-stack/README.md
+++ b/charts/openvox-stack/README.md
@@ -43,9 +43,11 @@ helm install openvox oci://ghcr.io/slauger/charts/openvox-stack
 | ca.storage.storageClass | string | `""` | Storage class for CA PVC. Empty uses cluster default. |
 | ca.ttl | string | `"5y"` | CA certificate time-to-live. |
 | config.code.claimName | string | `""` | Existing PVC claim name for code volume. |
+| config.code.environment | string | `""` | Mount this source as a single Puppet environment at `<environmentpath>/<environment>`. Mutually exclusive with `mountPath`. |
 | config.code.image | string | `""` | Init container image for Puppet code deployment. |
 | config.code.imagePullPolicy | string | `"IfNotPresent"` | Pull policy for the code init container. |
 | config.code.imagePullSecret | string | `""` | Pull secret for the code init container. |
+| config.code.mountPath | string | `""` | Mount this source at an absolute path under the Puppet codedir (`/etc/puppetlabs/code`), e.g. the global modules dir. Mutually exclusive with `environment`. |
 | config.image.pullPolicy | string | `"Always"` | Image pull policy. |
 | config.image.pullSecrets | list | `[]` | Image pull secrets. |
 | config.image.repository | string | `"ghcr.io/slauger/openvox-server"` | OpenVox Server image repository. |

--- a/charts/openvox-stack/README.md
+++ b/charts/openvox-stack/README.md
@@ -51,8 +51,10 @@ helm install openvox oci://ghcr.io/slauger/charts/openvox-stack
 | config.image.repository | string | `"ghcr.io/slauger/openvox-server"` | OpenVox Server image repository. |
 | config.image.tag | string | `""` | Image tag. Defaults to the chart appVersion. |
 | config.name | string | `""` | Config resource name. Defaults to release name. |
+| config.puppet.autosignCommand | string | `""` | Custom autosign executable path. When set, replaces the built-in autosign binary and disables the SigningPolicy-driven flow. The executable must be present in the server image or mounted via a Server's extraVolumes. |
 | config.puppet.environmentPath | string | `""` | Path to Puppet environments. |
 | config.puppet.environmentTimeout | string | `""` | Environment timeout setting. |
+| config.puppet.externalNodesCommand | string | `""` | Custom ENC (external_nodes) executable path. When set, replaces the built-in ENC binary and disables the NodeClassifier-driven flow. The executable must be present in the server image or mounted via a Server's extraVolumes. |
 | config.puppet.extraConfig | object | `{}` | Extra puppet.conf sections and settings. |
 | config.puppet.hieraConfig | string | `""` | Path to Hiera configuration file. |
 | config.puppet.reports | string | `"store"` | Enabled report processors. |

--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -49,20 +49,24 @@ spec:
     externalNodesCommand: {{ . | quote }}
     {{- end }}
   {{- with .Values.config.code }}
-  {{- if or .image .claimName }}
+  {{- if kindIs "slice" . }}
   code:
-    {{- with .image }}
-    image: {{ . }}
-    {{- end }}
-    {{- with .imagePullPolicy }}
-    imagePullPolicy: {{ . }}
-    {{- end }}
-    {{- with .imagePullSecret }}
-    imagePullSecret: {{ . }}
-    {{- end }}
-    {{- with .claimName }}
-    claimName: {{ . }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- else if or .image .claimName }}
+  code:
+    - {{ if .image }}image: {{ .image }}{{ else }}claimName: {{ .claimName }}{{ end }}
+      {{- with .imagePullPolicy }}
+      imagePullPolicy: {{ . }}
+      {{- end }}
+      {{- with .imagePullSecret }}
+      imagePullSecret: {{ . }}
+      {{- end }}
+      {{- with .environment }}
+      environment: {{ . }}
+      {{- end }}
+      {{- with .mountPath }}
+      mountPath: {{ . }}
+      {{- end }}
   {{- end }}
   {{- end }}
   {{- with .Values.config.puppetserver }}

--- a/charts/openvox-stack/templates/config.yaml
+++ b/charts/openvox-stack/templates/config.yaml
@@ -42,6 +42,12 @@ spec:
     extraConfig:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.config.puppet.autosignCommand }}
+    autosignCommand: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.puppet.externalNodesCommand }}
+    externalNodesCommand: {{ . | quote }}
+    {{- end }}
   {{- with .Values.config.code }}
   {{- if or .image .claimName }}
   code:

--- a/charts/openvox-stack/templates/servers.yaml
+++ b/charts/openvox-stack/templates/servers.yaml
@@ -35,8 +35,25 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with $entry.code }}
+  {{- if kindIs "slice" . }}
   code:
     {{- toYaml . | nindent 4 }}
+  {{- else if or .image .claimName }}
+  code:
+    - {{ if .image }}image: {{ .image }}{{ else }}claimName: {{ .claimName }}{{ end }}
+      {{- with .imagePullPolicy }}
+      imagePullPolicy: {{ . }}
+      {{- end }}
+      {{- with .imagePullSecret }}
+      imagePullSecret: {{ . }}
+      {{- end }}
+      {{- with .environment }}
+      environment: {{ . }}
+      {{- end }}
+      {{- with .mountPath }}
+      mountPath: {{ . }}
+      {{- end }}
+  {{- end }}
   {{- end }}
   {{- with $entry.autoscaling }}
   autoscaling:

--- a/charts/openvox-stack/tests/config_test.yaml
+++ b/charts/openvox-stack/tests/config_test.yaml
@@ -126,8 +126,24 @@ tests:
           image: ghcr.io/slauger/openvox-e2e-code:latest
     asserts:
       - equal:
-          path: spec.code.image
+          path: spec.code[0].image
           value: ghcr.io/slauger/openvox-e2e-code:latest
+
+  - it: should render code as a list when configured with multiple sources
+    set:
+      config:
+        code:
+          - image: ghcr.io/slauger/prod:latest
+            environment: production
+          - claimName: modules
+            mountPath: /etc/puppetlabs/code/modules
+    asserts:
+      - equal:
+          path: spec.code[0].environment
+          value: production
+      - equal:
+          path: spec.code[1].mountPath
+          value: /etc/puppetlabs/code/modules
 
   - it: should not render code section when image and claimName are empty
     asserts:

--- a/charts/openvox-stack/tests/servers_test.yaml
+++ b/charts/openvox-stack/tests/servers_test.yaml
@@ -161,7 +161,7 @@ tests:
             image: ghcr.io/example/code:latest
     asserts:
       - equal:
-          path: spec.code.image
+          path: spec.code[0].image
           value: ghcr.io/example/code:latest
 
   - it: should propagate autoscaling

--- a/charts/openvox-stack/values.schema.json
+++ b/charts/openvox-stack/values.schema.json
@@ -90,12 +90,20 @@
                 "puppet": {
                     "type": "object",
                     "properties": {
+                        "autosignCommand": {
+                            "description": "Custom autosign executable path. Replaces the built-in binary and disables the SigningPolicy flow.",
+                            "type": "string"
+                        },
                         "environmentPath": {
                             "description": "Path to Puppet environments.",
                             "type": "string"
                         },
                         "environmentTimeout": {
                             "description": "Environment timeout setting.",
+                            "type": "string"
+                        },
+                        "externalNodesCommand": {
+                            "description": "Custom ENC executable path. Replaces the built-in binary and disables the NodeClassifier flow.",
                             "type": "string"
                         },
                         "extraConfig": {

--- a/charts/openvox-stack/values.schema.json
+++ b/charts/openvox-stack/values.schema.json
@@ -32,10 +32,17 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "object",
+                    "type": [
+                        "object",
+                        "array"
+                    ],
                     "properties": {
                         "claimName": {
                             "description": "Existing PVC claim name for code volume.",
+                            "type": "string"
+                        },
+                        "environment": {
+                            "description": "Mount this source as a single Puppet environment at environmentpath/\u003cenvironment\u003e. Mutually exclusive with mountPath.",
                             "type": "string"
                         },
                         "image": {
@@ -53,6 +60,10 @@
                         },
                         "imagePullSecret": {
                             "description": "Pull secret for the code init container.",
+                            "type": "string"
+                        },
+                        "mountPath": {
+                            "description": "Mount this source at an absolute path under the Puppet codedir (/etc/puppetlabs/code). Mutually exclusive with environment.",
                             "type": "string"
                         }
                     }

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -64,6 +64,7 @@ config:
     # @schema description: Custom ENC executable path. Replaces the built-in binary and disables the NodeClassifier flow.
     # -- Custom ENC (external_nodes) executable path. When set, replaces the built-in ENC binary and disables the NodeClassifier-driven flow. The executable must be present in the server image or mounted via a Server's extraVolumes.
     externalNodesCommand: ""
+  # @schema type:[object, array]
   code:
     # @schema description: Init container image for Puppet code deployment.
     # -- Init container image for Puppet code deployment.
@@ -78,6 +79,19 @@ config:
     # @schema description: Existing PVC claim name for code volume.
     # -- Existing PVC claim name for code volume.
     claimName: ""
+    # @schema description: Mount this source as a single Puppet environment at environmentpath/<environment>. Mutually exclusive with mountPath.
+    # -- Mount this source as a single Puppet environment at `<environmentpath>/<environment>`. Mutually exclusive with `mountPath`.
+    environment: ""
+    # @schema description: Mount this source at an absolute path under the Puppet codedir (/etc/puppetlabs/code). Mutually exclusive with environment.
+    # -- Mount this source at an absolute path under the Puppet codedir (`/etc/puppetlabs/code`), e.g. the global modules dir. Mutually exclusive with `environment`.
+    mountPath: ""
+  # For multiple code sources (per-environment images, a global modules dir,
+  # hieradata), set config.code to a list instead of the object above:
+  # code:
+  #   - image: registry/control-repo-production:latest
+  #     environment: production
+  #   - claimName: shared-modules
+  #     mountPath: /etc/puppetlabs/code/modules
   # puppetserver:
   #   maxRequestsPerInstance: 0
   #   borrowTimeout: 1200000

--- a/charts/openvox-stack/values.yaml
+++ b/charts/openvox-stack/values.yaml
@@ -58,6 +58,12 @@ config:
     #   server:
     #     strict_variables: "true"
     #   agent: {}
+    # @schema description: Custom autosign executable path. Replaces the built-in binary and disables the SigningPolicy flow.
+    # -- Custom autosign executable path. When set, replaces the built-in autosign binary and disables the SigningPolicy-driven flow. The executable must be present in the server image or mounted via a Server's extraVolumes.
+    autosignCommand: ""
+    # @schema description: Custom ENC executable path. Replaces the built-in binary and disables the NodeClassifier flow.
+    # -- Custom ENC (external_nodes) executable path. When set, replaces the built-in ENC binary and disables the NodeClassifier-driven flow. The executable must be present in the server image or mounted via a Server's extraVolumes.
+    externalNodesCommand: ""
   code:
     # @schema description: Init container image for Puppet code deployment.
     # -- Init container image for Puppet code deployment.

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -201,6 +201,16 @@ spec:
               puppet:
                 description: Puppet defines shared puppet.conf settings.
                 properties:
+                  autosignCommand:
+                    description: |-
+                      AutosignCommand overrides the built-in autosign binary with a custom
+                      executable. When set, puppet.conf points autosign at this path and the
+                      operator disables the SigningPolicy-driven flow (the policy Secret is no
+                      longer mounted). Puppet passes the certname as an argument and the CSR on
+                      stdin; the value must be an absolute path to an executable already present in
+                      the server image or mounted via the Server's extraVolumes. Leave unset to use
+                      the built-in binary driven by SigningPolicy resources.
+                    type: string
                   environmentPath:
                     default: /etc/puppetlabs/code/environments
                     description: EnvironmentPath is the path to puppet environments.
@@ -209,6 +219,15 @@ spec:
                     description: |-
                       EnvironmentTimeout controls how long puppet caches environments.
                       When unset, Puppet's default (0 = no caching) is used.
+                    type: string
+                  externalNodesCommand:
+                    description: |-
+                      ExternalNodesCommand overrides the built-in ENC binary with a custom
+                      executable. When set, puppet.conf sets node_terminus=exec with this path and
+                      the operator disables the NodeClassifier-driven flow (the ENC Secret is no
+                      longer mounted). The value must be an absolute path to an executable already
+                      present in the server image or mounted via the Server's extraVolumes. Leave
+                      unset to use the built-in binary driven by a NodeClassifier resource.
                     type: string
                   extraConfig:
                     description: ExtraConfig adds additional puppet.conf entries to

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -62,36 +62,78 @@ spec:
                 type: string
               code:
                 description: |-
-                  Code defines the Puppet code source for all Servers in this Config.
-                  Only applied to Servers with server=true.
-                properties:
-                  claimName:
-                    description: |-
-                      ClaimName references an existing PVC containing Puppet code.
-                      Mutually exclusive with Image.
-                    type: string
-                  image:
-                    description: |-
-                      Image is an OCI image reference containing Puppet code.
-                      Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
-                      Mutually exclusive with ClaimName.
-                    type: string
-                  imagePullPolicy:
-                    default: IfNotPresent
-                    description: ImagePullPolicy defines when to pull the code image.
-                    type: string
-                  imagePullSecret:
-                    description: ImagePullSecret references a Secret for pulling from
-                      private registries.
-                    type: string
-                type: object
+                  Code defines the Puppet code sources for all Servers in this Config.
+                  Only applied to Servers with server=true. A single entry without environment
+                  or mountPath is mounted as the whole environments tree at environmentpath;
+                  with more than one entry each must set a unique environment or a mountPath.
+                items:
+                  description: |-
+                    CodeSpec defines one source of Puppet code to mount into Server pods.
+                    Either ClaimName (PVC) or Image (OCI image volume) must be set, not both.
+
+                    The mount target is chosen by Environment or MountPath (mutually exclusive):
+                      - Environment mounts at <environmentpath>/<environment> (a Puppet environment).
+                      - MountPath mounts at an absolute path, which must be under the Puppet codedir
+                        (/etc/puppetlabs/code) -- use this for the global modules dir or hieradata.
+                      - Neither: the source is mounted as the whole environments tree at
+                        environmentpath. This is only valid for a single-entry code list.
+                  properties:
+                    claimName:
+                      description: |-
+                        ClaimName references an existing PVC containing Puppet code.
+                        Mutually exclusive with Image.
+                      maxLength: 253
+                      type: string
+                    environment:
+                      description: |-
+                        Environment mounts this source as a single Puppet environment at
+                        <environmentpath>/<environment>. Mutually exclusive with MountPath.
+                        Environment values must be unique across the code list.
+                      maxLength: 253
+                      type: string
+                    image:
+                      description: |-
+                        Image is an OCI image reference containing Puppet code.
+                        Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
+                        Mutually exclusive with ClaimName.
+                      maxLength: 512
+                      type: string
+                    imagePullPolicy:
+                      default: IfNotPresent
+                      description: ImagePullPolicy defines when to pull the code image.
+                      type: string
+                    imagePullSecret:
+                      description: ImagePullSecret references a Secret for pulling
+                        from private registries.
+                      type: string
+                    mountPath:
+                      description: |-
+                        MountPath mounts this source at an absolute path, which must be under the
+                        Puppet codedir (/etc/puppetlabs/code). Use it for targets that are not a
+                        single environment, such as the global modules directory or hieradata.
+                        Mutually exclusive with Environment.
+                      maxLength: 512
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: image and claimName are mutually exclusive
+                    rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
+                      && size(self.claimName) > 0)'
+                  - message: either image or claimName must be set
+                    rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
+                      && size(self.claimName) > 0)
+                  - message: environment and mountPath are mutually exclusive
+                    rule: '!(has(self.environment) && size(self.environment) > 0 &&
+                      has(self.mountPath) && size(self.mountPath) > 0)'
+                  - message: mountPath must be under the Puppet codedir (/etc/puppetlabs/code)
+                    rule: '!has(self.mountPath) || size(self.mountPath) == 0 || self.mountPath.startsWith(''/etc/puppetlabs/code'')'
+                maxItems: 64
+                type: array
                 x-kubernetes-validations:
-                - message: image and claimName are mutually exclusive
-                  rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
-                    && size(self.claimName) > 0)'
-                - message: either image or claimName must be set
-                  rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
-                    && size(self.claimName) > 0)
+                - message: with more than one code entry, each entry must set either
+                    environment or mountPath
+                  rule: size(self) <= 1 || self.all(e, (has(e.environment) && e.environment
+                    != '') || (has(e.mountPath) && e.mountPath != ''))
               databaseRef:
                 description: |-
                   DatabaseRef references a Database whose status.URL is used for puppetdb.conf.

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -1008,35 +1008,79 @@ spec:
                   is mounted into the Server pods.
                 type: string
               code:
-                description: Code overrides the Config's code volume for this Server.
-                properties:
-                  claimName:
-                    description: |-
-                      ClaimName references an existing PVC containing Puppet code.
-                      Mutually exclusive with Image.
-                    type: string
-                  image:
-                    description: |-
-                      Image is an OCI image reference containing Puppet code.
-                      Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
-                      Mutually exclusive with ClaimName.
-                    type: string
-                  imagePullPolicy:
-                    default: IfNotPresent
-                    description: ImagePullPolicy defines when to pull the code image.
-                    type: string
-                  imagePullSecret:
-                    description: ImagePullSecret references a Secret for pulling from
-                      private registries.
-                    type: string
-                type: object
+                description: |-
+                  Code overrides the Config's code volumes for this Server (replace, not merge).
+                  A single entry without environment or mountPath is mounted as the whole
+                  environments tree; with more than one entry each must set a unique environment
+                  or a mountPath.
+                items:
+                  description: |-
+                    CodeSpec defines one source of Puppet code to mount into Server pods.
+                    Either ClaimName (PVC) or Image (OCI image volume) must be set, not both.
+
+                    The mount target is chosen by Environment or MountPath (mutually exclusive):
+                      - Environment mounts at <environmentpath>/<environment> (a Puppet environment).
+                      - MountPath mounts at an absolute path, which must be under the Puppet codedir
+                        (/etc/puppetlabs/code) -- use this for the global modules dir or hieradata.
+                      - Neither: the source is mounted as the whole environments tree at
+                        environmentpath. This is only valid for a single-entry code list.
+                  properties:
+                    claimName:
+                      description: |-
+                        ClaimName references an existing PVC containing Puppet code.
+                        Mutually exclusive with Image.
+                      maxLength: 253
+                      type: string
+                    environment:
+                      description: |-
+                        Environment mounts this source as a single Puppet environment at
+                        <environmentpath>/<environment>. Mutually exclusive with MountPath.
+                        Environment values must be unique across the code list.
+                      maxLength: 253
+                      type: string
+                    image:
+                      description: |-
+                        Image is an OCI image reference containing Puppet code.
+                        Mounted as a read-only image volume (Kubernetes 1.35+, or 1.31+ with ImageVolume feature gate).
+                        Mutually exclusive with ClaimName.
+                      maxLength: 512
+                      type: string
+                    imagePullPolicy:
+                      default: IfNotPresent
+                      description: ImagePullPolicy defines when to pull the code image.
+                      type: string
+                    imagePullSecret:
+                      description: ImagePullSecret references a Secret for pulling
+                        from private registries.
+                      type: string
+                    mountPath:
+                      description: |-
+                        MountPath mounts this source at an absolute path, which must be under the
+                        Puppet codedir (/etc/puppetlabs/code). Use it for targets that are not a
+                        single environment, such as the global modules directory or hieradata.
+                        Mutually exclusive with Environment.
+                      maxLength: 512
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: image and claimName are mutually exclusive
+                    rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
+                      && size(self.claimName) > 0)'
+                  - message: either image or claimName must be set
+                    rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
+                      && size(self.claimName) > 0)
+                  - message: environment and mountPath are mutually exclusive
+                    rule: '!(has(self.environment) && size(self.environment) > 0 &&
+                      has(self.mountPath) && size(self.mountPath) > 0)'
+                  - message: mountPath must be under the Puppet codedir (/etc/puppetlabs/code)
+                    rule: '!has(self.mountPath) || size(self.mountPath) == 0 || self.mountPath.startsWith(''/etc/puppetlabs/code'')'
+                maxItems: 64
+                type: array
                 x-kubernetes-validations:
-                - message: image and claimName are mutually exclusive
-                  rule: '!(has(self.image) && size(self.image) > 0 && has(self.claimName)
-                    && size(self.claimName) > 0)'
-                - message: either image or claimName must be set
-                  rule: (has(self.image) && size(self.image) > 0) || (has(self.claimName)
-                    && size(self.claimName) > 0)
+                - message: with more than one code entry, each entry must set either
+                    environment or mountPath
+                  rule: size(self) <= 1 || self.all(e, (has(e.environment) && e.environment
+                    != '') || (has(e.mountPath) && e.mountPath != ''))
               configRef:
                 description: ConfigRef references the Config this Server belongs to.
                 type: string

--- a/docs/concepts/config-rollout.md
+++ b/docs/concepts/config-rollout.md
@@ -15,6 +15,7 @@ Tracked annotations:
 | `openvox.voxpupuli.org/ca-secret-hash` | CA Secret (`{ca}-ca`) | Yes |
 | `openvox.voxpupuli.org/enc-secret-hash` | ENC Secret (`{config}-enc`) | Yes |
 | `openvox.voxpupuli.org/report-webhook-secret-hash` | Report webhook Secret (`{config}-report-webhook`) | Yes |
+| `openvox.voxpupuli.org/autosign-policy-secret-hash` | Autosign policy Secret (`{ca}-autosign-policy`, CA pods only) | Yes |
 | `openvox.voxpupuli.org/code-image` | Code OCI image reference | Yes |
 
 ## What Triggers a Restart
@@ -35,12 +36,12 @@ Changes to CRDs that generate Secrets with tracked hashes also trigger restarts:
 |--------------|-----------------|:---:|
 | NodeClassifier | `{config}-enc` | Yes |
 | ReportProcessor | `{config}-report-webhook` | Yes |
+| SigningPolicy | `{ca}-autosign-policy` | Yes (CA pods) |
 
 ## What Does NOT Trigger a Restart
 
 | Changed CRD | Generated Secret | Restart | How It Propagates |
 |--------------|-----------------|:---:|-------------------|
-| SigningPolicy | `{ca}-autosign-policy` | No | `openvox-autosign` reads the policy file on every CSR signing request. The Secret is not tracked in pod annotations. |
 | CRL updates (non-CA) | `{ca}-ca-crl` | No | Mounted as a directory volume (without SubPath), which kubelet auto-syncs every ~60 seconds. |
 
 ## Controller Watch Mechanics
@@ -86,9 +87,9 @@ Changing `spec.puppet.environmentTimeout` on a Config:
 Creating or updating a SigningPolicy:
 
 1. Config controller is triggered via SigningPolicy watcher
-2. Autosign policy Secret is updated
-3. Server controller is triggered but autosign hash is **not tracked** - no restart
-4. `openvox-autosign` reads the updated policy at the next CSR signing attempt
+2. Autosign policy Secret (`{ca}-autosign-policy`) is updated
+3. Server controller detects the updated `autosign-policy-secret-hash` annotation
+4. CA pod is recreated so `openvox-autosign` reads the new policy on the next CSR (no manual restart)
 
 ### Changing ENC Configuration
 

--- a/docs/concepts/external-node-classification.md
+++ b/docs/concepts/external-node-classification.md
@@ -20,7 +20,7 @@ flowchart LR
 4. puppet.conf gets `node_terminus = exec` and `external_nodes = /usr/local/bin/openvox-enc`
 5. Puppet Server calls the `openvox-enc` binary for every node, which queries the classifier and returns YAML
 
-The `openvox-enc` binary is a static Go binary shipped in the openvox-server container image. Like `openvox-autosign`, configuration changes only update the Secret -- kubelet syncs the file without a pod restart.
+The `openvox-enc` binary is a static Go binary shipped in the openvox-server container image. A NodeClassifier change rewrites the `{config}-enc` Secret, which the operator hashes into the `enc-secret-hash` pod annotation, so server pods roll automatically to pick up the new configuration (see [Configuration Rollout](config-rollout.md)).
 
 ## Supported Classifiers
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -60,7 +60,7 @@ declaratively: `openvox-autosign` (configured by [SigningPolicy](signingpolicy.m
 resources) and `openvox-enc` (configured by a [NodeClassifier](nodeclassifier.md)).
 
 `autosignCommand` and `externalNodesCommand` are escape hatches for teams that need
-to run their own script instead — for example an autosign hook that registers the
+to run their own script instead - for example an autosign hook that registers the
 node in an external inventory, or an ENC that queries a CMDB. When set:
 
 - puppet.conf points `autosign` / `external_nodes` at the given executable.
@@ -74,7 +74,7 @@ server image or is mounted into the pod via the Server's
 `extraEnv` / `envFrom`.
 
 !!! warning
-    Autosign is the certificate admission boundary — a command that signs
+    Autosign is the certificate admission boundary - a command that signs
     unconditionally will sign every CSR. Review a custom `autosignCommand` as
     carefully as you would a firewall rule.
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -50,6 +50,40 @@ spec:
 | `storeBackend` | string | `puppetdb` | Storeconfigs backend |
 | `reports` | string | `puppetdb` | Report processors |
 | `extraConfig` | [PuppetExtraConfig](#puppetextraconfig) | - | Additional puppet.conf entries per INI section |
+| `autosignCommand` | string | - | Custom autosign executable path. When set, replaces the built-in binary and disables the SigningPolicy flow (see [Custom autosign / ENC commands](#custom-autosign--enc-commands)) |
+| `externalNodesCommand` | string | - | Custom ENC (`external_nodes`) executable path. When set, replaces the built-in binary and disables the NodeClassifier flow (see [Custom autosign / ENC commands](#custom-autosign--enc-commands)) |
+
+### Custom autosign / ENC commands
+
+By default the operator ships two Go binaries in the server image and drives them
+declaratively: `openvox-autosign` (configured by [SigningPolicy](signingpolicy.md)
+resources) and `openvox-enc` (configured by a [NodeClassifier](nodeclassifier.md)).
+
+`autosignCommand` and `externalNodesCommand` are escape hatches for teams that need
+to run their own script instead — for example an autosign hook that registers the
+node in an external inventory, or an ENC that queries a CMDB. When set:
+
+- puppet.conf points `autosign` / `external_nodes` at the given executable.
+- The corresponding built-in flow is disabled: the policy / ENC Secret is no longer
+  rendered or mounted, and SigningPolicy / NodeClassifier resources are ignored.
+
+The value must be an absolute path to an executable that already exists in the
+server image or is mounted into the pod via the Server's
+[`extraVolumes` / `extraVolumeMounts`](server.md). Any credentials the script needs
+(client certificates, API tokens) are supplied the same way, via `extraVolumes` and
+`extraEnv` / `envFrom`.
+
+!!! warning
+    Autosign is the certificate admission boundary — a command that signs
+    unconditionally will sign every CSR. Review a custom `autosignCommand` as
+    carefully as you would a firewall rule.
+
+```yaml
+spec:
+  puppet:
+    autosignCommand: /etc/puppetlabs/autosign/inventory-autosign
+    externalNodesCommand: /etc/puppetlabs/enc/cmdb-enc
+```
 
 ### PuppetExtraConfig
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -36,7 +36,7 @@ spec:
 | `puppetserver` | [PuppetServerSpec](#puppetserverspec) | - | puppetserver.conf, webserver.conf, and auth.conf settings |
 | `logging` | [LoggingSpec](#loggingspec) | - | Logback.xml log level configuration |
 | `metrics` | [MetricsSpec](#metricsspec) | - | Puppet Server metrics (JMX, Graphite) |
-| `code` | [CodeSpec](index.md#codespec) | - | Puppet code source (OCI image or PVC) for all Servers |
+| `code` | [[]CodeSpec](index.md#codespec) | - | Puppet code sources (OCI images / PVCs) for all Servers. A list; see [CodeSpec](index.md#codespec) for the mount target rules |
 | `readOnlyRootFilesystem` | bool | `true` | Enable read-only root filesystem on all Server pods for security hardening |
 
 ### PuppetSpec

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -66,14 +66,38 @@ These types are reused across multiple CRDs.
 
 ### CodeSpec
 
-Used by [Config](config.md) and [Server](server.md) to define the Puppet code source. Either `claimName` or `image` may be set, not both.
+`code` on [Config](config.md) and [Server](server.md) is a **list** of code sources.
+Each entry sets exactly one source (`claimName` **or** `image`, not both) and an
+optional mount target (`environment` **or** `mountPath`, not both).
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `claimName` | string | - | Name of an existing PVC containing Puppet code |
-| `image` | string | - | OCI image reference containing Puppet code (Kubernetes 1.35+, or 1.31+ with feature gate) |
+| `claimName` | string | - | Name of an existing PVC containing Puppet code (mutually exclusive with `image`) |
+| `image` | string | - | OCI image reference containing Puppet code, Kubernetes 1.35+ or 1.31+ with feature gate (mutually exclusive with `claimName`) |
 | `imagePullPolicy` | string | `IfNotPresent` | When to pull the code image |
 | `imagePullSecret` | string | - | Secret name for pulling from private registries |
+| `environment` | string | - | Mount this source as a single Puppet environment at `<environmentpath>/<environment>`. Must be unique across the list (mutually exclusive with `mountPath`) |
+| `mountPath` | string | - | Mount this source at an absolute path under the Puppet codedir (`/etc/puppetlabs/code`), e.g. the global modules dir or hieradata (mutually exclusive with `environment`) |
+
+**Mount target rules:**
+
+- **0 entries** — an `emptyDir` is mounted at `environmentpath` so Puppet Server can
+  bootstrap its default `production` environment.
+- **1 entry without `environment`/`mountPath`** — the source is mounted as the whole
+  `environments` tree at `environmentpath` (the pre-list behaviour).
+- **More than 1 entry** — each entry must set `environment` or `mountPath`;
+  `environment` values must be unique. `mountPath` must be under `/etc/puppetlabs/code`.
+
+Entries are mounted read-only. A Server's `code` replaces (does not merge with) the
+Config's `code`.
+
+```yaml
+code:
+  - image: registry/control-repo-production:latest
+    environment: production                 # -> <environmentpath>/production
+  - claimName: shared-modules
+    mountPath: /etc/puppetlabs/code/modules # global modules dir
+```
 
 ### PodSecurityContextSpec
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -81,11 +81,11 @@ optional mount target (`environment` **or** `mountPath`, not both).
 
 **Mount target rules:**
 
-- **0 entries** — an `emptyDir` is mounted at `environmentpath` so Puppet Server can
+- **0 entries** - an `emptyDir` is mounted at `environmentpath` so Puppet Server can
   bootstrap its default `production` environment.
-- **1 entry without `environment`/`mountPath`** — the source is mounted as the whole
+- **1 entry without `environment`/`mountPath`** - the source is mounted as the whole
   `environments` tree at `environmentpath` (the pre-list behaviour).
-- **More than 1 entry** — each entry must set `environment` or `mountPath`;
+- **More than 1 entry** - each entry must set `environment` or `mountPath`;
   `environment` values must be unique. `mountPath` must be under `/etc/puppetlabs/code`.
 
 Entries are mounted read-only. A Server's `code` replaces (does not merge with) the

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -35,7 +35,7 @@ spec:
 | `resources` | ResourceRequirements | - | CPU/memory requests and limits |
 | `javaArgs` | string | `-Xms512m -Xmx1024m` | JVM arguments |
 | `maxActiveInstances` | int32 | `1` | Number of JRuby instances per pod |
-| `code` | [CodeSpec](index.md#codespec) | - | Override the Config's code volume |
+| `code` | [[]CodeSpec](index.md#codespec) | - | Override the Config's code sources (replace, not merge). A list; see [CodeSpec](index.md#codespec) |
 | `topologySpreadConstraints` | []TopologySpreadConstraint | - | Pod spread constraints across topology domains |
 | `affinity` | Affinity | - | Pod affinity/anti-affinity rules |
 | `pdb` | [PDBSpec](#pdbspec) | - | PodDisruptionBudget configuration |

--- a/docs/reference/signingpolicy.md
+++ b/docs/reference/signingpolicy.md
@@ -141,8 +141,8 @@ Either `value` or `valueFrom` must be set.
 
 1. The operator collects all SigningPolicies for a CertificateAuthority
 2. It renders a policy config YAML into a Secret, mounted into the CA pod
-3. puppet.conf always points to the `openvox-autosign` binary (static config, no pod restarts)
-4. When a SigningPolicy changes, the operator updates the Secret. Kubelet syncs the mounted file (~60s). **No pod restart needed.**
+3. puppet.conf always points to the `openvox-autosign` binary, so puppet.conf itself never changes when policies change
+4. When a SigningPolicy changes, the operator rewrites the Secret and hashes it into the CA pod's `autosign-policy-secret-hash` annotation, which rolls the CA pod so the new policy applies automatically. **No manual restart needed.**
 
 The `openvox-autosign` binary shipped in the openvox-server container image evaluates policies at CSR signing time:
 

--- a/internal/controller/config_autosign.go
+++ b/internal/controller/config_autosign.go
@@ -55,7 +55,9 @@ func (r *ConfigReconciler) reconcileAutosignSecrets(ctx context.Context, cfg *op
 
 // reconcileAutosignSecret renders the autosign policy config YAML into a Secret.
 // The Secret is always created -- the binary handles all cases (no policies = deny all,
-// any:true = approve all). This keeps puppet.conf static and avoids pod restarts.
+// any:true = approve all). puppet.conf stays static; a policy change rewrites this
+// Secret and the server controller rolls the CA pod via the autosign-policy-secret-hash
+// annotation to apply it.
 func (r *ConfigReconciler) reconcileAutosignSecret(ctx context.Context, cfg *openvoxv1alpha1.Config, ca *openvoxv1alpha1.CertificateAuthority) error {
 	secretName := fmt.Sprintf("%s-autosign-policy", ca.Name)
 

--- a/internal/controller/config_autosign.go
+++ b/internal/controller/config_autosign.go
@@ -40,6 +40,11 @@ func (r *ConfigReconciler) reconcileAutosignSecrets(ctx context.Context, cfg *op
 	if cfg.Spec.AuthorityRef == "" {
 		return nil
 	}
+	// A custom autosignCommand replaces the built-in binary, so the policy Secret
+	// it would read is neither rendered nor mounted.
+	if cfg.Spec.Puppet.AutosignCommand != "" {
+		return nil
+	}
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cfg.Spec.AuthorityRef, Namespace: cfg.Namespace}, ca); err != nil {
 		if errors.IsNotFound(err) {

--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -238,6 +238,75 @@ func TestConfigReconcile_PuppetConfWithENC(t *testing.T) {
 	}
 }
 
+func TestConfigReconcile_AutosignCommandOverride(t *testing.T) {
+	cfg := newConfig("production",
+		withAuthorityRef("production-ca"),
+		withAutosignCommand("/usr/local/bin/custom-autosign"),
+	)
+	ca := newCertificateAuthority("production-ca")
+	c := setupTestClient(cfg, ca)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+	puppetConf := cm.Data["puppet.conf"]
+	if !strings.Contains(puppetConf, "autosign = /usr/local/bin/custom-autosign") {
+		t.Errorf("puppet.conf should point autosign at the custom command\n---\n%s", puppetConf)
+	}
+	if strings.Contains(puppetConf, "autosign = /usr/local/bin/openvox-autosign") {
+		t.Errorf("puppet.conf should not use the built-in autosign binary\n---\n%s", puppetConf)
+	}
+
+	// The SigningPolicy-driven flow is disabled: no policy Secret is rendered.
+	secret := &corev1.Secret{}
+	err := c.Get(testCtx(), types.NamespacedName{Name: "production-ca-autosign-policy", Namespace: testNamespace}, secret)
+	if err == nil {
+		t.Error("autosign policy Secret should not be created when autosignCommand is set")
+	}
+}
+
+func TestConfigReconcile_ExternalNodesCommandOverride(t *testing.T) {
+	cfg := newConfig("production",
+		withNodeClassifierRef("my-enc"),
+		withExternalNodesCommand("/usr/local/bin/custom-enc"),
+	)
+	nc := newNodeClassifier("my-enc", "https://enc.example.com")
+	c := setupTestClient(cfg, nc)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+	puppetConf := cm.Data["puppet.conf"]
+	if !strings.Contains(puppetConf, "node_terminus = exec") {
+		t.Errorf("puppet.conf missing node_terminus\n---\n%s", puppetConf)
+	}
+	if !strings.Contains(puppetConf, "external_nodes = /usr/local/bin/custom-enc") {
+		t.Errorf("puppet.conf should point external_nodes at the custom command\n---\n%s", puppetConf)
+	}
+	if strings.Contains(puppetConf, "external_nodes = /usr/local/bin/openvox-enc") {
+		t.Errorf("puppet.conf should not use the built-in ENC binary\n---\n%s", puppetConf)
+	}
+
+	// The NodeClassifier-driven flow is disabled: no ENC Secret is rendered.
+	secret := &corev1.Secret{}
+	err := c.Get(testCtx(), types.NamespacedName{Name: "production-enc", Namespace: testNamespace}, secret)
+	if err == nil {
+		t.Error("ENC Secret should not be created when externalNodesCommand is set")
+	}
+}
+
 func TestConfigReconcile_PuppetConfWithReports(t *testing.T) {
 	cfg := newConfig("production")
 	rp := newReportProcessor("webhook-rp", "production", "https://reports.example.com")

--- a/internal/controller/config_enc.go
+++ b/internal/controller/config_enc.go
@@ -25,6 +25,11 @@ func (r *ConfigReconciler) reconcileENCSecret(ctx context.Context, cfg *openvoxv
 	if cfg.Spec.NodeClassifierRef == "" {
 		return nil
 	}
+	// A custom externalNodesCommand replaces the built-in binary, so the ENC Secret
+	// it would read is neither rendered nor mounted.
+	if cfg.Spec.Puppet.ExternalNodesCommand != "" {
+		return nil
+	}
 
 	nc := &openvoxv1alpha1.NodeClassifier{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cfg.Spec.NodeClassifierRef, Namespace: cfg.Namespace}, nc); err != nil {

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -71,16 +71,27 @@ func (r *ConfigReconciler) renderPuppetConf(ctx context.Context, cfg *openvoxv1a
 			}
 		}
 
-		// Always point to the autosign binary. The binary reads the policy config
-		// Secret (mounted by the server controller) and decides sign/deny.
-		// puppet.conf stays static: a policy change only rewrites the Secret, and the
-		// server controller rolls the CA pod via the autosign-policy-secret-hash
-		// annotation so the change applies without a manual restart.
-		fmt.Fprintf(&sb, "autosign = %s\n", autosignBinaryPath)
+		// Autosign: by default point to the built-in binary, which reads the policy
+		// Secret (mounted by the server controller) and decides sign/deny. A policy
+		// change rewrites the Secret and the server controller rolls the CA pod via
+		// the autosign-policy-secret-hash annotation, so it applies without a manual
+		// restart. A custom autosignCommand replaces the built-in binary and disables
+		// the SigningPolicy-driven flow (the policy Secret is not mounted).
+		autosignCmd := autosignBinaryPath
+		if cfg.Spec.Puppet.AutosignCommand != "" {
+			autosignCmd = cfg.Spec.Puppet.AutosignCommand
+		}
+		fmt.Fprintf(&sb, "autosign = %s\n", autosignCmd)
 	}
 
-	// ENC settings
-	if cfg.Spec.NodeClassifierRef != "" {
+	// ENC settings: a custom externalNodesCommand replaces the built-in binary and
+	// disables the NodeClassifier-driven flow (the ENC Secret is not mounted).
+	// Otherwise the built-in binary is used when a NodeClassifier is referenced.
+	switch {
+	case cfg.Spec.Puppet.ExternalNodesCommand != "":
+		sb.WriteString("node_terminus = exec\n")
+		fmt.Fprintf(&sb, "external_nodes = %s\n", cfg.Spec.Puppet.ExternalNodesCommand)
+	case cfg.Spec.NodeClassifierRef != "":
 		sb.WriteString("node_terminus = exec\n")
 		fmt.Fprintf(&sb, "external_nodes = %s\n", encBinaryPath)
 	}

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -73,8 +73,9 @@ func (r *ConfigReconciler) renderPuppetConf(ctx context.Context, cfg *openvoxv1a
 
 		// Always point to the autosign binary. The binary reads the policy config
 		// Secret (mounted by the server controller) and decides sign/deny.
-		// This keeps puppet.conf static -- policy changes only update the Secret,
-		// which kubelet syncs without a pod restart.
+		// puppet.conf stays static: a policy change only rewrites the Secret, and the
+		// server controller rolls the CA pod via the autosign-policy-secret-hash
+		// annotation so the change applies without a manual restart.
 		fmt.Fprintf(&sb, "autosign = %s\n", autosignBinaryPath)
 	}
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -187,12 +187,55 @@ func resolveEnvironmentPath(cfg *openvoxv1alpha1.Config) string {
 }
 
 // resolveCode determines the code source for a Server.
-// Priority: Server override > Config default.
-func resolveCode(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) *openvoxv1alpha1.CodeSpec {
-	if server.Spec.Code != nil {
+// Priority: Server override (replace, not merge) > Config default.
+func resolveCode(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) []openvoxv1alpha1.CodeSpec {
+	if len(server.Spec.Code) > 0 {
 		return server.Spec.Code
 	}
 	return cfg.Spec.Code
+}
+
+// codeMount is a resolved code source: a unique volume name, the container mount
+// path, and the originating CodeSpec.
+type codeMount struct {
+	VolumeName string
+	MountPath  string
+	Spec       openvoxv1alpha1.CodeSpec
+}
+
+// resolveCodeMounts maps the resolved code sources to concrete volume mounts.
+// A single entry without environment/mountPath is mounted as the whole
+// environments tree at environmentpath (backwards compatible). Otherwise each
+// entry is mounted at its environment subdirectory or its absolute mountPath.
+func resolveCodeMounts(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) []codeMount {
+	entries := resolveCode(server, cfg)
+	envPath := resolveEnvironmentPath(cfg)
+	mounts := make([]codeMount, 0, len(entries))
+	for i, e := range entries {
+		switch {
+		case e.Environment != "":
+			mounts = append(mounts, codeMount{
+				VolumeName: fmt.Sprintf("code-%d", i),
+				MountPath:  fmt.Sprintf("%s/%s", envPath, e.Environment),
+				Spec:       e,
+			})
+		case e.MountPath != "":
+			mounts = append(mounts, codeMount{
+				VolumeName: fmt.Sprintf("code-%d", i),
+				MountPath:  e.MountPath,
+				Spec:       e,
+			})
+		default:
+			// Single whole-tree entry: keep the stable "code" volume name and mount
+			// at environmentpath, matching the pre-list behaviour.
+			mounts = append(mounts, codeMount{
+				VolumeName: "code",
+				MountPath:  envPath,
+				Spec:       e,
+			})
+		}
+	}
+	return mounts
 }
 
 // resolveImage determines the container image for a Server.

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -151,12 +151,11 @@ func TestResolveImage(t *testing.T) {
 }
 
 func TestResolveCode(t *testing.T) {
-	cfgCode := &openvoxv1alpha1.CodeSpec{
-		Image: "ghcr.io/slauger/puppet-code:latest",
-	}
 	cfg := &openvoxv1alpha1.Config{
 		Spec: openvoxv1alpha1.ConfigSpec{
-			Code: cfgCode,
+			Code: []openvoxv1alpha1.CodeSpec{{
+				Image: "ghcr.io/slauger/puppet-code:latest",
+			}},
 		},
 	}
 
@@ -165,18 +164,51 @@ func TestResolveCode(t *testing.T) {
 		Spec: openvoxv1alpha1.ServerSpec{},
 	}
 	got := resolveCode(server, cfg)
-	if got != cfgCode {
-		t.Error("expected config code spec when server has no override")
+	if len(got) != 1 || got[0].Image != "ghcr.io/slauger/puppet-code:latest" {
+		t.Errorf("expected config code spec when server has no override, got %+v", got)
 	}
 
-	// Server with code override -> use server's
-	serverCode := &openvoxv1alpha1.CodeSpec{
+	// Server with code override -> use server's (replace, not merge)
+	server.Spec.Code = []openvoxv1alpha1.CodeSpec{{
 		Image: "custom/code:v2",
-	}
-	server.Spec.Code = serverCode
+	}}
 	got = resolveCode(server, cfg)
-	if got != serverCode {
-		t.Error("expected server code spec when override is set")
+	if len(got) != 1 || got[0].Image != "custom/code:v2" {
+		t.Errorf("expected server code spec when override is set, got %+v", got)
+	}
+}
+
+func TestResolveCodeMounts(t *testing.T) {
+	cfg := &openvoxv1alpha1.Config{}
+
+	// Single whole-tree entry keeps the stable "code" volume at environmentpath.
+	single := &openvoxv1alpha1.Server{Spec: openvoxv1alpha1.ServerSpec{
+		Code: []openvoxv1alpha1.CodeSpec{{Image: "img:1"}},
+	}}
+	got := resolveCodeMounts(single, cfg)
+	if len(got) != 1 || got[0].VolumeName != "code" || got[0].MountPath != defaultEnvironmentPath {
+		t.Errorf("single whole-tree entry: got %+v", got)
+	}
+
+	// Multiple entries map to environment subdirs and absolute mountPaths.
+	multi := &openvoxv1alpha1.Server{Spec: openvoxv1alpha1.ServerSpec{
+		Code: []openvoxv1alpha1.CodeSpec{
+			{Image: "img:prod", Environment: "production"},
+			{ClaimName: "modules", MountPath: "/etc/puppetlabs/code/modules"},
+		},
+	}}
+	got = resolveCodeMounts(multi, cfg)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 mounts, got %d", len(got))
+	}
+	if got[0].MountPath != defaultEnvironmentPath+"/production" {
+		t.Errorf("environment entry mountPath = %q", got[0].MountPath)
+	}
+	if got[1].MountPath != "/etc/puppetlabs/code/modules" {
+		t.Errorf("mountPath entry mountPath = %q", got[1].MountPath)
+	}
+	if got[0].VolumeName == got[1].VolumeName {
+		t.Errorf("volume names must be unique, both %q", got[0].VolumeName)
 	}
 }
 

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -180,6 +180,50 @@ func TestServerReconcile_AnnotationHashes(t *testing.T) {
 	}
 }
 
+func TestServerReconcile_AutosignPolicyHashAnnotation(t *testing.T) {
+	objs := append(serverPrereqs(),
+		newSecret("production-ca-autosign-policy", map[string][]byte{
+			"autosign-policy.yaml": []byte("policies:\n"),
+		}),
+		newServer("test-ca", withCA(true), withServerRole(false)),
+	)
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-ca")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	// The CA pod must carry the autosign-policy hash so a SigningPolicy change rolls it.
+	if v, ok := deploy.Spec.Template.Annotations["openvox.voxpupuli.org/autosign-policy-secret-hash"]; !ok || v == "" {
+		t.Error("CA pod should carry the autosign-policy-secret-hash annotation")
+	}
+}
+
+func TestServerReconcile_NoAutosignPolicyHashOnNonCA(t *testing.T) {
+	objs := append(serverPrereqs(), newServer("test-server"))
+	c := setupTestClient(objs...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	if _, ok := deploy.Spec.Template.Annotations["openvox.voxpupuli.org/autosign-policy-secret-hash"]; ok {
+		t.Error("non-CA server should not carry the autosign-policy-secret-hash annotation")
+	}
+}
+
 func TestServerReconcile_PDBCreation(t *testing.T) {
 	objs := append(serverPrereqs(), newServer("test-server", withPDBEnabled(true)))
 	c := setupTestClient(objs...)

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -82,10 +83,17 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 		"openvox.voxpupuli.org/ca-secret-hash":  caHash,
 	}
 
-	// Add code image annotation for server:true pods to trigger rollout on image change
+	// Add code image annotation for server:true pods to trigger rollout on image change.
+	// All code image references are joined so a change to any of them rolls the pod.
 	if server.Spec.Server {
-		if code := resolveCode(server, cfg); code != nil && code.Image != "" {
-			annotations["openvox.voxpupuli.org/code-image"] = code.Image
+		var codeImages []string
+		for _, e := range resolveCode(server, cfg) {
+			if e.Image != "" {
+				codeImages = append(codeImages, e.Image)
+			}
+		}
+		if len(codeImages) > 0 {
+			annotations["openvox.voxpupuli.org/code-image"] = strings.Join(codeImages, ",")
 		}
 	}
 
@@ -308,39 +316,41 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 		)
 	}
 
-	// Code volume: only mounted for server:true pods (CA-only pods don't compile catalogs)
+	// Code volumes: only mounted for server:true pods (CA-only pods don't compile catalogs)
 	if server.Spec.Server {
-		if code := resolveCode(server, cfg); code != nil {
-			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      "code",
-				MountPath: resolveEnvironmentPath(cfg),
-				ReadOnly:  true,
-			})
-			switch {
-			case code.Image != "":
-				pullPolicy := code.ImagePullPolicy
-				if pullPolicy == "" {
-					pullPolicy = corev1.PullIfNotPresent
+		if codeMounts := resolveCodeMounts(server, cfg); len(codeMounts) > 0 {
+			for _, cm := range codeMounts {
+				volumeMounts = append(volumeMounts, corev1.VolumeMount{
+					Name:      cm.VolumeName,
+					MountPath: cm.MountPath,
+					ReadOnly:  true,
+				})
+				switch {
+				case cm.Spec.Image != "":
+					pullPolicy := cm.Spec.ImagePullPolicy
+					if pullPolicy == "" {
+						pullPolicy = corev1.PullIfNotPresent
+					}
+					volumes = append(volumes, corev1.Volume{
+						Name: cm.VolumeName,
+						VolumeSource: corev1.VolumeSource{
+							Image: &corev1.ImageVolumeSource{
+								Reference:  cm.Spec.Image,
+								PullPolicy: pullPolicy,
+							},
+						},
+					})
+				case cm.Spec.ClaimName != "":
+					volumes = append(volumes, corev1.Volume{
+						Name: cm.VolumeName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: cm.Spec.ClaimName,
+								ReadOnly:  true,
+							},
+						},
+					})
 				}
-				volumes = append(volumes, corev1.Volume{
-					Name: "code",
-					VolumeSource: corev1.VolumeSource{
-						Image: &corev1.ImageVolumeSource{
-							Reference:  code.Image,
-							PullPolicy: pullPolicy,
-						},
-					},
-				})
-			case code.ClaimName != "":
-				volumes = append(volumes, corev1.Volume{
-					Name: "code",
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: code.ClaimName,
-							ReadOnly:  true,
-						},
-					},
-				})
 			}
 		} else {
 			// No external code source configured: mount a writable emptyDir at the
@@ -517,12 +527,16 @@ chmod 640 /ssl/private_keys/puppet.pem`
 		Volumes:                   volumes,
 	}
 
-	// Add imagePullSecrets for code image if configured
+	// Add imagePullSecrets for code images if configured (deduplicated across entries)
 	if server.Spec.Server {
-		if code := resolveCode(server, cfg); code != nil && code.ImagePullSecret != "" {
-			podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, corev1.LocalObjectReference{
-				Name: code.ImagePullSecret,
-			})
+		seen := make(map[string]bool)
+		for _, e := range resolveCode(server, cfg) {
+			if e.ImagePullSecret != "" && !seen[e.ImagePullSecret] {
+				seen[e.ImagePullSecret] = true
+				podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, corev1.LocalObjectReference{
+					Name: e.ImagePullSecret,
+				})
+			}
 		}
 	}
 

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -105,6 +105,17 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 		}
 	}
 
+	// Add autosign-policy secret hash annotation for CA pods to trigger rollout on
+	// SigningPolicy changes. The policy Secret is subPath-mounted, so kubelet does not
+	// live-sync it; hashing it into the pod template rolls the CA pod when the rendered
+	// policy changes, so a SigningPolicy edit applies without a manual restart.
+	if server.Spec.CA {
+		autosignSecretName := fmt.Sprintf("%s-autosign-policy", ca.Name)
+		if autosignHash, err := r.secretHash(ctx, autosignSecretName, server.Namespace); err == nil {
+			annotations["openvox.voxpupuli.org/autosign-policy-secret-hash"] = autosignHash
+		}
+	}
+
 	deploy := &appsv1.Deployment{}
 	err = r.Get(ctx, types.NamespacedName{Name: deployName, Namespace: server.Namespace}, deploy)
 	if errors.IsNotFound(err) {

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -89,8 +89,9 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 		}
 	}
 
-	// Add ENC secret hash annotation for server pods to trigger rollout on ENC config changes
-	if server.Spec.Server && cfg.Spec.NodeClassifierRef != "" {
+	// Add ENC secret hash annotation for server pods to trigger rollout on ENC config changes.
+	// Skipped when a custom externalNodesCommand disables the NodeClassifier-driven flow.
+	if server.Spec.Server && cfg.Spec.NodeClassifierRef != "" && cfg.Spec.Puppet.ExternalNodesCommand == "" {
 		encSecretName := fmt.Sprintf("%s-enc", server.Spec.ConfigRef)
 		if encHash, err := r.secretHash(ctx, encSecretName, server.Namespace); err == nil {
 			annotations["openvox.voxpupuli.org/enc-secret-hash"] = encHash
@@ -109,7 +110,8 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 	// SigningPolicy changes. The policy Secret is subPath-mounted, so kubelet does not
 	// live-sync it; hashing it into the pod template rolls the CA pod when the rendered
 	// policy changes, so a SigningPolicy edit applies without a manual restart.
-	if server.Spec.CA {
+	// Skipped when a custom autosignCommand disables the SigningPolicy-driven flow.
+	if server.Spec.CA && cfg.Spec.Puppet.AutosignCommand == "" {
 		autosignSecretName := fmt.Sprintf("%s-autosign-policy", ca.Name)
 		if autosignHash, err := r.secretHash(ctx, autosignSecretName, server.Namespace); err == nil {
 			annotations["openvox.voxpupuli.org/autosign-policy-secret-hash"] = autosignHash
@@ -280,22 +282,26 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 			configMapVolumeWithKey("ca-cfg", configMapName, "ca-enabled.cfg", "ca.cfg"),
 		)
 
-		// Mount autosign policy Secret (always present, managed by Config controller)
-		autosignSecretName := fmt.Sprintf("%s-autosign-policy", ca.Name)
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "autosign-policy",
-			MountPath: "/etc/puppetlabs/puppet/autosign-policy.yaml",
-			SubPath:   "autosign-policy.yaml",
-			ReadOnly:  true,
-		})
-		volumes = append(volumes, corev1.Volume{
-			Name: "autosign-policy",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: autosignSecretName,
+		// Mount autosign policy Secret (managed by the Config controller).
+		// Skipped when a custom autosignCommand disables the SigningPolicy-driven
+		// flow: the command is then responsible for its own signing decision.
+		if cfg.Spec.Puppet.AutosignCommand == "" {
+			autosignSecretName := fmt.Sprintf("%s-autosign-policy", ca.Name)
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      "autosign-policy",
+				MountPath: "/etc/puppetlabs/puppet/autosign-policy.yaml",
+				SubPath:   "autosign-policy.yaml",
+				ReadOnly:  true,
+			})
+			volumes = append(volumes, corev1.Volume{
+				Name: "autosign-policy",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: autosignSecretName,
+					},
 				},
-			},
-		})
+			})
+		}
 	} else {
 		volumes = append(volumes,
 			configMapVolumeWithKey("ca-cfg", configMapName, "ca-disabled.cfg", "ca.cfg"),
@@ -352,8 +358,9 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 		}
 	}
 
-	// ENC: mount config Secret and cache emptyDir for server:true pods with nodeClassifierRef
-	if server.Spec.Server && cfg.Spec.NodeClassifierRef != "" {
+	// ENC: mount config Secret and cache emptyDir for server:true pods with nodeClassifierRef.
+	// Skipped when a custom externalNodesCommand disables the NodeClassifier-driven flow.
+	if server.Spec.Server && cfg.Spec.NodeClassifierRef != "" && cfg.Spec.Puppet.ExternalNodesCommand == "" {
 		encSecretName := fmt.Sprintf("%s-enc", server.Spec.ConfigRef)
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -122,6 +122,45 @@ func TestBuildPodSpec_CARole(t *testing.T) {
 	}
 }
 
+func TestBuildPodSpec_AutosignCommandSkipsPolicyMount(t *testing.T) {
+	cfg := newConfig("production", withAutosignCommand("/usr/local/bin/custom-autosign"))
+	server := newServer("test-ca", withCA(true), withServerRole(false))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	for _, vm := range podSpec.Containers[0].VolumeMounts {
+		if vm.Name == "autosign-policy" {
+			t.Error("autosign-policy mount should be skipped when autosignCommand is set")
+		}
+	}
+	for _, v := range podSpec.Volumes {
+		if v.Name == "autosign-policy" {
+			t.Error("autosign-policy volume should be skipped when autosignCommand is set")
+		}
+	}
+}
+
+func TestBuildPodSpec_ExternalNodesCommandSkipsENCMount(t *testing.T) {
+	cfg := newConfig("production",
+		withNodeClassifierRef("my-enc"),
+		withExternalNodesCommand("/usr/local/bin/custom-enc"),
+	)
+	server := newServer("test-server", withServerRole(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	for _, vm := range podSpec.Containers[0].VolumeMounts {
+		if vm.Name == "enc-config" {
+			t.Error("enc-config mount should be skipped when externalNodesCommand is set")
+		}
+	}
+	for _, v := range podSpec.Volumes {
+		if v.Name == "enc-config" {
+			t.Error("enc-config volume should be skipped when externalNodesCommand is set")
+		}
+	}
+}
+
 func TestBuildPodSpec_CodeVolumeImage(t *testing.T) {
 	cfg := newConfig("production", withCodeImage("ghcr.io/slauger/puppet-code:v1.0"))
 	server := newServer("test-server", withServerRole(true))

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -118,6 +119,44 @@ func TestBuildPodSpec_CARole(t *testing.T) {
 	for _, v := range podSpec.Volumes {
 		if v.Name == "code" {
 			t.Error("CA-only pod should not have code volume")
+		}
+	}
+}
+
+func TestBuildPodSpec_MultipleCodeVolumes(t *testing.T) {
+	cfg := newConfig("production", withCodeList(
+		openvoxv1alpha1.CodeSpec{Image: "ghcr.io/slauger/prod:latest", Environment: "production"},
+		openvoxv1alpha1.CodeSpec{ClaimName: "modules", MountPath: "/etc/puppetlabs/code/modules"},
+	))
+	server := newServer("test-server", withServerRole(true))
+
+	podSpec := testBuildPodSpec(server, cfg)
+
+	mountByName := map[string]string{}
+	for _, vm := range podSpec.Containers[0].VolumeMounts {
+		mountByName[vm.Name] = vm.MountPath
+	}
+
+	// Environment entry -> <environmentpath>/production; mountPath entry -> absolute path.
+	envPath := resolveEnvironmentPath(cfg)
+	var codeMountPaths []string
+	codeVolumes := 0
+	for _, v := range podSpec.Volumes {
+		if strings.HasPrefix(v.Name, "code") {
+			codeVolumes++
+			codeMountPaths = append(codeMountPaths, mountByName[v.Name])
+		}
+	}
+	if codeVolumes != 2 {
+		t.Fatalf("expected 2 code volumes, got %d (%v)", codeVolumes, codeMountPaths)
+	}
+	wantPaths := map[string]bool{
+		envPath + "/production":        true,
+		"/etc/puppetlabs/code/modules": true,
+	}
+	for _, p := range codeMountPaths {
+		if !wantPaths[p] {
+			t.Errorf("unexpected code mount path %q", p)
 		}
 	}
 }

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -119,6 +119,18 @@ func withReadOnlyRootFS(v bool) configOption {
 	}
 }
 
+func withAutosignCommand(cmd string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.Puppet.AutosignCommand = cmd
+	}
+}
+
+func withExternalNodesCommand(cmd string) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.Puppet.ExternalNodesCommand = cmd
+	}
+}
+
 func withCodeImage(image string) configOption {
 	return func(c *openvoxv1alpha1.Config) {
 		c.Spec.Code = &openvoxv1alpha1.CodeSpec{Image: image}

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -133,13 +133,19 @@ func withExternalNodesCommand(cmd string) configOption {
 
 func withCodeImage(image string) configOption {
 	return func(c *openvoxv1alpha1.Config) {
-		c.Spec.Code = &openvoxv1alpha1.CodeSpec{Image: image}
+		c.Spec.Code = []openvoxv1alpha1.CodeSpec{{Image: image}}
 	}
 }
 
 func withCodePVC(claimName string) configOption {
 	return func(c *openvoxv1alpha1.Config) {
-		c.Spec.Code = &openvoxv1alpha1.CodeSpec{ClaimName: claimName}
+		c.Spec.Code = []openvoxv1alpha1.CodeSpec{{ClaimName: claimName}}
+	}
+}
+
+func withCodeList(code ...openvoxv1alpha1.CodeSpec) configOption {
+	return func(c *openvoxv1alpha1.Config) {
+		c.Spec.Code = code
 	}
 }
 

--- a/internal/webhook/config_webhook.go
+++ b/internal/webhook/config_webhook.go
@@ -53,6 +53,8 @@ func (v *ConfigValidator) validate(ctx context.Context, c *openvoxv1alpha1.Confi
 		}
 	}
 
+	errs = append(errs, validateCodeList(c.Spec.Code, specPath.Child("code"))...)
+
 	if len(errs) > 0 {
 		return nil, errs.ToAggregate()
 	}

--- a/internal/webhook/config_webhook_test.go
+++ b/internal/webhook/config_webhook_test.go
@@ -9,6 +9,29 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestConfigValidator_DuplicateCodeEnvironment(t *testing.T) {
+	c := setupTestClient()
+	v := &ConfigValidator{Client: c}
+
+	cfg := &openvoxv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: openvoxv1alpha1.ConfigSpec{
+			Code: []openvoxv1alpha1.CodeSpec{
+				{Image: "a:latest", Environment: "production"},
+				{Image: "b:latest", Environment: "production"},
+			},
+		},
+	}
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Error("expected error for duplicate code environment")
+	}
+
+	cfg.Spec.Code[1].Environment = "staging"
+	if _, err := v.ValidateCreate(context.Background(), cfg); err != nil {
+		t.Errorf("expected no error for unique code environments, got %v", err)
+	}
+}
+
 func TestConfigValidator_Update(t *testing.T) {
 	ca := &openvoxv1alpha1.CertificateAuthority{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},

--- a/internal/webhook/helpers.go
+++ b/internal/webhook/helpers.go
@@ -7,10 +7,29 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
+
+// validateCodeList checks cross-entry constraints on a code volume list that the
+// per-entry CEL rules cannot express: environment values must be unique.
+func validateCodeList(code []openvoxv1alpha1.CodeSpec, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	seen := make(map[string]bool, len(code))
+	for i, e := range code {
+		if e.Environment == "" {
+			continue
+		}
+		if seen[e.Environment] {
+			errs = append(errs, field.Duplicate(path.Index(i).Child("environment"), e.Environment))
+			continue
+		}
+		seen[e.Environment] = true
+	}
+	return errs
+}
 
 // refExists checks whether a same-namespace resource of type T exists.
 func refExists[T client.Object](ctx context.Context, c client.Reader, ns, name string, obj T) error {

--- a/internal/webhook/server_webhook.go
+++ b/internal/webhook/server_webhook.go
@@ -51,6 +51,8 @@ func (v *ServerValidator) validate(ctx context.Context, s *openvoxv1alpha1.Serve
 		warnings = append(warnings, fmt.Sprintf("running CA role with %d replicas; CA data is stored on a PVC and concurrent writes may cause issues", *s.Spec.Replicas))
 	}
 
+	errs = append(errs, validateCodeList(s.Spec.Code, specPath.Child("code"))...)
+
 	if len(errs) > 0 {
 		return warnings, errs.ToAggregate()
 	}


### PR DESCRIPTION
Implements five follow-ups from #477, in reviewable commits. The webhook /
REST-API halves of #490 and #491 are intentionally **out of scope** and left as
follow-ups — only the command-override escape hatches land here.

## What's included

| Commit | Issue | Summary |
|---|---|---|
| `fix: roll CA pod when the autosign policy changes` | #492 | Bug fix |
| `docs: describe autosign/ENC policy propagation as a pod rollout` | #493 | Docs/comment accuracy |
| `feat: custom autosignCommand and externalNodesCommand overrides` | #490, #491 | Escape hatches only |
| `feat: support multiple code sources via a code list` | #489 (closes #476) | `spec.code` object → list |

### #492 — SigningPolicy changes now apply without a manual restart
The `<ca>-autosign-policy` Secret is subPath-mounted (no kubelet live-sync) and,
unlike the ENC and report-webhook Secrets, was not hashed into the pod template.
A `SigningPolicy` edit therefore only took effect after a manual CA pod restart.
Fixed by adding an `autosign-policy-secret-hash` annotation on CA pods, mirroring
the existing hash-annotation pattern — so the CA pod rolls automatically.

> Note: a directory mount (like the CRL Secret) was considered but Puppet's
> `autosign` setting must be a bare executable path, so it can't point the binary
> at a directory-mounted file without coupling operator/server image versions.
> The hash-annotation is the accepted alternative from the issue and matches how
> ENC/report Secrets already behave.

### #493 — docs/comments
The code comments and docs claimed policy changes synced in "without a pod
restart" via kubelet, which was never true for the subPath mount. Corrected the
comments in `config_rendering.go` / `config_autosign.go`, updated the
SigningPolicy reference and the config-rollout concept doc (new hash annotation +
rollout row), and fixed the ENC doc which made the same inaccurate claim.

### #490 / #491 — custom autosign / ENC commands (override only)
New `spec.puppet.autosignCommand` and `spec.puppet.externalNodesCommand` on
Config. When set, puppet.conf points `autosign` / `external_nodes` at the given
executable and the corresponding declarative flow is fully disabled: the policy /
ENC Secret is neither rendered nor mounted, and the hash annotation is dropped.
Unset, behaviour is unchanged. The native webhook policy type on
SigningPolicy/NodeClassifier remains a follow-up (needs more design).

### #489 — `spec.code` as a list (closes #476)
`spec.code` on Config and Server becomes a list of code sources, so a codedir can
be assembled from several volumes: per-environment control repos from different
OCI images, plus a global modules dir or hieradata (the #476 case). Each entry
sets one source (`image`/`claimName`) and an optional target (`environment` →
`<environmentpath>/<env>`, or `mountPath` → an absolute path under
`/etc/puppetlabs/code`).

Backwards compatible: 0 entries → emptyDir bootstrap; a single entry without a
target → the whole environments tree at `environmentpath` (as before). More than
one entry requires a unique `environment` or a `mountPath` per entry. Being on
`v1alpha1`, this is the cheap moment for the breaking object→array change.

The openvox-stack chart accepts `config.code` / `servers[].code` as either the
existing object (rendered as a one-element list, so `--set config.code.image` and
the CI values files keep working) or a full list.

## Validation

- `make test` green (controller, webhook, and the api envtest CEL suite).
- `golangci-lint` (v2.12.2) clean; `go vet` clean.
- `make check-manifests` clean (CRDs/deepcopy regenerated).
- `helm lint`, `helm unittest` (116 tests), helm-schema and helm-docs all clean.
- New coverage: autosign-policy hash annotation, both command overrides
  (rendered puppet.conf + skipped mounts/Secrets), code-list resolution and
  mounting, and the code CEL rules + environment-uniqueness webhook check.
