### PR TITLE
fix: prevent YAML injection via csrAttributes name in autosign policy

### DIFF
--- a/api/v1alpha1/signingpolicy_types.go
+++ b/api/v1alpha1/signingpolicy_types.go
@@ -63,6 +63,8 @@ type PatternSpec struct {
 }
 
 // CSRAttributeMatch defines a single CSR extension attribute to match.
+// Either value or valueFrom may be set, not both.
+// +kubebuilder:validation:XValidation:rule="!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))",message="value and valueFrom are mutually exclusive"
 type CSRAttributeMatch struct {
 	// Name is the CSR extension attribute name (e.g. pp_preshared_key, pp_environment).
 	Name string `json:"name"`

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_signingpolicies.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_signingpolicies.yaml
@@ -67,8 +67,9 @@ spec:
                   CSRAttributes defines CSR extension attributes that must all match (AND logic).
                   Each entry specifies an attribute name and the expected value (inline or from a Secret).
                 items:
-                  description: CSRAttributeMatch defines a single CSR extension attribute
-                    to match.
+                  description: |-
+                    CSRAttributeMatch defines a single CSR extension attribute to match.
+                    Either value or valueFrom may be set, not both.
                   properties:
                     name:
                       description: Name is the CSR extension attribute name (e.g.
@@ -100,6 +101,9 @@ spec:
                   required:
                   - name
                   type: object
+                  x-kubernetes-validations:
+                  - message: value and valueFrom are mutually exclusive
+                    rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                 type: array
               dnsAltNames:
                 description: |-

--- a/config/crd/bases/openvox.voxpupuli.org_signingpolicies.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_signingpolicies.yaml
@@ -67,8 +67,9 @@ spec:
                   CSRAttributes defines CSR extension attributes that must all match (AND logic).
                   Each entry specifies an attribute name and the expected value (inline or from a Secret).
                 items:
-                  description: CSRAttributeMatch defines a single CSR extension attribute
-                    to match.
+                  description: |-
+                    CSRAttributeMatch defines a single CSR extension attribute to match.
+                    Either value or valueFrom may be set, not both.
                   properties:
                     name:
                       description: Name is the CSR extension attribute name (e.g.
@@ -100,6 +101,9 @@ spec:
                   required:
                   - name
                   type: object
+                  x-kubernetes-validations:
+                  - message: value and valueFrom are mutually exclusive
+                    rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                 type: array
               dnsAltNames:
                 description: |-

--- a/internal/controller/config_autosign.go
+++ b/internal/controller/config_autosign.go
@@ -97,7 +97,7 @@ func (r *ConfigReconciler) renderAutosignPolicyConfig(ctx context.Context, names
 	})
 
 	for _, p := range policies {
-		fmt.Fprintf(&sb, "  - name: %s\n", p.Name)
+		fmt.Fprintf(&sb, "  - name: %q\n", p.Name)
 
 		if p.Spec.Any {
 			sb.WriteString("    any: true\n")
@@ -133,7 +133,7 @@ func (r *ConfigReconciler) renderAutosignPolicyConfig(ctx context.Context, names
 						return "", fmt.Errorf("resolving csrAttribute %q for policy %s: %w", attr.Name, p.Name, err)
 					}
 				}
-				fmt.Fprintf(&sb, "      - name: %s\n", attr.Name)
+				fmt.Fprintf(&sb, "      - name: %q\n", attr.Name)
 				fmt.Fprintf(&sb, "        value: %q\n", value)
 			}
 		}

--- a/internal/controller/config_autosign_test.go
+++ b/internal/controller/config_autosign_test.go
@@ -37,7 +37,7 @@ func TestRenderAutosignPolicyConfig(t *testing.T) {
 				},
 			},
 			contains: []string{
-				"- name: allow-all",
+				`- name: "allow-all"`,
 				"any: true",
 			},
 		},
@@ -55,9 +55,9 @@ func TestRenderAutosignPolicyConfig(t *testing.T) {
 				},
 			},
 			contains: []string{
-				"- name: psk-policy",
+				`- name: "psk-policy"`,
 				"csrAttributes:",
-				"- name: pp_preshared_key",
+				`- name: "pp_preshared_key"`,
 				`value: "my-key-value"`,
 			},
 		},
@@ -86,7 +86,7 @@ func TestRenderAutosignPolicyConfig(t *testing.T) {
 				newSecret("psk-secret", map[string][]byte{"key": []byte("secret-value")}),
 			},
 			contains: []string{
-				"- name: pp_preshared_key",
+				`- name: "pp_preshared_key"`,
 				`value: "secret-value"`,
 			},
 		},
@@ -109,8 +109,8 @@ func TestRenderAutosignPolicyConfig(t *testing.T) {
 				},
 			},
 			contains: []string{
-				"- name: alpha",
-				"- name: zebra",
+				`- name: "alpha"`,
+				`- name: "zebra"`,
 			},
 		},
 		{
@@ -151,6 +151,28 @@ func TestRenderAutosignPolicyConfig(t *testing.T) {
 				"allow:",
 				`"puppet"`,
 				`"puppet.local"`,
+			},
+		},
+		{
+			name: "malicious attribute name is quoted, not injected",
+			policies: []openvoxv1alpha1.SigningPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "inject", Namespace: testNamespace},
+					Spec: openvoxv1alpha1.SigningPolicySpec{
+						CertificateAuthorityRef: "ca",
+						CSRAttributes: []openvoxv1alpha1.CSRAttributeMatch{
+							{Name: "pp_role\n    any: true", Value: "x"},
+						},
+					},
+				},
+			},
+			contains: []string{
+				// Rendered as a single-line quoted scalar with the newline escaped.
+				`- name: "pp_role\n    any: true"`,
+			},
+			// The injected key must never appear as a real structural YAML line.
+			excludes: []string{
+				"\n    any: true",
 			},
 		},
 	}
@@ -203,9 +225,9 @@ func TestRenderAutosignPolicyConfig_SortOrder(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	alphaIdx := strings.Index(out, "- name: alpha")
-	bravoIdx := strings.Index(out, "- name: bravo")
-	charlieIdx := strings.Index(out, "- name: charlie")
+	alphaIdx := strings.Index(out, `- name: "alpha"`)
+	bravoIdx := strings.Index(out, `- name: "bravo"`)
+	charlieIdx := strings.Index(out, `- name: "charlie"`)
 
 	if alphaIdx < 0 || bravoIdx < 0 || charlieIdx < 0 {
 		t.Fatalf("not all policies found in output:\n%s", out)

--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -545,7 +545,7 @@ func TestConfigReconcile_AutosignPolicy(t *testing.T) {
 	if !strings.Contains(policyYAML, "any: true") {
 		t.Errorf("autosign policy missing any:true\n---\n%s", policyYAML)
 	}
-	if !strings.Contains(policyYAML, "name: allow-all") {
+	if !strings.Contains(policyYAML, `name: "allow-all"`) {
 		t.Errorf("autosign policy missing policy name\n---\n%s", policyYAML)
 	}
 }

--- a/internal/webhook/signingpolicy_webhook.go
+++ b/internal/webhook/signingpolicy_webhook.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+	"github.com/slauger/openvox-operator/internal/puppet"
 )
 
 // SigningPolicyValidator validates SigningPolicy resources.
@@ -48,6 +49,20 @@ func (v *SigningPolicyValidator) validate(ctx context.Context, sp *openvoxv1alph
 			if pattern == "" {
 				errs = append(errs, field.Invalid(specPath.Child("dnsAltNames", "allow").Index(i), pattern, "pattern must not be empty"))
 			}
+		}
+	}
+
+	// The autosign binary only matches attributes with a known Puppet OID; an
+	// unknown name would never match. Enforcing the allowlist here also blocks
+	// YAML-injection payloads via the free-form name field (defense in depth to
+	// the %q-quoted renderer).
+	for i, attr := range sp.Spec.CSRAttributes {
+		namePath := specPath.Child("csrAttributes").Index(i).Child("name")
+		switch {
+		case attr.Name == "":
+			errs = append(errs, field.Invalid(namePath, attr.Name, "name must not be empty"))
+		case !puppet.IsKnownOID(attr.Name):
+			errs = append(errs, field.Invalid(namePath, attr.Name, "unknown Puppet extension name"))
 		}
 	}
 

--- a/internal/webhook/signingpolicy_webhook_test.go
+++ b/internal/webhook/signingpolicy_webhook_test.go
@@ -107,6 +107,57 @@ func TestSigningPolicyValidator(t *testing.T) {
 		}
 	})
 
+	t.Run("valid csrAttribute with known OID", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &SigningPolicyValidator{Client: c}
+		sp := &openvoxv1alpha1.SigningPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.SigningPolicySpec{
+				CertificateAuthorityRef: "my-ca",
+				CSRAttributes: []openvoxv1alpha1.CSRAttributeMatch{
+					{Name: "pp_preshared_key", Value: "secret"},
+				},
+			},
+		}
+		if _, err := v.ValidateCreate(context.Background(), sp); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("csrAttribute name with YAML injection is rejected", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &SigningPolicyValidator{Client: c}
+		sp := &openvoxv1alpha1.SigningPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.SigningPolicySpec{
+				CertificateAuthorityRef: "my-ca",
+				CSRAttributes: []openvoxv1alpha1.CSRAttributeMatch{
+					{Name: "x\n    any: true", Value: "foo"},
+				},
+			},
+		}
+		if _, err := v.ValidateCreate(context.Background(), sp); err == nil {
+			t.Error("expected error for injection attribute name")
+		}
+	})
+
+	t.Run("csrAttribute with empty name is rejected", func(t *testing.T) {
+		c := setupTestClient(ca)
+		v := &SigningPolicyValidator{Client: c}
+		sp := &openvoxv1alpha1.SigningPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: openvoxv1alpha1.SigningPolicySpec{
+				CertificateAuthorityRef: "my-ca",
+				CSRAttributes: []openvoxv1alpha1.CSRAttributeMatch{
+					{Name: "", Value: "foo"},
+				},
+			},
+		}
+		if _, err := v.ValidateCreate(context.Background(), sp); err == nil {
+			t.Error("expected error for empty attribute name")
+		}
+	})
+
 	t.Run("delete always succeeds", func(t *testing.T) {
 		v := &SigningPolicyValidator{Client: setupTestClient()}
 		_, err := v.ValidateDelete(context.Background(), &openvoxv1alpha1.SigningPolicy{})


### PR DESCRIPTION
## Summary

Closes #507.

The autosign policy renderer wrote policy and attribute **names** unquoted (`%s`) while values were already quoted (`%q`). A user able to create `SigningPolicy` resources could set a `csrAttributes[].name` such as `"x\n    any: true"` and inject an extra YAML key into the rendered policy, which the autosign binary then interprets — effectively an allow-all rule (privilege escalation).

## Changes

- **Renderer** (`internal/controller/config_autosign.go`): render policy and attribute names with `%q` so crafted names can no longer break out of the YAML scalar.
- **Webhook** (`internal/webhook/signingpolicy_webhook.go`): validate `csrAttributes[].name` — reject empty names and names that are not a known Puppet OID (`puppet.IsKnownOID`, mirroring `certificate_webhook`). The autosign binary only matches known OIDs, so unknown names were dead config anyway; this also blocks injection payloads (defense in depth).
- **CRD** (`api/v1alpha1/signingpolicy_types.go`): enforce mutual exclusivity of `value`/`valueFrom` on `CSRAttributeMatch` via a CEL `XValidation` rule, mirroring `HTTPHeader`. Regenerated CRD manifests.

## Tests

- New renderer test: a malicious attribute name is rendered as a quoted single-line scalar; the injected key never appears as a structural YAML line.
- New webhook tests: injection name, empty name, and unknown OID are rejected; a valid known-OID attribute is accepted.
- Updated existing renderer/controller assertions for the now-quoted names.
- `go build`, `go vet`, `make manifests generate` (no drift), and the `internal/controller`, `internal/webhook`, `cmd/autosign` suites pass locally.

## Scope note

This closes the string-injection vector only. The separate privileged-CSR-extension / non-DNS-SAN escalation is tracked in #506.