### PR TITLE
Experiment: native (no-JVM) openvox-server on CRuby

### DIFF
--- a/cmd/edge/authz.go
+++ b/cmd/edge/authz.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Ruleset is the config-driven equivalent of puppetserver's auth.conf. It mirrors
+// the operator's builtinAuthRules HOCON model (match-request + allow/deny), so the
+// same authorization intent can be rendered to JSON for the native edge instead of
+// to trapperkeeper-authorization HOCON for the JVM server.
+type Ruleset struct {
+	// Rules are evaluated in order; the first whose path+method matches decides.
+	Rules []Rule `json:"rules"`
+	// Default applies when no rule matches: "deny" (the safe default) or "allow".
+	Default string `json:"default"`
+}
+
+// Rule is one auth.conf entry. Exactly one of Allow/Deny/AllowUnauthenticated is
+// typically set, matching the HOCON rules the operator already emits.
+type Rule struct {
+	Name                 string          `json:"name"`
+	Path                 string          `json:"path"`
+	Type                 string          `json:"type"`   // "path" (prefix) or "regex"
+	Method               []string        `json:"method"` // empty = any method
+	Allow                json.RawMessage `json:"allow"`
+	Deny                 json.RawMessage `json:"deny"`
+	AllowUnauthenticated bool            `json:"allow_unauthenticated"`
+
+	re    *regexp.Regexp
+	allow []matcher
+	deny  []matcher
+}
+
+// matcher is one entry of an allow/deny list: "*", the "$1" capture, a literal
+// certname, or a set of required certificate extensions (e.g. pp_cli_auth: "true").
+type matcher struct {
+	star       bool
+	capture    bool
+	certname   string
+	extensions map[string]string
+}
+
+// Identity is the verified client presented by the TLS layer.
+type Identity struct {
+	Authenticated bool
+	CN            string
+	Extensions    map[string]string // by short name (pp_cli_auth) and by raw OID
+}
+
+// Decision is the outcome of authorizing a request.
+type Decision struct {
+	Allowed bool
+	Status  int
+	Reason  string
+}
+
+func parseRuleset(data []byte) (*Ruleset, error) {
+	var rs Ruleset
+	if err := json.Unmarshal(data, &rs); err != nil {
+		return nil, err
+	}
+	if rs.Default == "" {
+		rs.Default = "deny"
+	}
+	if rs.Default != "deny" && rs.Default != "allow" {
+		return nil, fmt.Errorf("default must be \"deny\" or \"allow\", got %q", rs.Default)
+	}
+	for i := range rs.Rules {
+		r := &rs.Rules[i]
+		switch r.Type {
+		case "regex":
+			re, err := regexp.Compile(r.Path)
+			if err != nil {
+				return nil, fmt.Errorf("rule %q: bad regex %q: %w", r.Name, r.Path, err)
+			}
+			r.re = re
+		case "path", "":
+			r.Type = "path"
+		default:
+			return nil, fmt.Errorf("rule %q: unknown type %q", r.Name, r.Type)
+		}
+		var err error
+		if r.allow, err = parseMatchers(r.Allow); err != nil {
+			return nil, fmt.Errorf("rule %q: allow: %w", r.Name, err)
+		}
+		if r.deny, err = parseMatchers(r.Deny); err != nil {
+			return nil, fmt.Errorf("rule %q: deny: %w", r.Name, err)
+		}
+	}
+	return &rs, nil
+}
+
+// parseMatchers accepts a bare string ("*", "$1", "<certname>"), a single
+// {extensions:{...}} object, or a JSON array mixing the two.
+func parseMatchers(raw json.RawMessage) ([]matcher, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		// Not an array: treat as a single entry.
+		arr = []json.RawMessage{raw}
+	}
+	out := make([]matcher, 0, len(arr))
+	for _, item := range arr {
+		var s string
+		if err := json.Unmarshal(item, &s); err == nil {
+			switch s {
+			case "*":
+				out = append(out, matcher{star: true})
+			case "$1":
+				out = append(out, matcher{capture: true})
+			default:
+				out = append(out, matcher{certname: s})
+			}
+			continue
+		}
+		var obj struct {
+			Extensions map[string]string `json:"extensions"`
+		}
+		if err := json.Unmarshal(item, &obj); err != nil {
+			return nil, fmt.Errorf("entry %s: not a string or {extensions}: %w", item, err)
+		}
+		if len(obj.Extensions) == 0 {
+			return nil, fmt.Errorf("entry %s: empty extensions", item)
+		}
+		out = append(out, matcher{extensions: obj.Extensions})
+	}
+	return out, nil
+}
+
+// Authorize evaluates the ruleset against a request. The first rule whose path and
+// method match decides; deny takes precedence over allow within that rule.
+func (rs *Ruleset) Authorize(method, path string, id Identity) Decision {
+	for i := range rs.Rules {
+		r := &rs.Rules[i]
+		capture, ok := r.matchPath(path)
+		if !ok || !r.matchMethod(method) {
+			continue
+		}
+		if r.AllowUnauthenticated {
+			return Decision{Allowed: true, Status: http.StatusOK, Reason: r.Name}
+		}
+		if !id.Authenticated {
+			return Decision{Status: http.StatusUnauthorized, Reason: r.Name + ": no verified client certificate"}
+		}
+		if anyMatch(r.deny, id, capture) {
+			return Decision{Status: http.StatusForbidden, Reason: r.Name + ": denied"}
+		}
+		if r.allow != nil {
+			if anyMatch(r.allow, id, capture) {
+				return Decision{Allowed: true, Status: http.StatusOK, Reason: r.Name}
+			}
+			return Decision{Status: http.StatusForbidden, Reason: r.Name + ": not in allow list"}
+		}
+		// Only a deny list (that did not match) -> allowed.
+		return Decision{Allowed: true, Status: http.StatusOK, Reason: r.Name}
+	}
+	if rs.Default == "allow" {
+		return Decision{Allowed: true, Status: http.StatusOK, Reason: "default allow"}
+	}
+	return Decision{Status: http.StatusForbidden, Reason: "no matching rule (default deny)"}
+}
+
+// matchPath reports whether path matches the rule and returns the first regex
+// capture group (empty for path-type rules), used to evaluate the "$1" matcher.
+func (r *Rule) matchPath(path string) (capture string, ok bool) {
+	if r.Type == "regex" {
+		m := r.re.FindStringSubmatch(path)
+		if m == nil {
+			return "", false
+		}
+		if len(m) > 1 {
+			return m[1], true
+		}
+		return "", true
+	}
+	return "", strings.HasPrefix(path, r.Path)
+}
+
+func (r *Rule) matchMethod(method string) bool {
+	if len(r.Method) == 0 {
+		return true
+	}
+	for _, m := range r.Method {
+		if strings.EqualFold(m, method) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyMatch(ms []matcher, id Identity, capture string) bool {
+	for _, m := range ms {
+		if m.match(id, capture) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m matcher) match(id Identity, capture string) bool {
+	switch {
+	case m.star:
+		return true
+	case m.capture:
+		return capture != "" && id.CN == capture
+	case m.certname != "":
+		return id.CN == m.certname
+	case m.extensions != nil:
+		for name, want := range m.extensions {
+			if id.Extensions[name] != want {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// puppetOIDNames maps Puppet's registered certificate-extension OIDs to their short
+// names so rules can reference e.g. "pp_cli_auth" instead of the raw arc. Mirrors
+// puppet/ssl/oids.rb (ppRegCertExt 1.3.6.1.4.1.34380.1.1 and ppAuthCertExt .1.3).
+var puppetOIDNames = map[string]string{
+	"1.3.6.1.4.1.34380.1.1.1":  "pp_uuid",
+	"1.3.6.1.4.1.34380.1.1.2":  "pp_instance_id",
+	"1.3.6.1.4.1.34380.1.1.3":  "pp_image_name",
+	"1.3.6.1.4.1.34380.1.1.4":  "pp_preshared_key",
+	"1.3.6.1.4.1.34380.1.1.5":  "pp_cost_center",
+	"1.3.6.1.4.1.34380.1.1.6":  "pp_product",
+	"1.3.6.1.4.1.34380.1.1.7":  "pp_project",
+	"1.3.6.1.4.1.34380.1.1.8":  "pp_application",
+	"1.3.6.1.4.1.34380.1.1.9":  "pp_service",
+	"1.3.6.1.4.1.34380.1.1.10": "pp_employee",
+	"1.3.6.1.4.1.34380.1.1.11": "pp_created_by",
+	"1.3.6.1.4.1.34380.1.1.12": "pp_environment",
+	"1.3.6.1.4.1.34380.1.1.13": "pp_role",
+	"1.3.6.1.4.1.34380.1.1.14": "pp_software_version",
+	"1.3.6.1.4.1.34380.1.1.15": "pp_department",
+	"1.3.6.1.4.1.34380.1.1.16": "pp_cluster",
+	"1.3.6.1.4.1.34380.1.1.17": "pp_provisioner",
+	"1.3.6.1.4.1.34380.1.1.18": "pp_region",
+	"1.3.6.1.4.1.34380.1.1.19": "pp_datacenter",
+	"1.3.6.1.4.1.34380.1.1.20": "pp_zone",
+	"1.3.6.1.4.1.34380.1.1.21": "pp_network",
+	"1.3.6.1.4.1.34380.1.1.22": "pp_securitypolicy",
+	"1.3.6.1.4.1.34380.1.1.23": "pp_cloudplatform",
+	"1.3.6.1.4.1.34380.1.1.24": "pp_apptier",
+	"1.3.6.1.4.1.34380.1.1.25": "pp_hostname",
+	"1.3.6.1.4.1.34380.1.3.1":  "pp_authorization",
+	"1.3.6.1.4.1.34380.1.3.39": "pp_cli_auth",
+}
+
+// identityFromCert builds an Identity from a verified peer certificate, exposing
+// its Puppet extensions by both short name and raw OID.
+func identityFromCert(cert *x509.Certificate) Identity {
+	id := Identity{Authenticated: true, CN: cert.Subject.CommonName, Extensions: map[string]string{}}
+	for _, ext := range cert.Extensions {
+		oid := ext.Id.String()
+		val := decodeExtensionValue(ext.Value)
+		id.Extensions[oid] = val
+		if name, ok := puppetOIDNames[oid]; ok {
+			id.Extensions[name] = val
+		}
+	}
+	return id
+}
+
+// decodeExtensionValue unwraps the ASN.1-encoded string Puppet uses for its
+// cert extensions (UTF8String/PrintableString/IA5String). Falls back to the raw
+// bytes if the value is not a recognizable ASN.1 string.
+func decodeExtensionValue(raw []byte) string {
+	var s string
+	if _, err := asn1.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return strings.TrimRight(string(raw), "\x00")
+}

--- a/cmd/edge/authz_test.go
+++ b/cmd/edge/authz_test.go
@@ -1,6 +1,34 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
+
+func TestHandshakeNoiseFilter(t *testing.T) {
+	cases := []struct {
+		line string
+		kept bool
+	}{
+		{"2026/08/05 21:45:32 http: TLS handshake error from 1.2.3.4:5: EOF\n", false},
+		{"2026/08/05 21:45:32 http: TLS handshake error from 1.2.3.4:5: read: connection reset by peer\n", false},
+		{"2026/08/05 21:45:32 http: TLS handshake error from 1.2.3.4:5: write: broken pipe\n", false},
+		{"2026/08/05 21:45:32 http: TLS handshake error from 1.2.3.4:5: remote error: tls: bad certificate\n", true},
+		{"2026/08/05 21:45:32 http: TLS handshake error from 1.2.3.4:5: tls: client didn't provide a certificate\n", true},
+		{"2026/08/05 21:45:32 some other server error\n", true},
+	}
+	for _, tc := range cases {
+		var buf bytes.Buffer
+		f := &handshakeNoiseFilter{out: &buf}
+		n, err := f.Write([]byte(tc.line))
+		if err != nil || n != len(tc.line) {
+			t.Fatalf("Write returned n=%d err=%v, want n=%d nil", n, err, len(tc.line))
+		}
+		if got := buf.Len() > 0; got != tc.kept {
+			t.Errorf("line %q kept=%v, want %v", tc.line, got, tc.kept)
+		}
+	}
+}
 
 // rulesetJSON mirrors the operator's builtinAuthRules intent for the compile
 // endpoints the native server serves, plus the CA CLI rule for cross-checking

--- a/cmd/edge/authz_test.go
+++ b/cmd/edge/authz_test.go
@@ -1,0 +1,107 @@
+package main
+
+import "testing"
+
+// rulesetJSON mirrors the operator's builtinAuthRules intent for the compile
+// endpoints the native server serves, plus the CA CLI rule for cross-checking
+// the pp_cli_auth extension matcher.
+const rulesetJSON = `{
+  "rules": [
+    {
+      "name": "puppetlabs v3 catalog from agents",
+      "path": "^/puppet/v3/catalog/([^/]+)$",
+      "type": "regex",
+      "method": ["get", "post"],
+      "allow": "$1"
+    },
+    {
+      "name": "puppetlabs v3 environments",
+      "path": "/puppet/v3/environments",
+      "type": "path",
+      "method": ["get"],
+      "allow": "*"
+    },
+    {
+      "name": "puppetlabs certificate",
+      "path": "/puppet-ca/v1/certificate/",
+      "type": "path",
+      "method": ["get"],
+      "allow_unauthenticated": true
+    },
+    {
+      "name": "puppetlabs cert status",
+      "path": "/puppet-ca/v1/certificate_status",
+      "type": "path",
+      "method": ["get", "put", "delete"],
+      "allow": [{"extensions": {"pp_cli_auth": "true"}}, "operator.example"]
+    },
+    {
+      "name": "status",
+      "path": "/status/",
+      "type": "path",
+      "allow_unauthenticated": true
+    }
+  ],
+  "default": "deny"
+}`
+
+func mustRuleset(t *testing.T) *Ruleset {
+	t.Helper()
+	rs, err := parseRuleset([]byte(rulesetJSON))
+	if err != nil {
+		t.Fatalf("parseRuleset: %v", err)
+	}
+	return rs
+}
+
+func agent(cn string) Identity {
+	return Identity{Authenticated: true, CN: cn, Extensions: map[string]string{}}
+}
+
+func TestAuthorize(t *testing.T) {
+	rs := mustRuleset(t)
+	cliAuth := Identity{Authenticated: true, CN: "cli.example", Extensions: map[string]string{"pp_cli_auth": "true"}}
+
+	cases := []struct {
+		name    string
+		method  string
+		path    string
+		id      Identity
+		allowed bool
+		status  int
+	}{
+		{"catalog own node", "GET", "/puppet/v3/catalog/web01.example", agent("web01.example"), true, 200},
+		{"catalog other node denied", "GET", "/puppet/v3/catalog/web01.example", agent("intruder.example"), false, 403},
+		{"catalog needs cert", "GET", "/puppet/v3/catalog/web01.example", Identity{}, false, 401},
+		{"environments any agent", "GET", "/puppet/v3/environments", agent("web01.example"), true, 200},
+		{"environments wrong method", "POST", "/puppet/v3/environments", agent("web01.example"), false, 403},
+		{"cert fetch unauthenticated", "GET", "/puppet-ca/v1/certificate/web01.example", Identity{}, true, 200},
+		{"cert status via pp_cli_auth", "GET", "/puppet-ca/v1/certificate_status/web01", cliAuth, true, 200},
+		{"cert status via operator cn", "GET", "/puppet-ca/v1/certificate_status/web01", agent("operator.example"), true, 200},
+		{"cert status plain agent denied", "GET", "/puppet-ca/v1/certificate_status/web01", agent("web01.example"), false, 403},
+		{"status unauthenticated", "GET", "/status/v1/simple", Identity{}, true, 200},
+		{"unknown path default deny", "GET", "/puppet/v3/nope", agent("web01.example"), false, 403},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := rs.Authorize(tc.method, tc.path, tc.id)
+			if d.Allowed != tc.allowed || d.Status != tc.status {
+				t.Fatalf("got allowed=%v status=%d (%s), want allowed=%v status=%d",
+					d.Allowed, d.Status, d.Reason, tc.allowed, tc.status)
+			}
+		})
+	}
+}
+
+func TestParseRulesetDefaults(t *testing.T) {
+	rs, err := parseRuleset([]byte(`{"rules":[]}`))
+	if err != nil {
+		t.Fatalf("parseRuleset: %v", err)
+	}
+	if rs.Default != "deny" {
+		t.Fatalf("default = %q, want deny", rs.Default)
+	}
+	if d := rs.Authorize("GET", "/anything", agent("x")); d.Allowed {
+		t.Fatalf("empty ruleset should default-deny, got %+v", d)
+	}
+}

--- a/cmd/edge/main.go
+++ b/cmd/edge/main.go
@@ -11,8 +11,10 @@
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -91,10 +93,31 @@ func main() {
 			ClientCAs:  pool,
 			MinVersion: tls.VersionTLS12,
 		},
+		// Drop the connection-noise handshake errors (probes, port scans, LB
+		// health checks that open and close a socket) while keeping real mTLS
+		// failures -- bad/unknown client certificates -- visible.
+		ErrorLog: log.New(&handshakeNoiseFilter{out: os.Stderr}, "", log.LstdFlags),
 	}
 	log.Printf("openvox-edge listening on %s (mTLS) -> %s, %d auth rules (default %s)",
 		listen, backendURL, len(rules.Rules), rules.Default)
 	log.Fatal(srv.ListenAndServeTLS(certFile, keyFile))
+}
+
+// handshakeNoiseFilter forwards http.Server error lines to out, except benign
+// "TLS handshake error ... EOF / connection reset / broken pipe" lines caused by
+// clients that close the socket before completing the handshake. Real handshake
+// failures (e.g. "remote error: tls: bad certificate", "unknown authority",
+// "client didn't provide a certificate") are kept.
+type handshakeNoiseFilter struct{ out io.Writer }
+
+func (f *handshakeNoiseFilter) Write(p []byte) (int, error) {
+	if bytes.Contains(p, []byte("TLS handshake error")) &&
+		(bytes.HasSuffix(bytes.TrimRight(p, "\n"), []byte("EOF")) ||
+			bytes.Contains(p, []byte("connection reset by peer")) ||
+			bytes.Contains(p, []byte("broken pipe"))) {
+		return len(p), nil
+	}
+	return f.out.Write(p)
 }
 
 func getenv(k, def string) string {

--- a/cmd/edge/main.go
+++ b/cmd/edge/main.go
@@ -1,0 +1,105 @@
+// Command openvox-edge is a small mTLS reverse proxy that enforces puppet
+// auth.conf-style rules and forwards to a CRuby compile backend (Puma + the
+// openvox gem). It is the "Go edge + native Ruby behind it" front for the
+// experimental non-JVM openvox-server-native image: the edge terminates mTLS and
+// authorizes requests (the job the JVM's trapperkeeper-authorization does today),
+// while catalog compilation happens in plain CRuby instead of a JRuby pool.
+//
+// Everything is config-driven: the authorization rules come from a JSON file
+// (EDGE_AUTH_RULES) modeled on the operator's builtinAuthRules, so the operator
+// can render the same intent it already renders as HOCON auth.conf.
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+)
+
+func main() {
+	var (
+		listen   = getenv("EDGE_LISTEN", ":8140")
+		backend  = getenv("EDGE_BACKEND_URL", "http://127.0.0.1:9140")
+		certFile = getenv("EDGE_TLS_CERT", "/etc/edge/server.pem")
+		keyFile  = getenv("EDGE_TLS_KEY", "/etc/edge/server-key.pem")
+		caFile   = getenv("EDGE_TLS_CA", "/etc/edge/ca.pem")
+		rulesF   = getenv("EDGE_AUTH_RULES", "/etc/edge/auth-rules.json")
+	)
+
+	backendURL, err := url.Parse(backend)
+	if err != nil {
+		log.Fatalf("bad EDGE_BACKEND_URL %q: %v", backend, err)
+	}
+
+	rulesData, err := os.ReadFile(rulesF)
+	if err != nil {
+		log.Fatalf("read auth rules %q: %v", rulesF, err)
+	}
+	rules, err := parseRuleset(rulesData)
+	if err != nil {
+		log.Fatalf("parse auth rules %q: %v", rulesF, err)
+	}
+
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		log.Fatalf("read CA %q: %v", caFile, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		log.Fatalf("no CA certificates parsed from %q", caFile)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var id Identity
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			id = identityFromCert(r.TLS.PeerCertificates[0])
+		}
+
+		d := rules.Authorize(r.Method, r.URL.Path, id)
+		if !d.Allowed {
+			log.Printf("DENY  %s %s (cn=%q): %s", r.Method, r.URL.Path, id.CN, d.Reason)
+			http.Error(w, d.Reason+"\n", d.Status)
+			return
+		}
+
+		// Hand the verified identity to the backend, which trusts these headers
+		// because only the edge can reach it (localhost). Mirrors the classic
+		// nginx/Passenger master pattern.
+		if id.Authenticated {
+			r.Header.Set("X-Client-Verify", "SUCCESS")
+			r.Header.Set("X-Client-DN", "CN="+id.CN)
+			r.Header.Set("X-Client-CN", id.CN)
+		} else {
+			r.Header.Set("X-Client-Verify", "NONE")
+			r.Header.Del("X-Client-DN")
+			r.Header.Del("X-Client-CN")
+		}
+		log.Printf("ALLOW %s %s (cn=%q): %s", r.Method, r.URL.Path, id.CN, d.Reason)
+		proxy.ServeHTTP(w, r)
+	})
+
+	srv := &http.Server{
+		Addr:    listen,
+		Handler: handler,
+		TLSConfig: &tls.Config{
+			ClientAuth: tls.VerifyClientCertIfGiven,
+			ClientCAs:  pool,
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	log.Printf("openvox-edge listening on %s (mTLS) -> %s, %d auth rules (default %s)",
+		listen, backendURL, len(rules.Rules), rules.Default)
+	log.Fatal(srv.ListenAndServeTLS(certFile, keyFile))
+}
+
+func getenv(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/images/openvox-server-native/Containerfile
+++ b/images/openvox-server-native/Containerfile
@@ -1,0 +1,137 @@
+# EXPERIMENTAL rootless native (no-JVM) OpenVox Server on UBI9.
+#
+# A drop-in-shaped alternative to images/openvox-server: same rootless/OpenShift
+# conventions and :8140 mTLS surface, but the JRuby pool + JVM are replaced by
+#   Go edge (mTLS + config-driven auth)  -->  Puma/CRuby + the openvox gem
+# for the SERVER role (catalog compilation). The CA role stays on the JVM
+# puppetserver image, so this can be swapped in for server-only pods.
+#
+# No RPM install of OpenVox: the Ruby interpreter comes from the ubi ruby module
+# (interpreter only, exactly like images/openvox-server), and OpenVox itself is
+# installed as the openvox gem into a self-contained GEM_HOME -- the CRuby analogue
+# of the server tarball.
+#
+# Build (from repo root):
+#   podman build -t openvox-server-native:latest -f images/openvox-server-native/Containerfile .
+
+ARG OPENVOX_VERSION=8.28.1
+ARG RUBY_STREAM=3.3
+
+################################################################################
+# Stage: base — CRuby runtime deps only (no JDK, no JRuby)
+################################################################################
+FROM registry.access.redhat.com/ubi9/ubi:9.8-1785906690 AS base
+
+ARG RUBY_STREAM
+
+RUN dnf module enable ruby:${RUBY_STREAM} -y \
+    && dnf install -y --allowerasing --setopt=install_weak_deps=False \
+        ruby \
+        rubygems \
+        rubygem-json \
+        rubygem-psych \
+        rubygem-bigdecimal \
+        rubygem-io-console \
+        rubygem-racc \
+        bash \
+        curl \
+        openssl \
+        tar \
+        gzip \
+        findutils \
+        hostname \
+    && dnf clean all
+
+################################################################################
+# Stage: gems — install OpenVox + Puma into a self-contained GEM_HOME
+################################################################################
+FROM base AS gems
+
+ARG OPENVOX_VERSION
+
+ENV GEM_HOME=/opt/openvox-native \
+    GEM_PATH=/opt/openvox-native
+
+# Build toolchain is only needed here to compile native gem extensions (Puma);
+# it never lands in the final image.
+RUN dnf install -y --setopt=install_weak_deps=False \
+        ruby-devel gcc make redhat-rpm-config \
+    && dnf clean all \
+    && gem install --no-document \
+        openvox --version "${OPENVOX_VERSION}" \
+    && gem install --no-document \
+        puma rack
+
+################################################################################
+# Stage: edge — compile the openvox-edge Go binary
+################################################################################
+FROM docker.io/library/golang:1.26.5 AS edge
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/edge/ cmd/edge/
+RUN CGO_ENABLED=0 go build -o /openvox-edge ./cmd/edge/
+
+################################################################################
+# Stage: final — rootless runtime image
+################################################################################
+FROM base AS final
+
+ARG OPENVOX_VERSION
+
+LABEL org.opencontainers.image.title="OpenVox Server (native, experimental)" \
+      org.opencontainers.image.description="Experimental non-JVM OpenVox Server: Go edge + CRuby/Puma catalog compilation" \
+      org.opencontainers.image.vendor="slauger" \
+      org.opencontainers.image.url="https://github.com/slauger/openvox-operator" \
+      org.opencontainers.image.source="https://github.com/slauger/openvox-operator" \
+      org.opencontainers.image.version="${OPENVOX_VERSION}" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ENV GEM_HOME=/opt/openvox-native \
+    GEM_PATH=/opt/openvox-native \
+    PATH=/opt/openvox-native/bin:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:$PATH \
+    CODEDIR=/etc/puppetlabs/code \
+    PUMA_WORKERS=2 \
+    HOME=/opt/puppetlabs/server/data/puppetserver
+
+# OpenVox gems (incl. compiled Puma extension) from the gems stage.
+COPY --from=gems /opt/openvox-native /opt/openvox-native
+
+# The compile backend, edge binary, auth rules and a demo control repo.
+COPY --from=edge /openvox-edge /usr/local/bin/openvox-edge
+COPY images/openvox-server-native/backend/          /opt/openvox-native/backend/
+COPY images/openvox-server-native/auth-rules.json   /etc/edge/auth-rules.json
+COPY images/openvox-server-native/code/             /etc/puppetlabs/code/
+COPY images/openvox-server-native/entrypoint.sh     /entrypoint.sh
+COPY images/openvox-server-native/healthcheck.sh    /healthcheck.sh
+
+RUN install -d -m 0755 \
+        /etc/puppetlabs/puppet/ssl \
+        /var/log/puppetlabs \
+        /var/run/puppetlabs \
+        /opt/puppetlabs/server/data/puppetserver \
+    && chmod +x /entrypoint.sh /healthcheck.sh /usr/local/bin/openvox-edge
+
+# OpenShift random-UID pattern: group root(0), mirror user perms to group,
+# SGID on directories so new files inherit the group.
+RUN for d in \
+        /etc/puppetlabs \
+        /etc/edge \
+        /opt/openvox-native \
+        /var/log/puppetlabs \
+        /var/run/puppetlabs \
+        /opt/puppetlabs \
+    ; do \
+        chgrp -R 0 "$d"; \
+        chmod -R g=u "$d"; \
+        find "$d" -type d -exec chmod g+s {} +; \
+    done
+
+USER 1001:0
+
+HEALTHCHECK --interval=20s --timeout=15s --retries=12 --start-period=2m CMD ["/healthcheck.sh"]
+
+EXPOSE 8140
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/openvox-server-native/README.md
+++ b/images/openvox-server-native/README.md
@@ -1,0 +1,100 @@
+# openvox-server-native (experimental)
+
+A non-JVM OpenVox Server image. It keeps the same rootless/OpenShift conventions
+and `:8140` mTLS surface as [`images/openvox-server`](../openvox-server), but
+replaces the JRuby pool and the JVM with:
+
+```
+          :8140 (mTLS)                     127.0.0.1:9140
+  agent ───────────────▶  Go edge  ──────────────────────▶  Puma (cluster) ─▶ CRuby + openvox gem
+                          mTLS + auth.conf rules            preload_app!       catalog compilation
+```
+
+- **Go edge** (`cmd/edge`) terminates mTLS and does authorization — the job
+  trapperkeeper-authorization does on the JVM server. Rules are **config-driven**
+  (`auth-rules.json`), modeled on the operator's `builtinAuthRules`, so the
+  operator could render this file from the same authorization intent it already
+  renders as HOCON `auth.conf`.
+- **CRuby backend** (`backend/config.ru`) drives the very same Puppet indirections
+  as openvox-server's `compiler.rb` (`node = plain`, `catalog = compiler`) — only
+  on plain MRI instead of JRuby.
+- **Puma** runs one worker per core, one thread each (catalog compile is CPU-bound
+  and CRuby holds the GIL), with `preload_app!` for copy-on-write sharing of the
+  loaded environment. Scale out with pod replicas + an HPA.
+
+## Scope
+
+This is the **server role only** (catalog compilation). The **CA role stays on the
+JVM `openvox-server` image** — the native image is meant to be swapped in for
+server-only pods while the CA is left as-is. No RPM install of OpenVox: the Ruby
+interpreter comes from the ubi `ruby` module (interpreter only), OpenVox itself is
+the `openvox` gem in a self-contained `GEM_HOME` (the CRuby analogue of the
+server tarball).
+
+## auth-rules.json
+
+Config-driven equivalent of `auth.conf`. Each rule mirrors a `match-request`
+block; the first rule whose `path` + `method` matches decides, `deny` before
+`allow`, and unmatched requests fall through to `default` (`deny`).
+
+| Field | Meaning |
+|-------|---------|
+| `path` + `type` | `regex` (matched with captures) or `path` (prefix) |
+| `method` | list of HTTP methods; empty = any |
+| `allow` | `"*"` (any authenticated), `"$1"` (client CN must equal capture group 1), a literal certname, `{"extensions": {"pp_cli_auth": "true"}}`, or a list mixing these |
+| `deny` | same forms as `allow`; takes precedence |
+| `allow_unauthenticated` | serve without a client certificate (e.g. `/status/`) |
+
+The `"$1"` matcher is the dynamic catalog rule (`allow "$1"`) plain reverse
+proxies can't express: a client may only fetch the catalog for its own certname.
+Certificate extensions (`pp_cli_auth`, `pp_authorization`, `pp_preshared_key`, …)
+are read straight from the client cert.
+
+## Build
+
+From the repo root:
+
+```sh
+podman build -t openvox-server-native:latest -f images/openvox-server-native/Containerfile .
+```
+
+## Run standalone
+
+With no operator-provided certificate, the entrypoint generates a throwaway
+self-signed PoC PKI (CA, server cert, and a demo agent cert `CN=agent.example`)
+under `/tmp/edge`:
+
+```sh
+podman run --rm --name ovnative -p 8140:8140 openvox-server-native:latest
+
+# health (unauthenticated)
+curl -sk https://localhost:8140/status/v1/simple      # -> running
+
+# compile a catalog as the demo agent (auth.conf allow "$1": CN must equal the node)
+podman exec ovnative sh -c '
+  curl -sk https://localhost:8140/puppet/v3/catalog/agent.example \
+    --cert /tmp/edge/agent.pem --key /tmp/edge/agent-key.pem \
+    -H "Content-Type: application/json" -d "{\"values\":{}}"'
+
+# a different node is refused (403) — the dynamic allow "$1" rule
+podman exec ovnative sh -c '
+  curl -sk https://localhost:8140/puppet/v3/catalog/other.example \
+    --cert /tmp/edge/agent.pem --key /tmp/edge/agent-key.pem -d "{}" -w "\n%{http_code}\n"'
+```
+
+## Run under the operator
+
+When the operator mounts a Puppet-signed server certificate under the standard
+`ssldir` (`/etc/puppetlabs/puppet/ssl`, `CERTNAME` = the server certname) — the
+same Secret the JVM server consumes — the edge uses it instead of the PoC PKI.
+Point a server-role pod's image at this build and mount the control repo via
+`config.code`, exactly like the JVM server.
+
+## Status
+
+Experimental / proof-of-concept. Known gaps vs. the JVM server: no CA endpoints
+(delegated to the JVM CA), a subset of the v3 API (catalog/node/file/report/
+environments/status), no PuppetDB termini wiring, and CRuby's copy-on-write
+sharing erodes under GC at scale — the JRuby pool's warm in-process caches remain
+the stronger option for very large fleets. See the top-level design notes for the
+full trade-off analysis.

--- a/images/openvox-server-native/auth-rules.json
+++ b/images/openvox-server-native/auth-rules.json
@@ -1,0 +1,75 @@
+{
+  "_comment": "Config-driven auth for the native openvox-server edge. Mirrors the operator's builtinAuthRules (auth.conf) for the SERVER role only -- the CA role stays on the JVM puppetserver. The operator could render this file from the same authorization model it uses for HOCON auth.conf.",
+  "rules": [
+    {
+      "name": "puppetlabs v3 catalog from agents",
+      "path": "^/puppet/v3/catalog/([^/]+)$",
+      "type": "regex",
+      "method": ["get", "post"],
+      "allow": "$1"
+    },
+    {
+      "name": "puppetlabs v3 node",
+      "path": "^/puppet/v3/node/([^/]+)$",
+      "type": "regex",
+      "method": ["get"],
+      "allow": "$1"
+    },
+    {
+      "name": "puppetlabs v3 file_metadata",
+      "path": "/puppet/v3/file_metadata",
+      "type": "path",
+      "method": ["get", "post"],
+      "allow": "*"
+    },
+    {
+      "name": "puppetlabs v3 file_metadatas",
+      "path": "/puppet/v3/file_metadatas",
+      "type": "path",
+      "method": ["get", "post"],
+      "allow": "*"
+    },
+    {
+      "name": "puppetlabs v3 file_content",
+      "path": "/puppet/v3/file_content",
+      "type": "path",
+      "method": ["get", "post"],
+      "allow": "*"
+    },
+    {
+      "name": "puppetlabs v3 file_bucket_file",
+      "path": "/puppet/v3/file_bucket_file",
+      "type": "path",
+      "method": ["get", "head", "put"],
+      "allow": "*"
+    },
+    {
+      "name": "puppetlabs v3 environments",
+      "path": "/puppet/v3/environments",
+      "type": "path",
+      "method": ["get"],
+      "allow": "*"
+    },
+    {
+      "name": "puppetlabs v3 environment",
+      "path": "^/puppet/v3/environment/[^/]+$",
+      "type": "regex",
+      "method": ["get"],
+      "allow": "*"
+    },
+    {
+      "name": "puppetlabs v3 report",
+      "path": "^/puppet/v3/report/([^/]+)$",
+      "type": "regex",
+      "method": ["put"],
+      "allow": "$1"
+    },
+    {
+      "name": "puppetlabs status",
+      "path": "/status/",
+      "type": "path",
+      "allow_unauthenticated": true
+    }
+  ],
+  "default": "deny"
+}

--- a/images/openvox-server-native/backend/config.ru
+++ b/images/openvox-server-native/backend/config.ru
@@ -1,0 +1,63 @@
+# Native CRuby compile backend for the openvox-server-native image.
+#
+# This is the Rack equivalent of openvox-server's compiler.rb: it drives the very
+# same Puppet indirections (node = plain, catalog = compiler) the JVM server drives
+# through its JRuby pool -- only here it runs on plain CRuby (MRI). The Go edge in
+# front terminates mTLS and authorizes; this backend only ever sees localhost
+# traffic and trusts the X-Client-* headers the edge sets.
+
+require 'json'
+require 'rack'
+require 'puppet'
+
+CODEDIR = ENV.fetch('CODEDIR', '/etc/puppetlabs/code')
+
+Puppet.initialize_settings(%W[
+  --codedir #{CODEDIR}
+  --environmentpath #{CODEDIR}/environments
+  --vardir #{ENV.fetch('VARDIR', '/opt/puppetlabs/server/data/puppetserver')}
+  --confdir #{ENV.fetch('CONFDIR', '/etc/puppetlabs/puppet')}
+  --rundir #{ENV.fetch('RUNDIR', '/var/run/puppetlabs')}
+  --logdir #{ENV.fetch('LOGDIR', '/var/log/puppetlabs')}
+  --autosign false
+])
+Puppet::Node.indirection.terminus_class = :plain
+Puppet::Resource::Catalog.indirection.terminus_class = :compiler
+
+# GET /puppet/v3/catalog/<certname> -- the endpoint agents hit for their catalog.
+CATALOG = %r{\A/puppet/v3/catalog/([^/]+)\z}
+
+run(lambda do |env|
+  req = Rack::Request.new(env)
+
+  if req.path_info == '/status/v1/simple'
+    return [200, { 'content-type' => 'text/plain' }, ["running\n"]]
+  end
+
+  m = CATALOG.match(req.path_info)
+  unless m
+    return [404, { 'content-type' => 'text/plain' }, ["not found\n"]]
+  end
+
+  certname    = Rack::Utils.unescape(m[1])
+  environment = req.params['environment'] || 'production'
+
+  # The edge already proved the client owns this certname (auth.conf allow "$1").
+  facts_values = {}
+  raw = req.body.read.to_s
+  unless raw.empty?
+    parsed = (JSON.parse(raw) rescue {})
+    facts_values = parsed['values'] || parsed
+  end
+  facts = Puppet::Node::Facts.new(certname, facts_values)
+
+  begin
+    node    = Puppet::Node.indirection.find(certname, environment: environment, facts: facts)
+    catalog = Puppet::Parser::Compiler.compile(node)
+    [200, { 'content-type' => 'application/json' }, [catalog.to_data_hash.to_json]]
+  rescue => e
+    Puppet.err("catalog compile failed for #{certname}: #{e.class}: #{e.message}")
+    [500, { 'content-type' => 'text/plain' },
+     ["compile error: #{e.class}: #{e.message}\n"]]
+  end
+end)

--- a/images/openvox-server-native/backend/puma.rb
+++ b/images/openvox-server-native/backend/puma.rb
@@ -1,0 +1,11 @@
+# Puma config for the CRuby compile backend.
+#
+# Catalog compilation is CPU-bound and CRuby holds the GIL, so parallelism comes
+# from *processes*, not threads: one worker per core, a single thread each.
+# preload_app! loads Puppet + the environment once in the master so forked
+# workers share it copy-on-write (the CRuby analogue of the JRuby pool's warm
+# caches). Scale further in Kubernetes with pod replicas + an HPA, not threads.
+bind ENV.fetch('BACKEND_BIND', 'tcp://127.0.0.1:9140')
+workers Integer(ENV.fetch('PUMA_WORKERS', '2'))
+threads 1, 1
+preload_app!

--- a/images/openvox-server-native/code/environments/production/environment.conf
+++ b/images/openvox-server-native/code/environments/production/environment.conf
@@ -1,0 +1,2 @@
+modulepath = modules:$basemodulepath
+manifest = manifests/site.pp

--- a/images/openvox-server-native/code/environments/production/manifests/site.pp
+++ b/images/openvox-server-native/code/environments/production/manifests/site.pp
@@ -1,0 +1,7 @@
+# Bundled demo environment so the image compiles a catalog out of the box.
+# Replace it via a code volume (config.code) exactly like the JVM server image.
+node default {
+  notify { 'openvox-server-native':
+    message => 'Catalog compiled by native CRuby behind the Go edge (no JVM)',
+  }
+}

--- a/images/openvox-server-native/entrypoint.sh
+++ b/images/openvox-server-native/entrypoint.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Rootless entrypoint for the experimental native (no-JVM) OpenVox Server.
+#
+# Layout:  Go edge (mTLS + auth) on :8140  -->  Puma/CRuby compile backend on :9140
+#
+# TLS certs: if the operator mounted a Puppet-signed server certificate under the
+# standard ssldir (the same Secret the JVM server consumes), the edge uses it.
+# Otherwise a throwaway self-signed PoC PKI is generated so the image also runs
+# standalone (podman run) without the operator/CA.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+export PATH="/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:${PATH}"
+export GEM_HOME="${GEM_HOME:-/opt/openvox-native}"
+export GEM_PATH="${GEM_HOME}"
+export CODEDIR="${CODEDIR:-/etc/puppetlabs/code}"
+
+SSLDIR="${SSLDIR:-/etc/puppetlabs/puppet/ssl}"
+CERTNAME="${CERTNAME:-$(hostname -f 2>/dev/null || hostname)}"
+EDGE_DIR="/tmp/edge"
+
+mkdir -p "${EDGE_DIR}" /var/run/puppetlabs /var/log/puppetlabs \
+         "${GEM_HOME}" "/opt/puppetlabs/server/data/puppetserver"
+
+server_cert="${SSLDIR}/certs/${CERTNAME}.pem"
+server_key="${SSLDIR}/private_keys/${CERTNAME}.pem"
+ca_cert="${SSLDIR}/certs/ca.pem"
+
+if [[ -f "${server_cert}" && -f "${server_key}" && -f "${ca_cert}" ]]; then
+    echo "Using operator-provided certificate for ${CERTNAME} from ${SSLDIR}"
+    export EDGE_TLS_CERT="${server_cert}"
+    export EDGE_TLS_KEY="${server_key}"
+    export EDGE_TLS_CA="${ca_cert}"
+else
+    echo "No operator certificate found for ${CERTNAME}; generating a self-signed PoC PKI in ${EDGE_DIR}"
+    if [[ ! -f "${EDGE_DIR}/ca.pem" ]]; then
+        openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout "${EDGE_DIR}/ca-key.pem" -out "${EDGE_DIR}/ca.pem" \
+            -days 3650 -subj "/CN=openvox-native-poc-ca" 2>/dev/null
+        openssl req -newkey rsa:2048 -nodes \
+            -keyout "${EDGE_DIR}/server-key.pem" -out "${EDGE_DIR}/server.csr" \
+            -subj "/CN=${CERTNAME}" 2>/dev/null
+        openssl x509 -req -in "${EDGE_DIR}/server.csr" \
+            -CA "${EDGE_DIR}/ca.pem" -CAkey "${EDGE_DIR}/ca-key.pem" -CAcreateserial \
+            -out "${EDGE_DIR}/server.pem" -days 825 \
+            -extfile <(printf "subjectAltName=DNS:%s,DNS:localhost,IP:127.0.0.1" "${CERTNAME}") 2>/dev/null
+        # A demo agent cert (CN=agent.example) for manual smoke tests against :8140.
+        openssl req -newkey rsa:2048 -nodes \
+            -keyout "${EDGE_DIR}/agent-key.pem" -out "${EDGE_DIR}/agent.csr" \
+            -subj "/CN=agent.example" 2>/dev/null
+        openssl x509 -req -in "${EDGE_DIR}/agent.csr" \
+            -CA "${EDGE_DIR}/ca.pem" -CAkey "${EDGE_DIR}/ca-key.pem" -CAcreateserial \
+            -out "${EDGE_DIR}/agent.pem" -days 825 2>/dev/null
+        echo "PoC PKI generated (CA, server cert for ${CERTNAME}, demo agent cert CN=agent.example)"
+    fi
+    export EDGE_TLS_CERT="${EDGE_DIR}/server.pem"
+    export EDGE_TLS_KEY="${EDGE_DIR}/server-key.pem"
+    export EDGE_TLS_CA="${EDGE_DIR}/ca.pem"
+fi
+
+export EDGE_AUTH_RULES="${EDGE_AUTH_RULES:-/etc/edge/auth-rules.json}"
+export EDGE_BACKEND_URL="${EDGE_BACKEND_URL:-http://127.0.0.1:9140}"
+
+# Start the CRuby compile backend (localhost only, behind the edge).
+cd /opt/openvox-native/backend
+puma -C puma.rb config.ru &
+backend_pid=$!
+
+echo "Waiting for the compile backend on 127.0.0.1:9140 ..."
+for _ in $(seq 1 60); do
+    if ruby -rsocket -e 'TCPSocket.new("127.0.0.1", 9140).close' 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 "${backend_pid}" 2>/dev/null; then
+        echo "ERROR: compile backend exited during startup" >&2
+        exit 1
+    fi
+    sleep 1
+done
+echo "Compile backend is up (pid ${backend_pid})"
+
+# Reap the backend if the edge exits, and vice-versa.
+trap 'kill "${backend_pid}" 2>/dev/null || true' EXIT
+
+exec /usr/local/bin/openvox-edge

--- a/images/openvox-server-native/healthcheck.sh
+++ b/images/openvox-server-native/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Simple healthcheck for Docker/Podman. K8s uses livenessProbe/readinessProbe.
+# /status/ is allow_unauthenticated in auth-rules.json, so no client cert needed.
+set -e
+
+timeout="${1:-10}"
+
+curl --fail --silent --max-time "${timeout}" --insecure \
+    "https://localhost:8140/status/v1/simple" \
+    | grep -q '^running$' \
+    || exit 1


### PR DESCRIPTION
Experimental, additional server image that runs the **server role** (catalog compilation) on plain CRuby instead of the JRuby pool + JVM.

Shape:

    agent --mTLS--> Go edge (auth) --localhost--> Puma cluster --> CRuby + openvox gem

- `cmd/edge` (`openvox-edge`): small Go reverse proxy that terminates mTLS and does authorization from a JSON ruleset (`EDGE_AUTH_RULES`) modeled on the operator`s `builtinAuthRules`. Supports the dynamic `allow "$1"` catalog rule (client CN must equal the certname), literal certnames, `*`, `allow_unauthenticated`, and `pp_cli_auth`/`pp_*` cert-extension matching. Forwards the verified identity to the backend via `X-Client-*` headers.
- `images/openvox-server-native`: Go edge + a Puma/CRuby compile backend (`backend/config.ru` drives the same `node=plain` / `catalog=compiler` indirections as openvox-server`s `compiler.rb`). OpenVox is installed as the `openvox` gem into a self-contained `GEM_HOME` (no RPM); the Ruby interpreter comes from the ubi `ruby:3.3` module (Ruby 3.3.12). Keeps the rootless/OpenShift conventions and `:8140` mTLS surface of the JVM image.

Scope / intent:

- **Additional, swappable image** for server-only pods. The **CA role stays on the JVM puppetserver image** - the CA is left as-is.
- No RPM install of OpenVox (gem-based, tarball-equivalent for the Ruby side).
- Auth is config-driven, so the operator could later render `auth-rules.json` from the same authorization model it already renders as HOCON `auth.conf`.

Verified locally (standalone `docker run`, self-bootstrapped PoC PKI):

- matching client CN -> `200` + a real catalog compiled by CRuby (openvox 8.28.1)
- wrong CN -> `403` (the dynamic `allow "$1"` rule)
- no client cert -> `401`
- benign TLS handshake noise (probe EOF / reset) filtered; real bad/unknown-cert errors still logged

Known gaps vs. the JVM server: CA endpoints delegated to the JVM CA, only a subset of the v3 API (catalog/node/file/report/environments/status), no PuppetDB termini wiring, and CRuby copy-on-write sharing erodes under GC at scale. Draft / proof-of-concept - opening for discussion, not for merge yet.