### PR TITLE
test(e2e): cover code list, puppet command overrides, and autosign rollout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,8 @@ e2e-group-base: e2e-operator-base chainsaw ## Group: base tests (stack, agent, d
 		tests/e2e/autosign-policy \
 		tests/e2e/cert-rotation \
 		tests/e2e/server-extra-env-volumes \
-		tests/e2e/server-fsgroup; \
+		tests/e2e/server-fsgroup \
+		tests/e2e/puppet-command-overrides; \
 	EXIT=$$?; $(MAKE) e2e-cleanup; exit $$EXIT
 
 .PHONY: e2e-group-enc

--- a/charts/openvox-stack/ci/code-pvc-values.yaml
+++ b/charts/openvox-stack/ci/code-pvc-values.yaml
@@ -2,9 +2,8 @@ signingPolicies:
   - name: autosign-any
     any: true
 
-config:
-  code:
-    claimName: puppet-code
+# config.code is set as a list via --set-json in the chainsaw test (a PVC "production"
+# environment plus an image mountPath), so it is intentionally not defined here.
 
 servers:
   - name: ca

--- a/charts/openvox-stack/ci/puppet-command-overrides-values.yaml
+++ b/charts/openvox-stack/ci/puppet-command-overrides-values.yaml
@@ -1,0 +1,50 @@
+# A SigningPolicy and a NodeClassifier are configured on purpose: the puppet.*Command
+# overrides must disable both built-in flows (no policy/ENC Secret rendered or mounted)
+# and point puppet.conf at the custom executables instead.
+signingPolicies:
+  - name: any
+    any: true
+
+nodeClassifier:
+  enabled: true
+  url: https://enc.example.invalid
+
+config:
+  puppet:
+    autosignCommand: /etc/puppetlabs/overrides/sign.sh
+    externalNodesCommand: /etc/puppetlabs/overrides/classify.sh
+
+servers:
+  - name: ca
+    ca: true
+    server: true
+    poolRefs: [ca, server]
+    certificate:
+      certname: puppet
+    replicas: 1
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+    # Mount the custom executables the override commands point at.
+    extraVolumes:
+      - name: puppet-overrides
+        configMap:
+          name: puppet-overrides
+          defaultMode: 0755
+    extraVolumeMounts:
+      - name: puppet-overrides
+        mountPath: /etc/puppetlabs/overrides
+        readOnly: true
+
+pools:
+  - name: ca
+    service:
+      type: ClusterIP
+      port: 8140
+  - name: server
+    service:
+      type: ClusterIP
+      port: 8140

--- a/tests/e2e/autosign-policy/chainsaw-test.yaml
+++ b/tests/e2e/autosign-policy/chainsaw-test.yaml
@@ -123,6 +123,36 @@ spec:
             content: |
               kubectl wait --for=jsonpath='{.status.failed}'=1 job/puppet-agent-nomatch \
                 -n e2e-autosign-policy --timeout=120s
+
+    - name: Change the SigningPolicy and assert the CA pod rolls
+      try:
+        - script:
+            timeout: 8m
+            content: |
+              set -eu
+              NS=e2e-autosign-policy
+              DEPLOY=e2e-autosign-policy-ca
+              HASH='{.spec.template.metadata.annotations.openvox\.voxpupuli\.org/autosign-policy-secret-hash}'
+              BEFORE=$(kubectl get deploy "${DEPLOY}" -n "${NS}" -o jsonpath="${HASH}")
+              echo "before=${BEFORE}"
+              [ -n "${BEFORE}" ] || { echo "ERROR: CA deployment has no autosign-policy-secret-hash annotation"; exit 1; }
+
+              # A SigningPolicy change must re-render the policy Secret and roll the CA pod,
+              # so the new policy applies without a manual restart.
+              kubectl patch signingpolicies.openvox.voxpupuli.org preshared-key -n "${NS}" --type=merge \
+                -p '{"spec":{"csrAttributes":[{"name":"pp_preshared_key","value":"e2e-rotated-key"}]}}'
+
+              AFTER="${BEFORE}"
+              for _ in $(seq 1 30); do
+                AFTER=$(kubectl get deploy "${DEPLOY}" -n "${NS}" -o jsonpath="${HASH}")
+                [ -n "${AFTER}" ] && [ "${AFTER}" != "${BEFORE}" ] && break
+                sleep 5
+              done
+              echo "after=${AFTER}"
+              [ "${AFTER}" != "${BEFORE}" ] || { echo "ERROR: autosign-policy-secret-hash did not change after the SigningPolicy update"; exit 1; }
+
+              kubectl rollout status deploy/"${DEPLOY}" -n "${NS}" --timeout=300s
+              echo "OK: SigningPolicy change rolled the CA pod without a manual restart"
       finally:
         - script:
             timeout: 2m

--- a/tests/e2e/code-pvc/chainsaw-test.yaml
+++ b/tests/e2e/code-pvc/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
     - name: major
       value: (env('OPENVOX_MAJOR') || '8')
   steps:
-    - name: Create PVC and populate with Puppet code
+    - name: Create PVC and populate with a Puppet environment
       try:
         - apply:
             resource:
@@ -44,13 +44,16 @@ spec:
                         command: ["sh", "-c"]
                         args:
                           - |
-                            mkdir -p /code/production/manifests
-                            cat > /code/production/manifests/site.pp << 'SITEPP'
+                            # The PVC holds a single environment's content (mounted as the
+                            # "production" environment via code[].environment), so the tree
+                            # is rooted at the environment, not at environments/.
+                            mkdir -p /code/manifests
+                            cat > /code/manifests/site.pp << 'SITEPP'
                             node default {
                               notify { 'code-pvc-test': message => 'Hello from PVC code' }
                             }
                             SITEPP
-                            cat > /code/production/environment.conf << 'ENVCONF'
+                            cat > /code/environment.conf << 'ENVCONF'
                             modulepath = modules:$basemodulepath
                             manifest = manifests/site.pp
                             ENVCONF
@@ -69,7 +72,7 @@ spec:
               kubectl wait --for=condition=Complete job/init-code \
                 -n e2e-code-pvc --timeout=120s
 
-    - name: Install openvox-stack with PVC code
+    - name: Install openvox-stack with a code list (PVC environment + image mountPath)
       try:
         - script:
             timeout: 2m
@@ -77,12 +80,17 @@ spec:
               REPO_ROOT=$(git rev-parse --show-toplevel)
               IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
               IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              CODE_IMAGE="${IMAGE_REGISTRY}/openvox-e2e-code:${IMAGE_TAG}"
+              # config.code as a list: the PVC as the "production" environment plus the
+              # e2e-code image mounted at a codedir path (hieradata) to exercise both
+              # the environment and mountPath targets and multiple code volumes.
               helm upgrade --install e2e-code-pvc "${REPO_ROOT}/charts/openvox-stack" \
                 --namespace e2e-code-pvc --create-namespace \
                 --values "${REPO_ROOT}/charts/openvox-stack/ci/code-pvc-values.yaml" \
                 --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
                 --set config.image.tag="${IMAGE_TAG}" \
-                --set config.image.pullPolicy=Always
+                --set config.image.pullPolicy=Always \
+                --set-json "config.code=[{\"claimName\":\"puppet-code\",\"environment\":\"production\"},{\"image\":\"${CODE_IMAGE}\",\"imagePullPolicy\":\"Always\",\"mountPath\":\"/etc/puppetlabs/code/hieradata\"}]"
       catch:
         - events: {}
 
@@ -99,7 +107,29 @@ spec:
                 ready: 1
                 desired: 1
 
-    - name: Run Puppet agent
+    - name: Verify both code volumes are mounted at their targets
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              set -eu
+              NS=e2e-code-pvc
+              POD=$(kubectl get pods -n "${NS}" \
+                -l openvox.voxpupuli.org/server=e2e-code-pvc-ca \
+                -o jsonpath='{.items[0].metadata.name}')
+              echo "pod=${POD}"
+              fail() { echo "ERROR: $1"; kubectl get pod "${POD}" -n "${NS}" -o yaml; exit 1; }
+
+              MOUNTS=$(kubectl get pod "${POD}" -n "${NS}" \
+                -o jsonpath='{.spec.containers[?(@.name=="openvox-server")].volumeMounts[*].mountPath}')
+              echo "mounts=${MOUNTS}"
+              echo "${MOUNTS}" | tr ' ' '\n' | grep -qx '/etc/puppetlabs/code/environments/production' \
+                || fail "environment code mount missing"
+              echo "${MOUNTS}" | tr ' ' '\n' | grep -qx '/etc/puppetlabs/code/hieradata' \
+                || fail "mountPath code mount missing"
+              echo "OK: code list mounted both the environment and the mountPath entry"
+
+    - name: Run Puppet agent against the PVC environment
       try:
         - apply:
             resource:

--- a/tests/e2e/puppet-command-overrides/chainsaw-test.yaml
+++ b/tests/e2e/puppet-command-overrides/chainsaw-test.yaml
@@ -1,0 +1,112 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: puppet-command-overrides
+spec:
+  namespace: e2e-puppet-overrides
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+  steps:
+    - name: Create namespace and the custom autosign/ENC executables
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: e2e-puppet-overrides
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: puppet-overrides
+                namespace: e2e-puppet-overrides
+              data:
+                sign.sh: |
+                  #!/bin/sh
+                  exit 0
+                classify.sh: |
+                  #!/bin/sh
+                  exit 0
+
+    - name: Install openvox-stack with autosign/externalNodes command overrides
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              REPO_ROOT=$(git rev-parse --show-toplevel)
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              helm upgrade --install e2e-puppet-overrides "${REPO_ROOT}/charts/openvox-stack" \
+                --namespace e2e-puppet-overrides --create-namespace \
+                --values "${REPO_ROOT}/charts/openvox-stack/ci/puppet-command-overrides-values.yaml" \
+                --set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8} \
+                --set config.image.tag="${IMAGE_TAG}" \
+                --set config.image.pullPolicy=Always
+      catch:
+        - events: {}
+
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: e2e-puppet-overrides-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Verify overrides win and the built-in flows are disabled
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              set -eu
+              NS=e2e-puppet-overrides
+              fail() { echo "ERROR: $1"; exit 1; }
+
+              # puppet.conf points at the custom commands, not the built-in binaries.
+              CONF=$(kubectl get configmap e2e-puppet-overrides-config -n "${NS}" \
+                -o jsonpath='{.data.puppet\.conf}')
+              echo "${CONF}" | grep -qF 'autosign = /etc/puppetlabs/overrides/sign.sh' \
+                || fail "puppet.conf missing custom autosign command"
+              echo "${CONF}" | grep -qF 'external_nodes = /etc/puppetlabs/overrides/classify.sh' \
+                || fail "puppet.conf missing custom external_nodes command"
+              echo "${CONF}" | grep -qF 'node_terminus = exec' \
+                || fail "puppet.conf missing node_terminus = exec"
+              echo "${CONF}" | grep -qF '/usr/local/bin/openvox-autosign' \
+                && fail "puppet.conf still uses the built-in autosign binary"
+              echo "${CONF}" | grep -qF '/usr/local/bin/openvox-enc' \
+                && fail "puppet.conf still uses the built-in ENC binary"
+
+              # The built-in policy/ENC Secrets are not rendered.
+              kubectl get secret e2e-puppet-overrides-ca-autosign-policy -n "${NS}" >/dev/null 2>&1 \
+                && fail "autosign policy Secret should not exist when autosignCommand is set"
+              kubectl get secret e2e-puppet-overrides-enc -n "${NS}" >/dev/null 2>&1 \
+                && fail "ENC Secret should not exist when externalNodesCommand is set"
+
+              # And they are not mounted into the pod.
+              POD=$(kubectl get pods -n "${NS}" \
+                -l openvox.voxpupuli.org/server=e2e-puppet-overrides-ca \
+                -o jsonpath='{.items[0].metadata.name}')
+              VOLS=$(kubectl get pod "${POD}" -n "${NS}" -o jsonpath='{.spec.volumes[*].name}')
+              echo "volumes=${VOLS}"
+              echo "${VOLS}" | tr ' ' '\n' | grep -qx 'autosign-policy' \
+                && fail "autosign-policy volume should not be mounted"
+              echo "${VOLS}" | tr ' ' '\n' | grep -qx 'enc-config' \
+                && fail "enc-config volume should not be mounted"
+
+              echo "OK: command overrides applied and built-in autosign/ENC flows disabled"
+      finally:
+        - script:
+            timeout: 2m
+            content: |
+              helm uninstall e2e-puppet-overrides --namespace e2e-puppet-overrides --wait 2>/dev/null || true
+              kubectl delete namespace e2e-puppet-overrides --ignore-not-found 2>/dev/null || true


### PR DESCRIPTION
Adds e2e coverage for the #498 features that so far only had unit/envtest tests:

- **code list** (folded into `code-pvc`): drives `config.code` as a list (a PVC
  `production` environment plus an image `mountPath`) and asserts both code volumes
  are mounted at their targets.
- **`autosignCommand` + `externalNodesCommand`** (new `puppet-command-overrides`):
  with a SigningPolicy and NodeClassifier also configured, asserts puppet.conf points
  at the custom commands and the built-in policy/ENC Secrets are neither rendered nor
  mounted.
- **autosign policy rollout** (extra step in `autosign-policy`): changes the
  SigningPolicy and asserts the CA pod rolls via the `autosign-policy-secret-hash`
  annotation, so the change applies without a manual restart.

No operator code changes; test files only. The new test is registered in the base
e2e group.
