### PR TITLE
fix: PuppetDB receives no facts — render routes.yaml

### DIFF
--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -27,7 +27,7 @@ flowchart LR
 2. It validates that the PostgreSQL credentials Secret exists
 3. It renders a `database.ini` Secret with the PostgreSQL connection string and a ConfigMap with `jetty.ini`, `config.ini`, and `auth.conf`
 4. It creates a Deployment of OpenVox DB pods that connect to the external PostgreSQL backend over SSL and serve mTLS traffic on port 8081
-5. A `Config` can reference the Database via `databaseRef` to automatically wire the PuppetDB connection URL into Server pods -- the operator reads `status.url` and writes it into `puppetdb.conf` (no need to set `puppetdb.serverUrls` manually)
+5. A `Config` can reference the Database via `databaseRef` to automatically wire the PuppetDB connection URL into Server pods -- the operator reads `status.url` and writes it into `puppetdb.conf` (no need to set `puppetdb.serverUrls` manually), and renders a `routes.yaml` so facts are stored in PuppetDB too (see [Fact Storage](#fact-storage))
 
 ## Why an External PostgreSQL?
 
@@ -96,6 +96,21 @@ Puppet Agent → Puppet Server → openvox-report → Database (mTLS) → Postgr
 ```
 
 See [Report Processing](report-processing.md) for the full pipeline and [ReportProcessor](../reference/reportprocessor.md) for configuration options.
+
+## Fact Storage
+
+PuppetDB stores catalogs, reports, **and facts**, but the three are wired independently. `storeconfigs_backend = puppetdb` triggers the `replace catalog` command (catalogs and exported resources) and `reports = puppetdb` triggers `store report`, but neither switches the facts indirector. Facts only reach PuppetDB when the `facts` terminus points at `puppetdb`, which is configured through `routes.yaml`:
+
+```yaml
+master:
+  facts:
+    terminus: puppetdb
+    cache: json
+```
+
+The operator renders this `routes.yaml` automatically and mounts it at `$confdir/routes.yaml` (Puppet's default `route_file`) whenever PuppetDB is the active backend -- i.e. a `databaseRef` or `puppetdb.serverUrls` is set **and** `storeBackend`/`reports` use `puppetdb`. Like every other rendered config file it lives in the Config ConfigMap, so a change rolls the Server pods automatically (see [Configuration Rollout](config-rollout.md)). No manual `routes.yaml` is required.
+
+Without it, everything fact-based stays empty: PQL / `puppetdb_query()` on facts, inventory and node fact age, dashboard fact views, and fact-based exported-resource queries.
 
 ## PostgreSQL Credentials
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -214,6 +214,6 @@ Controls Puppet Server metrics.conf settings.
 
 | Resource | Name | Description |
 |---|---|---|
-| ConfigMap | `{name}` | puppet.conf, puppetserver.conf, auth.conf, webserver.conf, etc. |
+| ConfigMap | `{name}` | puppet.conf, puppetserver.conf, auth.conf, webserver.conf, `routes.yaml` (facts terminus, when PuppetDB is the active backend), etc. |
 | Secret | `{name}-enc` | ENC config for openvox-enc binary (only when `nodeClassifierRef` is set) |
 | ServiceAccount | `{name}-server` | Shared ServiceAccount for all Server pods (`automountServiceAccountToken: false`) |

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -158,6 +158,13 @@ func (r *ConfigReconciler) reconcileConfigMap(ctx context.Context, cfg *openvoxv
 		"ca-disabled.cfg":   "puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service\npuppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service\n",
 	}
 
+	// Route the facts terminus to PuppetDB (only when PuppetDB is the active
+	// backend). Without this, facts never reach PuppetDB. The Server controller
+	// mounts it at $confdir/routes.yaml under the same condition.
+	if routes := renderRoutesYAML(cfg); routes != "" {
+		data["routes.yaml"] = routes
+	}
+
 	cm := &corev1.ConfigMap{}
 	err = r.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: cfg.Namespace}, cm)
 	if errors.IsNotFound(err) {

--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -680,6 +680,53 @@ func TestConfigReconcile_PuppetDBConfNoConfig(t *testing.T) {
 	}
 }
 
+func TestConfigReconcile_RoutesYAMLWithDatabaseRef(t *testing.T) {
+	db := newDatabase("production-db",
+		withDatabaseStatusURL("https://production-db.default.svc.cluster.local:8081"),
+	)
+	cfg := newConfig("production", withDatabaseRef("production-db"))
+	c := setupTestClient(cfg, db)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	routes, ok := cm.Data["routes.yaml"]
+	if !ok {
+		t.Fatalf("ConfigMap missing routes.yaml when PuppetDB is the active backend")
+	}
+	if !strings.Contains(routes, "terminus: puppetdb") {
+		t.Errorf("routes.yaml does not route facts to puppetdb\n---\n%s", routes)
+	}
+}
+
+func TestConfigReconcile_NoRoutesYAMLWithoutPuppetDB(t *testing.T) {
+	// Default config has storeconfigs/reports=puppetdb but no DatabaseRef/ServerURLs,
+	// so PuppetDB is not actually wired up and no routes.yaml should be rendered.
+	cfg := newConfig("production")
+	c := setupTestClient(cfg)
+	r := newConfigReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-config", Namespace: testNamespace}, cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	if _, ok := cm.Data["routes.yaml"]; ok {
+		t.Errorf("ConfigMap should not contain routes.yaml when PuppetDB is not wired up\n---\n%s", cm.Data["routes.yaml"])
+	}
+}
+
 func TestConfigReconcile_UpdateExistingConfigMap(t *testing.T) {
 	cfg := newConfig("production")
 	existingCM := newConfigMap("production-config", map[string]string{

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -151,6 +151,37 @@ func (r *ConfigReconciler) renderPuppetDBConf(ctx context.Context, cfg *openvoxv
 	return "[main]\nsoft_write_failure = true\n", nil
 }
 
+// puppetDBActiveForFacts reports whether PuppetDB is wired up (via DatabaseRef or
+// explicit ServerURLs) and configured as the active backend for storeconfigs or
+// reports. Only then must the facts indirector be routed to PuppetDB via
+// routes.yaml: storeconfigs_backend and reports=puppetdb trigger the `replace
+// catalog` and `store report` commands, but neither switches the facts terminus,
+// so without routes.yaml the `replace facts` command is never issued.
+func puppetDBActiveForFacts(cfg *openvoxv1alpha1.Config) bool {
+	wired := cfg.Spec.DatabaseRef != "" || len(cfg.Spec.PuppetDB.ServerURLs) > 0
+	if !wired {
+		return false
+	}
+	return (cfg.Spec.Puppet.Storeconfigs && cfg.Spec.Puppet.StoreBackend == "puppetdb") ||
+		strings.Contains(cfg.Spec.Puppet.Reports, "puppetdb")
+}
+
+// renderRoutesYAML returns the routes.yaml that points the facts indirector
+// terminus at PuppetDB, so the `replace facts` command is issued on every agent
+// run. Mounted at $confdir/routes.yaml, which Puppet's route_file setting already
+// points at by default. Returns "" when PuppetDB is not the active backend, in
+// which case no routes.yaml is rendered or mounted.
+func renderRoutesYAML(cfg *openvoxv1alpha1.Config) string {
+	if !puppetDBActiveForFacts(cfg) {
+		return ""
+	}
+	return "---\n" +
+		"master:\n" +
+		"  facts:\n" +
+		"    terminus: puppetdb\n" +
+		"    cache: json\n"
+}
+
 // renderWebserverConf returns the webserver.conf for non-CA servers.
 // CRL is read from the kubelet-synced secret mount at /etc/puppetlabs/puppet/crl/.
 func (r *ConfigReconciler) renderWebserverConf(cfg *openvoxv1alpha1.Config) string {

--- a/internal/controller/config_rendering_test.go
+++ b/internal/controller/config_rendering_test.go
@@ -7,6 +7,65 @@ import (
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
+func TestRenderRoutesYAML(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *openvoxv1alpha1.Config
+		want bool // expect a non-empty routes.yaml routing facts to puppetdb
+	}{
+		{
+			name: "databaseRef + puppetdb backend",
+			cfg:  newConfig("c", withDatabaseRef("db")),
+			want: true,
+		},
+		{
+			name: "explicit serverUrls + puppetdb backend",
+			cfg: func() *openvoxv1alpha1.Config {
+				c := newConfig("c")
+				c.Spec.PuppetDB.ServerURLs = []string{"https://pdb:8081"}
+				return c
+			}(),
+			want: true,
+		},
+		{
+			name: "no puppetdb wired up",
+			cfg:  newConfig("c"),
+			want: false,
+		},
+		{
+			name: "wired up but backend is not puppetdb",
+			cfg: newConfig("c", withDatabaseRef("db"), withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				Storeconfigs: false,
+				StoreBackend: "",
+				Reports:      "store",
+			})),
+			want: false,
+		},
+		{
+			name: "wired up via reports=puppetdb only",
+			cfg: newConfig("c", withDatabaseRef("db"), withPuppetSpec(openvoxv1alpha1.PuppetSpec{
+				Storeconfigs: false,
+				Reports:      "puppetdb",
+			})),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderRoutesYAML(tt.cfg)
+			if tt.want {
+				for _, want := range []string{"master:", "facts:", "terminus: puppetdb", "cache: json"} {
+					if !strings.Contains(got, want) {
+						t.Errorf("routes.yaml missing %q\n---\n%s", want, got)
+					}
+				}
+			} else if got != "" {
+				t.Errorf("expected empty routes.yaml, got:\n%s", got)
+			}
+		})
+	}
+}
+
 func TestRenderMetricsConf(t *testing.T) {
 	r := newConfigReconciler(setupTestClient())
 

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -244,6 +244,16 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 		configMapVolume("metrics-conf", configMapName, "metrics.conf"),
 	}
 
+	// routes.yaml routes the facts terminus to PuppetDB. Mounted only when PuppetDB
+	// is the active backend, matching the ConfigMap key rendered by the Config
+	// controller (SubPath mounts require the key to exist).
+	if puppetDBActiveForFacts(cfg) {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name: "routes-yaml", MountPath: "/etc/puppetlabs/puppet/routes.yaml", SubPath: "routes.yaml", ReadOnly: true,
+		})
+		volumes = append(volumes, configMapVolume("routes-yaml", configMapName, "routes.yaml"))
+	}
+
 	// Non-CA pods: mount CRL secret as directory (NOT SubPath) for kubelet auto-sync,
 	// and use the standard webserver.conf pointing to the CRL secret mount.
 	// CA pods: no CRL volume (Puppetserver manages CRL from PVC), use webserver-ca.conf.

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -123,6 +123,45 @@ func TestBuildPodSpec_CARole(t *testing.T) {
 	}
 }
 
+func TestBuildPodSpec_RoutesYAMLMount(t *testing.T) {
+	routesMount := func(podSpec corev1.PodSpec) *corev1.VolumeMount {
+		for i, vm := range podSpec.Containers[0].VolumeMounts {
+			if vm.Name == "routes-yaml" {
+				return &podSpec.Containers[0].VolumeMounts[i]
+			}
+		}
+		return nil
+	}
+
+	// PuppetDB wired up -> routes.yaml mounted at $confdir/routes.yaml.
+	cfgWithDB := newConfig("production", withDatabaseRef("production-db"))
+	server := newServer("test-server", withServerRole(true))
+	podSpec := testBuildPodSpec(server, cfgWithDB)
+
+	vm := routesMount(podSpec)
+	if vm == nil {
+		t.Fatal("server pod should mount routes-yaml when PuppetDB is the active backend")
+	}
+	if vm.MountPath != "/etc/puppetlabs/puppet/routes.yaml" || vm.SubPath != "routes.yaml" {
+		t.Errorf("unexpected routes.yaml mount: path=%q subPath=%q", vm.MountPath, vm.SubPath)
+	}
+	hasVol := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == "routes-yaml" {
+			hasVol = true
+		}
+	}
+	if !hasVol {
+		t.Error("server pod should have a routes-yaml volume")
+	}
+
+	// No PuppetDB wired up -> no routes.yaml mount (SubPath would fail on a missing key).
+	cfgNoDB := newConfig("production")
+	if routesMount(testBuildPodSpec(server, cfgNoDB)) != nil {
+		t.Error("server pod should not mount routes-yaml when PuppetDB is not wired up")
+	}
+}
+
 func TestBuildPodSpec_MultipleCodeVolumes(t *testing.T) {
 	cfg := newConfig("production", withCodeList(
 		openvoxv1alpha1.CodeSpec{Image: "ghcr.io/slauger/prod:latest", Environment: "production"},

--- a/tests/e2e/database-cnpg/chainsaw-test.yaml
+++ b/tests/e2e/database-cnpg/chainsaw-test.yaml
@@ -4,6 +4,13 @@ metadata:
   name: database-cnpg
 spec:
   namespace: e2e-database-cnpg
+  bindings:
+    - name: registry
+      value: (env('IMAGE_REGISTRY') || 'ghcr.io/slauger')
+    - name: imageTag
+      value: (env('IMAGE_TAG') || 'latest')
+    - name: major
+      value: (env('OPENVOX_MAJOR') || '8')
   steps:
     - name: Install CNPG PostgreSQL cluster
       try:
@@ -42,7 +49,7 @@ spec:
                 --set config.image.tag="${IMAGE_TAG}" \
                 --set config.image.pullPolicy=Always \
                 --set database.image.repository=${IMAGE_REGISTRY}/openvox-db-${OPENVOX_MAJOR:-8} \
-                --set database.image.tag=latest \
+                --set database.image.tag="${IMAGE_TAG}" \
                 --set database.image.pullPolicy=Always
       catch:
         - events: {}
@@ -91,6 +98,106 @@ spec:
                 ports:
                   - port: 8081
 
+    - name: Assert Server is Running
+      try:
+        - assert:
+            resource:
+              apiVersion: openvox.voxpupuli.org/v1alpha1
+              kind: Server
+              metadata:
+                name: openvox-stack-db-ca
+              status:
+                phase: Running
+                ready: 1
+                desired: 1
+
+    - name: Verify routes.yaml routes facts to PuppetDB
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              set -eu
+              NS=e2e-database-cnpg
+              # The operator must render routes.yaml (facts terminus -> puppetdb) into
+              # the Config ConfigMap and mount it, otherwise facts never reach PuppetDB.
+              ROUTES=$(kubectl get configmap openvox-stack-db-config -n "${NS}" \
+                -o jsonpath='{.data.routes\.yaml}')
+              echo "routes.yaml:"; echo "${ROUTES}"
+              echo "${ROUTES}" | grep -qF 'terminus: puppetdb' \
+                || { echo "ERROR: routes.yaml does not route facts to puppetdb"; exit 1; }
+
+              POD=$(kubectl get pods -n "${NS}" \
+                -l openvox.voxpupuli.org/server=openvox-stack-db-ca \
+                -o jsonpath='{.items[0].metadata.name}')
+              kubectl exec "${POD}" -n "${NS}" -- \
+                cat /etc/puppetlabs/puppet/routes.yaml | grep -qF 'terminus: puppetdb' \
+                || { echo "ERROR: routes.yaml not mounted into the server pod"; exit 1; }
+              echo "OK: routes.yaml renders and is mounted with the puppetdb facts terminus"
+
+    - name: Run a Puppet agent so it submits facts
+      try:
+        - apply:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: puppet-agent-facts
+                namespace: e2e-database-cnpg
+              spec:
+                backoffLimit: 0
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: puppet-agent
+                        image: (join('', [$registry, '/openvox-agent-', $major, ':', $imageTag]))
+                        imagePullPolicy: Always
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            puppet agent --test \
+                              --server openvox-stack-db-server \
+                              --waitforcert 30 \
+                              --certname agent-db-facts-test;
+                            EXIT=$?;
+                            if [ $EXIT -eq 0 ] || [ $EXIT -eq 2 ]; then exit 0; else exit $EXIT; fi
+                        securityContext:
+                          runAsUser: 0
+        - script:
+            timeout: 5m
+            content: |
+              kubectl wait --for=condition=Complete job/puppet-agent-facts \
+                -n e2e-database-cnpg --timeout=300s
+
+    - name: Assert the agent's facts landed in PuppetDB
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              set -eu
+              NS=e2e-database-cnpg
+              CERTNAME=agent-db-facts-test
+              # PuppetDB ingests commands asynchronously, so poll the query API (plain
+              # HTTP on localhost inside the puppetdb pod) until the node's facts appear.
+              found=0
+              for i in $(seq 1 30); do
+                OUT=$(kubectl exec deploy/openvox-stack-db-puppetdb -n "${NS}" -- \
+                  curl -sf "http://127.0.0.1:8080/pdb/query/v4/facts" 2>/dev/null || true)
+                if echo "${OUT}" | grep -q "\"${CERTNAME}\""; then
+                  found=1
+                  echo "OK: PuppetDB has facts for ${CERTNAME}"
+                  break
+                fi
+                echo "waiting for facts to be ingested (${i})..."
+                sleep 5
+              done
+              if [ "${found}" -ne 1 ]; then
+                echo "ERROR: no facts for ${CERTNAME} in PuppetDB (routes.yaml facts terminus not effective)"
+                kubectl exec deploy/openvox-stack-db-puppetdb -n "${NS}" -- \
+                  curl -sf "http://127.0.0.1:8080/pdb/query/v4/nodes" 2>/dev/null || true
+                exit 1
+              fi
+
     - name: Check operator logs for errors (warning only)
       try:
         - script:
@@ -118,6 +225,7 @@ spec:
         - script:
             timeout: 2m
             content: |
+              kubectl logs -n e2e-database-cnpg job/puppet-agent-facts || true
               helm uninstall openvox-stack-db --namespace e2e-database-cnpg --wait 2>/dev/null || true
               helm uninstall pg-cluster --namespace e2e-database-cnpg --wait 2>/dev/null || true
               kubectl delete namespace e2e-database-cnpg --ignore-not-found 2>/dev/null || true


### PR DESCRIPTION
Fixes #512.

## Problem

PuppetDB has three independent commands: `replace catalog`, `store report`, and `replace facts`. The operator wired up the first two (`storeconfigs_backend = puppetdb`, `reports = puppetdb`) but **rendered no `routes.yaml`**, so the facts indirector terminus was never switched to `puppetdb` and the `replace facts` command was never issued. Result: PuppetDB fact tables stay empty — breaking PQL / `puppetdb_query()` on facts, inventory / node fact age, and dashboard fact views. Catalogs (incl. exported resources) and reports were unaffected.

## Fix

Render `routes.yaml` and mount it at `$confdir/routes.yaml` (Puppet's default `route_file`) whenever PuppetDB is the active backend:

```yaml
master:
  facts:
    terminus: puppetdb
    cache: json
```

Condition: a `databaseRef` or `puppetdb.serverUrls` is set **and** `storeBackend`/`reports` use `puppetdb`. When PuppetDB is not the active backend, neither the ConfigMap key nor the mount is emitted (so a SubPath mount never references a missing key).

It is part of the Config ConfigMap, which is already hashed into the Server pod template, so a change rolls the pods automatically — no extra hash annotation needed. Puppet's `route_file` already defaults to this path, so no `puppet.conf` change is required.

## Open questions from the issue

- Verified the `openvox-server` image ships no default `routes.yaml` (the operator mounts none, and the e2e now checks the mounted file).
- Facts cache is fixed to `json` (the `puppetlabs-puppetdb` module default). Making it configurable can be a small follow-up if needed — deliberately kept out to avoid a CRD change here.
- Only rendered when PuppetDB is the active backend (no empty `routes.yaml` forced otherwise).

## Tests

- Unit: `renderRoutesYAML` truth table (databaseRef / serverUrls / reports=puppetdb / disabled), ConfigMap contains/omits `routes.yaml`, and the server pod mounts/omits it.
- E2E (`database-cnpg`): run a Puppet agent, then poll the PuppetDB query API until the node's facts appear; also assert `routes.yaml` is rendered and mounted. Additionally fixes the database image tag (`latest` → `IMAGE_TAG`) so the test pulls the build under test.

## Docs

Added a **Fact Storage** section to the Database concept and noted `routes.yaml` in the Config reference.