### PR TITLE
ci: disable OpenVox 9 builds until GA, republish unsuffixed server/db aliases

### DIFF
--- a/.github/workflows/_container-build.yaml
+++ b/.github/workflows/_container-build.yaml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      alias_image_name:
+        description: 'Optional unsuffixed alias image name (e.g. openvox-server) published from the same manifest as a backward-compat alias for the default major. Empty = no alias.'
+        required: false
+        type: string
+        default: ''
       build_args:
         description: 'Build-time arguments passed to docker build (one KEY=VALUE per line)'
         required: false
@@ -206,6 +211,17 @@ jobs:
             docker buildx imagetools create -t "${IMAGE}:latest" ${SOURCES}
           fi
 
+          # Publish the unsuffixed backward-compat alias for the default major, from the
+          # same per-arch sources, so it shares the primary manifest digest.
+          ALIAS="${{ inputs.alias_image_name }}"
+          if [[ -n "${ALIAS}" ]]; then
+            ALIAS_IMAGE="ghcr.io/${{ github.repository_owner }}/${ALIAS}"
+            docker buildx imagetools create -t "${ALIAS_IMAGE}:${VERSION}" ${SOURCES}
+            if [[ "${{ inputs.latest }}" == "true" ]]; then
+              docker buildx imagetools create -t "${ALIAS_IMAGE}:latest" ${SOURCES}
+            fi
+          fi
+
       - name: Get manifest digest
         id: digest
         run: |
@@ -219,11 +235,23 @@ jobs:
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}"
           cosign sign --yes "${IMAGE}@${{ steps.digest.outputs.digest }}"
+          ALIAS="${{ inputs.alias_image_name }}"
+          if [[ -n "${ALIAS}" ]]; then
+            cosign sign --yes "ghcr.io/${{ github.repository_owner }}/${ALIAS}@${{ steps.digest.outputs.digest }}"
+          fi
 
       - name: Attest manifest index
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest manifest index (unsuffixed alias)
+        if: inputs.alias_image_name != ''
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ inputs.alias_image_name }}
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,8 @@ jobs:
       attestations: write
     with:
       image_name: openvox-server-${{ matrix.major }}
+      # Publish the unsuffixed backward-compat alias only for the default major.
+      alias_image_name: ${{ matrix.latest && 'openvox-server' || '' }}
       allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
@@ -98,6 +100,8 @@ jobs:
       attestations: write
     with:
       image_name: openvox-db-${{ matrix.major }}
+      # Publish the unsuffixed backward-compat alias only for the default major.
+      alias_image_name: ${{ matrix.latest && 'openvox-db' || '' }}
       allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,6 +89,8 @@ jobs:
       attestations: write
     with:
       image_name: openvox-server-${{ matrix.major }}
+      # Publish the unsuffixed backward-compat alias only for the default major.
+      alias_image_name: ${{ matrix.latest && 'openvox-server' || '' }}
       allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-server/Containerfile
       context: '.'
@@ -114,6 +116,8 @@ jobs:
       attestations: write
     with:
       image_name: openvox-db-${{ matrix.major }}
+      # Publish the unsuffixed backward-compat alias only for the default major.
+      alias_image_name: ${{ matrix.latest && 'openvox-db' || '' }}
       allow_failure: ${{ matrix.major != '8' }}
       dockerfile: images/openvox-db/Containerfile
       context: '.'

--- a/README.md
+++ b/README.md
@@ -202,32 +202,17 @@ helm install production \
   --set database.postgres.credentialsSecretRef=pg-cluster-app
 ```
 
-## OpenVox 8 and 9
+## Content images
 
-The content images are published per OpenVox major: the image **name** encodes the
-major, the **tag** stays the operator release version. For backward compatibility the
-default major is also published under the **unsuffixed** name.
-
-| Image | Unsuffixed alias | OpenVox 8 (default) | OpenVox 9 |
-|---|---|---|---|
-| Server | `ghcr.io/slauger/openvox-server` | `ghcr.io/slauger/openvox-server-8` | `ghcr.io/slauger/openvox-server-9` |
-| DB | `ghcr.io/slauger/openvox-db` | `ghcr.io/slauger/openvox-db-8` | `ghcr.io/slauger/openvox-db-9` |
-
-`openvox-server` / `openvox-db` (unsuffixed) are aliases of the current default major
-(`-8`) -- the same image digest under a compatibility name -- so existing pins keep
-working. Use the `-8` / `-9` suffix to pin a major explicitly.
+The OpenVox Server and DB content images are published under their plain names,
+`ghcr.io/slauger/openvox-server` and `ghcr.io/slauger/openvox-db`. A major-suffixed variant
+(`openvox-server-8` / `openvox-db-8`) is also published for pinning a specific OpenVox major;
+the unsuffixed name tracks the current default major and shares its image digest.
 
 The exact OpenVox versions baked into each image are pinned in
 [`images/openvox-versions.yaml`](images/openvox-versions.yaml) (kept current by Renovate),
 and every operator release lists the shipped component versions in its GitHub release notes.
-
-The operator defaults to OpenVox 8 everywhere (chart values, CRD defaults, samples) and
-only the default (`-8` / unsuffixed) images are tagged `:latest`.
-
-> **OpenVox 9 builds are paused until 9.0 GA.** The operator already supports OpenVox 9
-> (point `spec.image.repository` at an `openvox-server-9` image), but the `-9` images are
-> **not currently published**: the 9.0 betas ship inconsistent build artifacts (no release
-> tarball, per-artifact version-string quirks). Building resumes at 9.0 GA.
+The operator uses these images everywhere by default (chart values, CRD defaults, samples).
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -205,32 +205,29 @@ helm install production \
 ## OpenVox 8 and 9
 
 The content images are published per OpenVox major: the image **name** encodes the
-major, the **tag** stays the operator release version.
+major, the **tag** stays the operator release version. For backward compatibility the
+default major is also published under the **unsuffixed** name.
 
-| Image | OpenVox 8 (default) | OpenVox 9 (beta) |
-|---|---|---|
-| Server | `ghcr.io/slauger/openvox-server-8` | `ghcr.io/slauger/openvox-server-9` |
-| DB | `ghcr.io/slauger/openvox-db-8` | `ghcr.io/slauger/openvox-db-9` |
+| Image | Unsuffixed alias | OpenVox 8 (default) | OpenVox 9 |
+|---|---|---|---|
+| Server | `ghcr.io/slauger/openvox-server` | `ghcr.io/slauger/openvox-server-8` | `ghcr.io/slauger/openvox-server-9` |
+| DB | `ghcr.io/slauger/openvox-db` | `ghcr.io/slauger/openvox-db-8` | `ghcr.io/slauger/openvox-db-9` |
+
+`openvox-server` / `openvox-db` (unsuffixed) are aliases of the current default major
+(`-8`) -- the same image digest under a compatibility name -- so existing pins keep
+working. Use the `-8` / `-9` suffix to pin a major explicitly.
 
 The exact OpenVox versions baked into each image are pinned in
 [`images/openvox-versions.yaml`](images/openvox-versions.yaml) (kept current by Renovate),
 and every operator release lists the shipped component versions in its GitHub release notes.
 
 The operator defaults to OpenVox 8 everywhere (chart values, CRD defaults, samples) and
-only the `-8` images are tagged `:latest`. To opt a Config into OpenVox 9, set the image
-repository explicitly:
+only the default (`-8` / unsuffixed) images are tagged `:latest`.
 
-```yaml
-spec:
-  image:
-    repository: ghcr.io/slauger/openvox-server-8   # or -9 for OpenVox 9 (beta)
-```
-
-> **OpenVox 9 is a pre-release** (Jetty 12, JRuby 10, Java 17 dropped). The `-9` images
-> track 9.x betas, are never tagged `:latest`, and are not recommended for production yet.
-
-> **Migration:** the previously published unsuffixed images (`openvox-server`,
-> `openvox-db`) are no longer built. Update any hand-pinned references to the `-8` variants.
+> **OpenVox 9 builds are paused until 9.0 GA.** The operator already supports OpenVox 9
+> (point `spec.image.repository` at an `openvox-server-9` image), but the `-9` images are
+> **not currently published**: the 9.0 betas ship inconsistent build artifacts (no release
+> tarball, per-artifact version-string quirks). Building resumes at 9.0 GA.
 
 ## Local Development
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,16 +23,13 @@ spec:
       - "https://openvoxdb.example.com:8081"
 ```
 
-!!! note "Choosing an OpenVox major (8 or 9)"
-    The content images are published per OpenVox major - the image name encodes the
-    major (`openvox-server-8` / `openvox-server-9`), the tag stays the operator release
-    version. The default is `openvox-server-8`, also published under the unsuffixed
-    `openvox-server` / `openvox-db` alias (same digest) for backward compatibility.
-    OpenVox 9 builds are **paused until 9.0 GA**: the operator supports pointing
-    `spec.image.repository` at an `openvox-server-9` image, but the `-9` images are not
-    currently published (the 9.0 betas ship inconsistent build artifacts). The exact
-    OpenVox versions baked into each image are pinned in `images/openvox-versions.yaml`,
-    and every operator release lists the shipped component versions in its GitHub release notes.
+!!! note "Image naming"
+    The content images are published as `openvox-server` / `openvox-db` (the current default
+    major), with a major-suffixed variant (`openvox-server-8`) available to pin a specific
+    OpenVox major - the unsuffixed name and the default-major suffix share the same image
+    digest. The exact OpenVox versions baked into each image are pinned in
+    `images/openvox-versions.yaml`, and every operator release lists the shipped component
+    versions in its GitHub release notes.
 
 ## Spec
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -26,13 +26,13 @@ spec:
 !!! note "Choosing an OpenVox major (8 or 9)"
     The content images are published per OpenVox major - the image name encodes the
     major (`openvox-server-8` / `openvox-server-9`), the tag stays the operator release
-    version. The default is `openvox-server-8`. To opt a Config into OpenVox 9, set
-    `spec.image.repository: ghcr.io/slauger/openvox-server-9`. OpenVox 9 is a pre-release
-    (Jetty 12, JRuby 10, Java 17 dropped), never tagged `:latest`, and not recommended
-    for production yet. The previously published unsuffixed images (`openvox-server`,
-    `openvox-db`) are no longer built. The exact OpenVox versions baked into each image
-    are pinned in `images/openvox-versions.yaml`, and every operator release lists the
-    shipped component versions in its GitHub release notes.
+    version. The default is `openvox-server-8`, also published under the unsuffixed
+    `openvox-server` / `openvox-db` alias (same digest) for backward compatibility.
+    OpenVox 9 builds are **paused until 9.0 GA**: the operator supports pointing
+    `spec.image.repository` at an `openvox-server-9` image, but the `-9` images are not
+    currently published (the 9.0 betas ship inconsistent build artifacts). The exact
+    OpenVox versions baked into each image are pinned in `images/openvox-versions.yaml`,
+    and every operator release lists the shipped component versions in its GitHub release notes.
 
 ## Spec
 

--- a/images/openvox-versions.yaml
+++ b/images/openvox-versions.yaml
@@ -13,7 +13,7 @@
 # release tarball, but 9.0.0 betas publish only RPMs/DEBs (no tarball), and the version
 # strings differ per artifact (RPM/repo use ~beta, the openvox gem uses .pre.beta, the
 # GitHub tag uses -beta). Re-enable at GA by uncommenting the entry below and updating
-# the server/db install path -- see the tracking issue.
+# the server/db install path -- see #503.
 include:
   - major: "8"
     latest: true

--- a/images/openvox-versions.yaml
+++ b/images/openvox-versions.yaml
@@ -5,10 +5,15 @@
 # this file (yq -o=json '.include') to build the per-major matrix and pass the
 # versions as build-args to the Containerfiles.
 #
-# Renovate keeps the pins current: the "8" entry tracks the stable 8.x line, the
-# "9" entry tracks 9.x pre-releases. The two majors bump independently in separate
-# grouped PRs (see renovate.json). Major 8 is the default and the only one tagged
-# :latest; major 9 is built and pushed but never :latest and never the default.
+# Renovate keeps the pins current: the "8" entry tracks the stable 8.x line. Major 8
+# is the default and the only one tagged :latest.
+#
+# Major 9 is TEMPORARILY DISABLED (commented out below) until OpenVox 9.0 GA. The 9.x
+# pre-releases cannot be built reproducibly today: the server/db images install from a
+# release tarball, but 9.0.0 betas publish only RPMs/DEBs (no tarball), and the version
+# strings differ per artifact (RPM/repo use ~beta, the openvox gem uses .pre.beta, the
+# GitHub tag uses -beta). Re-enable at GA by uncommenting the entry below and updating
+# the server/db install path -- see the tracking issue.
 include:
   - major: "8"
     latest: true
@@ -22,15 +27,16 @@ include:
     db: 8.15.0
     # renovate: datasource=github-releases depName=OpenVoxProject/openvox
     agent: 8.28.1
-  - major: "9"
-    latest: false
-    # renovate: datasource=github-releases depName=OpenVoxProject/openvox-server
-    server: 9.0.0-beta2
-    # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
-    termini: 9.0.0-beta1
-    # renovate: datasource=github-releases depName=OpenVoxProject/openvox
-    openvox: 9.0.0-beta1
-    # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
-    db: 9.0.0-beta1
-    # renovate: datasource=github-releases depName=OpenVoxProject/openvox
-    agent: 9.0.0-beta1
+  # Re-enable at OpenVox 9.0 GA (also fix server/db to install from RPM, not tarball):
+  # - major: "9"
+  #   latest: false
+  #   # renovate: datasource=github-releases depName=OpenVoxProject/openvox-server
+  #   server: 9.0.0-beta2
+  #   # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
+  #   termini: 9.0.0-beta1
+  #   # renovate: datasource=github-releases depName=OpenVoxProject/openvox
+  #   openvox: 9.0.0-beta1
+  #   # renovate: datasource=github-releases depName=OpenVoxProject/openvoxdb
+  #   db: 9.0.0-beta1
+  #   # renovate: datasource=github-releases depName=OpenVoxProject/openvox
+  #   agent: 9.0.0-beta1

--- a/images/openvox-versions.yaml
+++ b/images/openvox-versions.yaml
@@ -8,12 +8,8 @@
 # Renovate keeps the pins current: the "8" entry tracks the stable 8.x line. Major 8
 # is the default and the only one tagged :latest.
 #
-# Major 9 is TEMPORARILY DISABLED (commented out below) until OpenVox 9.0 GA. The 9.x
-# pre-releases cannot be built reproducibly today: the server/db images install from a
-# release tarball, but 9.0.0 betas publish only RPMs/DEBs (no tarball), and the version
-# strings differ per artifact (RPM/repo use ~beta, the openvox gem uses .pre.beta, the
-# GitHub tag uses -beta). Re-enable at GA by uncommenting the entry below and updating
-# the server/db install path -- see #503.
+# Major 9 is disabled (commented out below) until OpenVox 9.0 GA -- the 9.x pre-release
+# artifacts can't be built reproducibly yet. Re-enable by uncommenting the entry; see #503.
 include:
   - major: "8"
     latest: true


### PR DESCRIPTION
## Why

Since #487 merged, every CI run also builds the `openvox-*-9` content images, and those jobs
fail — cascading into the `-9` manifest jobs (`...openvox-agent-9:develop-linux-arm64: not found`).

The root cause is **not** a CI-logic bug. OpenVox 9 is a pre-release and its upstream artifacts
are inconsistent (verified against the yum repo + `artifacts.voxpupuli.org`):

- **agent**: published only as RPM `openvox-agent-9.0.0~beta1` (RPM tilde form). The `-beta1`
  form (GitHub tag / Renovate value) is a 404; `~beta2` does not exist.
- **server/db**: the Containerfiles install by extracting a `.tar.gz`, but the `9.0.0~beta1/`
  dirs contain **only RPMs/DEBs — no tarball**. So 9 can't build without switching to RPM install.
- **openvox gem**: `9.0.0.pre.beta1` — a third version-string convention.
- The pins were also internally inconsistent (server `beta2`, agent/db `beta1`).

Building 9 now would mean reworking the server/db Containerfiles + three per-artifact version
normalisations for a moving beta target. So: **build only major 8 until OpenVox 9.0 GA.**

Separately, #487's rename stopped publishing the old **unsuffixed** images
(`openvox-server` / `openvox-db`), which breaks consumers that pinned them. This PR brings them
back as backward-compat aliases of the default major.

## What

**1. Disable OpenVox 9** (`ci: disable OpenVox 9 image builds until 9.0 GA`)
- Comment out the `major: "9"` entry in `images/openvox-versions.yaml`. Workflows derive the
  matrix from `.include`, so only major 8 builds — **no workflow changes needed** for the disable.
- The commented `# renovate:` lines no longer match the custom manager, so Renovate stops
  opening 9-bump PRs. Re-enabling is uncommenting the entry (see the tracking issue).

**2. Unsuffixed aliases** (`ci: publish unsuffixed openvox-server/openvox-db aliases`)
- Add an optional `alias_image_name` input to `_container-build.yaml`. When set, the manifest
  job creates the alias tags from the **same per-arch sources** (so the alias shares the primary
  manifest digest) and cosign-signs + attests the alias name.
- `ci.yaml` (develop) and `release.yaml` (version + `:latest`) pass `alias_image_name` for
  **server and db**, gated on `matrix.latest` so only the default major (8) produces it.
- Agent stays `-8`-only; chart/CRD/Makefile/e2e defaults stay `-8` (aliases are compat-only).

**3. Docs** (`docs: ...`) — README image table + Config reference note updated: 9 builds paused
until GA (operator still supports `-9`), and `openvox-server`/`openvox-db` are aliases of `-8`.

## Verification

- `yq -o=json -I=0 '{"include": .include}' images/openvox-versions.yaml` → matrix with **only**
  major 8.
- Workflows parse (`yq`), no actionlint/shellcheck regressions (the unquoted `${SOURCES}` is the
  pre-existing intentional word-split pattern; CI shellcheck scans `.sh` files only).
- After merge/develop push: only `openvox-*-8` build/manifest jobs run (no `-9` failures), and
  `docker buildx imagetools inspect ghcr.io/slauger/openvox-server:develop` shares the digest of
  `openvox-server-8:develop` (same for `-db`).
- Release path (`:latest` alias) is fully verifiable only on an actual release.

Follow-up: re-enable OpenVox 9 at 9.0 GA (tracked separately).
