### PR TITLE
chore(renovate): mark release-relevant deps as fix commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,7 +66,8 @@
       "matchManagers": [
         "gomod"
       ],
-      "groupName": "Go dependencies"
+      "groupName": "Go dependencies",
+      "semanticCommitType": "fix"
     },
     {
       "matchManagers": [
@@ -78,7 +79,8 @@
       "matchManagers": [
         "dockerfile"
       ],
-      "groupName": "Container base images"
+      "groupName": "Container base images",
+      "semanticCommitType": "fix"
     },
     {
       "matchManagers": [
@@ -92,7 +94,8 @@
       ],
       "matchCurrentValue": "/^8\\./",
       "allowedVersions": "<9.0.0",
-      "groupName": "OpenVox 8 versions"
+      "groupName": "OpenVox 8 versions",
+      "semanticCommitType": "fix"
     },
     {
       "matchManagers": [
@@ -107,7 +110,8 @@
       "matchCurrentValue": "/^9\\./",
       "allowedVersions": ">=9.0.0",
       "ignoreUnstable": false,
-      "groupName": "OpenVox 9 versions"
+      "groupName": "OpenVox 9 versions",
+      "semanticCommitType": "fix"
     },
     {
       "matchManagers": [


### PR DESCRIPTION
## Problem

Renovate committet alle Dependency-Updates als `chore(deps): …`. Da semantic-release (Angular-Preset) nur `fix`/`feat` als release-relevant wertet, lösen z.B. Security-Updates der Container Base Images **keinen** neuen Release aus (siehe #532).

## Änderung

`semanticCommitType: fix` auf den release-relevanten Grouping-Rules gesetzt:

| Kategorie | Manager | vorher | nachher | Release |
|---|---|---|---|---|
| Container base images | `dockerfile` | `chore(deps)` | `fix(deps)` | ✅ patch |
| Go dependencies | `gomod` | `chore(deps)` | `fix(deps)` | ✅ patch |
| OpenVox 8/9 versions | `custom.regex` | `chore(deps)` | `fix(deps)` | ✅ patch |
| CI tooling / GitHub Actions | — | `chore(deps)` | *(unverändert)* | ❌ kein Release |

Der Renovate-Default-Scope `deps` bleibt erhalten. CI-Tooling, hadolint/shellcheck/conforma und GitHub Actions bleiben bewusst `chore`, da sie nicht ins ausgelieferte Artefakt einfließen.

## Hinweis

Greift erst für **neue** Renovate-PRs; bereits offene PRs behalten ihren `chore`-Titel, bis Renovate sie neu erstellt.