### PR TITLE
fix(controller): let terminating certificates release the CA finalizer

### DIFF
--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -133,6 +133,11 @@ resource in `Terminating` with a `DeletionBlocked` condition naming the
 certificates that are in the way. With the admission webhooks enabled the
 delete is rejected outright instead, so you get the answer immediately.
 
+A Certificate that is itself being deleted does not hold the CA back -- only one
+nobody asked to remove does. That is what lets `kubectl delete namespace` finish:
+everything is marked for deletion at once, and the CA would otherwise wait for
+Certificates whose own cleanup needs the CA service that is going away with it.
+
 To delete a CertificateAuthority on purpose, remove the Certificates first:
 
 ```console

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -239,11 +239,19 @@ func (r *CertificateAuthorityReconciler) handleDeletion(ctx context.Context, ca 
 		return ctrl.Result{}, fmt.Errorf("checking Certificates before deleting CertificateAuthority %s: %w", ca.Name, err)
 	}
 
-	if len(certs) > 0 {
-		blocking := make([]string, 0, len(certs))
-		for i := range certs {
+	// A Certificate that is itself being deleted is not in use any more, so it
+	// must not hold the CA back. Counting those too deadlocks namespace
+	// deletion: everything is marked for deletion at once, the Certificate
+	// finalizers need the CA service to revoke on, and the CA waits for exactly
+	// those Certificates to disappear.
+	blocking := make([]string, 0, len(certs))
+	for i := range certs {
+		if certs[i].DeletionTimestamp.IsZero() {
 			blocking = append(blocking, certs[i].Name)
 		}
+	}
+
+	if len(blocking) > 0 {
 		sort.Strings(blocking)
 		msg := fmt.Sprintf("%d Certificate(s) still reference this CA: %s", len(blocking), strings.Join(blocking, ", "))
 		logger.Info("CertificateAuthority deletion blocked", "certificates", blocking)

--- a/internal/controller/certificateauthority_deletion_test.go
+++ b/internal/controller/certificateauthority_deletion_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -134,5 +135,89 @@ func TestCAReconcile_DeletionDoesNotRunSetup(t *testing.T) {
 	}
 	if len(pvcList.Items) > 0 {
 		t.Errorf("a CA being deleted must not create the CA data PVC, found %d", len(pvcList.Items))
+	}
+}
+
+// TestCAReconcile_DeletionNotBlockedByTerminatingCertificates is the case that
+// broke namespace teardown.
+//
+// Deleting a namespace marks everything at once. The Certificate finalizers
+// then need the CA service to revoke against, while the CA waits for exactly
+// those Certificates to disappear -- so the CA has to treat a Certificate that
+// is already being deleted as no longer in use.
+func TestCAReconcile_DeletionNotBlockedByTerminatingCertificates(t *testing.T) {
+	now := metav1.Now()
+	ca := newCertificateAuthority("production-ca")
+	ca.DeletionTimestamp = &now
+	ca.Finalizers = []string{certificateAuthorityFinalizer}
+
+	terminating := newCertificate("web-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	terminating.DeletionTimestamp = &now
+	terminating.Finalizers = []string{certificateFinalizer}
+
+	c := setupTestClient(ca, terminating)
+	r := newCertificateAuthorityReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("production-ca"))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a CA whose certificates are all terminating should not keep waiting, got %v", res.RequeueAfter)
+	}
+
+	got := &openvoxv1alpha1.CertificateAuthority{}
+	getErr := c.Get(testCtx(), types.NamespacedName{Name: "production-ca", Namespace: testNamespace}, got)
+	switch {
+	case apierrors.IsNotFound(getErr):
+	case getErr != nil:
+		t.Fatalf("reading CertificateAuthority: %v", getErr)
+	case controllerutil.ContainsFinalizer(got, certificateAuthorityFinalizer):
+		t.Error("the finalizer must be released when every referencing certificate is already terminating")
+	}
+}
+
+// TestCAReconcile_DeletionBlockedByLiveCertificateAmongTerminating keeps the
+// guarantee intact: one certificate nobody asked to delete is enough to hold
+// the CA.
+func TestCAReconcile_DeletionBlockedByLiveCertificateAmongTerminating(t *testing.T) {
+	now := metav1.Now()
+	ca := newCertificateAuthority("production-ca")
+	ca.DeletionTimestamp = &now
+	ca.Finalizers = []string{certificateAuthorityFinalizer}
+
+	terminating := newCertificate("old-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	terminating.DeletionTimestamp = &now
+	terminating.Finalizers = []string{certificateFinalizer}
+	live := newCertificate("web-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+
+	c := setupTestClient(ca, terminating, live)
+	r := newCertificateAuthorityReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("production-ca"))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Error("expected the controller to keep waiting while a live certificate references the CA")
+	}
+
+	got := &openvoxv1alpha1.CertificateAuthority{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-ca", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("the CertificateAuthority must still exist: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, certificateAuthorityFinalizer) {
+		t.Fatal("the finalizer must not be released while a live certificate exists")
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionCADeletionBlocked)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected a DeletionBlocked condition, got %+v", got.Status.Conditions)
+	}
+	if strings.Contains(cond.Message, "old-cert") {
+		t.Errorf("a terminating certificate must not be listed as blocking: %q", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "web-cert") {
+		t.Errorf("the live certificate should be named as blocking: %q", cond.Message)
 	}
 }


### PR DESCRIPTION
## Summary

The CA protection finalizer added in #549 stalls namespace deletion. Found by
the first e2e run after that merge
([run 33512951692](https://github.com/slauger/openvox-operator/actions/runs/33512951692)).

## What happened

Every assertion in `single-node` passed -- CertificateAuthority Ready, Config
Running, Server Running, no error-level operator logs. The job failed in the
`finally` step:

```
| Check operator logs for errors (warning only) | FINALLY | BEGIN |
| CMD | RUN | helm uninstall openvox-stack-single --namespace e2e-single-node --wait
              kubectl delete namespace e2e-single-node --ignore-not-found
13:27:35 -> 13:32:38  (5 minutes)
=== ERROR
signal: killed
```

## Why

Deleting a namespace marks every object for deletion at once, and then:

1. Each `Certificate` gets a deletion timestamp. Its finalizer calls the CA HTTP
   API to revoke -- but the CA Deployment and Service are being deleted too, so
   the call fails and retries (`maxCleanupAttempts` x `RequeueIntervalLong`).
2. `handleDeletion` on the CertificateAuthority counted *every* Certificate
   referencing it, including the ones already terminating, and refused to release
   its finalizer.

So the CA waited for Certificates whose own cleanup needed the CA service that
was disappearing along with it. Teardown only completed once the certificate
cleanup exhausted its retry budget, which took longer than the step allowed.

Before #549 the CA had no finalizer, so it disappeared immediately and the
namespace only waited for the Certificate finalizers. The new finalizer stacked
another wait on top of that.

## Fix

A Certificate carrying a deletion timestamp is no longer in use, so it no longer
counts as blocking. A Certificate nobody asked to delete still does -- which is
the case the finalizer exists for.

This keeps the guarantee from #549 intact: `kubectl delete certificateauthority`
on a CA with live Certificates is still refused, with the blocking names in the
`DeletionBlocked` condition.

## Tests

- `TestCAReconcile_DeletionNotBlockedByTerminatingCertificates` -- the case that
  broke teardown
- `TestCAReconcile_DeletionBlockedByLiveCertificateAmongTerminating` -- one live
  certificate among terminating ones still blocks, and the terminating one is
  not named in the condition message

Both were run against the previous implementation to confirm they fail on it:

```
--- FAIL: TestCAReconcile_DeletionNotBlockedByTerminatingCertificates
    a CA whose certificates are all terminating should not keep waiting, got 15s
    the finalizer must be released when every referencing certificate is already terminating
```

## Verification

`make test`, `make lint` and `make check-manifests` are green. E2E needs a
re-run against this branch to confirm the teardown completes.
