### PR TITLE
fix(controller): do not let a CA-owned certificate block its own deletion

### DIFF
--- a/docs/reference/certificate.md
+++ b/docs/reference/certificate.md
@@ -36,6 +36,19 @@ spec:
 | `notAfter` | time | Expiry time of the signed certificate |
 | `conditions` | []Condition | `CertSigned` |
 
+## Deletion
+
+Deleting a Certificate revokes it on the CA before the finalizer
+(`openvox.voxpupuli.org/certificate-cleanup`) is released, so the certificate
+cannot be used again. If the CA cannot be reached the controller retries a few
+times and then releases the finalizer anyway, rather than leaving the resource
+stuck in `Terminating`.
+
+Revocation is skipped when the CertificateAuthority is itself being deleted --
+there is nothing left to revoke against, and its Service is on its way out. This
+is what lets `kubectl delete namespace` finish promptly: every object is marked
+for deletion at the same moment.
+
 ## Phases
 
 | Phase | Description |

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -518,6 +518,16 @@ func (r *CertificateReconciler) handleCertificateCleanup(ctx context.Context, ce
 		return fmt.Errorf("getting CertificateAuthority %s for cleanup: %w", cert.Spec.AuthorityRef, err)
 	}
 
+	// A CA that is itself being deleted has nothing left to revoke against, and
+	// its Service is on its way out. Trying anyway means running into the HTTP
+	// timeout on every attempt until the retry budget is spent, which is what
+	// makes namespace deletion crawl: every object is marked at once, so the
+	// certificates and their CA go away together.
+	if !ca.DeletionTimestamp.IsZero() {
+		logger.Info("skipping CA cleanup, the CertificateAuthority is being deleted", "ca", ca.Name)
+		return nil
+	}
+
 	// Skip cleanup for external CAs without a signing secret (no admin access)
 	if ca.Spec.External != nil || ca.Status.SigningSecretName == "" {
 		logger.Info("skipping CA cleanup (external CA or no signing secret)", "ca", ca.Name)

--- a/internal/controller/certificate_teardown_test.go
+++ b/internal/controller/certificate_teardown_test.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// TestCertReconcile_CleanupSkippedWhenCAIsTerminating covers the second half of
+// the namespace teardown deadlock.
+//
+// Deleting a namespace marks everything at once. A certificate that still tries
+// to revoke against its CA then talks to a Service whose endpoints are already
+// gone -- a ClusterIP with no backends drops the packets rather than refusing
+// them, so every attempt burns the full HTTP timeout. With the retry budget
+// that is 5 x 30s plus 4 x 15s of requeue, per certificate, which is what made
+// the e2e cleanup step time out.
+//
+// A CA that is being deleted has nothing left to revoke against, so the
+// certificate releases its finalizer immediately.
+func TestCertReconcile_CleanupSkippedWhenCAIsTerminating(t *testing.T) {
+	now := metav1.Now()
+
+	ca := newCertificateAuthority("production-ca")
+	ca.DeletionTimestamp = &now
+	ca.Finalizers = []string{certificateAuthorityFinalizer}
+	ca.Status.SigningSecretName = "production-ca-signing-tls"
+
+	cert := newCertificate("web-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.DeletionTimestamp = &now
+	cert.Finalizers = []string{certificateFinalizer}
+
+	c := setupTestClient(ca, cert)
+	r := newCertificateReconciler(c)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := r.Reconcile(testCtx(), testRequest("web-cert")); err != nil {
+			t.Errorf("reconcile: %v", err)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the reconcile is still running; the cleanup must not attempt to reach a CA that is going away")
+	}
+
+	got := &openvoxv1alpha1.Certificate{}
+	err := c.Get(testCtx(), types.NamespacedName{Name: "web-cert", Namespace: testNamespace}, got)
+	switch {
+	case apierrors.IsNotFound(err):
+	case err != nil:
+		t.Fatalf("reading Certificate: %v", err)
+	case controllerutil.ContainsFinalizer(got, certificateFinalizer):
+		t.Error("the finalizer must be released when the CA is being deleted too")
+	}
+	if got.Annotations[AnnotationCleanupAttempts] != "" {
+		t.Errorf("no cleanup attempt should have been recorded, got %q", got.Annotations[AnnotationCleanupAttempts])
+	}
+}
+
+// TestCertReconcile_CleanupStillRunsForLiveCA keeps the guarantee: deleting a
+// single certificate while its CA is healthy still revokes it.
+func TestCertReconcile_CleanupStillRunsForLiveCA(t *testing.T) {
+	now := metav1.Now()
+
+	ca := newCertificateAuthority("production-ca")
+	ca.Status.SigningSecretName = "production-ca-signing-tls"
+
+	cert := newCertificate("web-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	cert.DeletionTimestamp = &now
+	cert.Finalizers = []string{certificateFinalizer}
+
+	c := setupTestClient(ca, cert)
+	r := newCertificateReconciler(c)
+
+	// Signing against a CA that has no reachable service fails, which is the
+	// point: the attempt is made and recorded rather than skipped.
+	if _, err := r.Reconcile(testCtx(), testRequest("web-cert")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "web-cert", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading Certificate: %v", err)
+	}
+	if got.Annotations[AnnotationCleanupAttempts] == "" {
+		t.Error("a live CA must still be asked to revoke the certificate")
+	}
+	if !controllerutil.ContainsFinalizer(got, certificateFinalizer) {
+		t.Error("the finalizer must be held while cleanup is still being retried")
+	}
+}

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -239,16 +239,24 @@ func (r *CertificateAuthorityReconciler) handleDeletion(ctx context.Context, ca 
 		return ctrl.Result{}, fmt.Errorf("checking Certificates before deleting CertificateAuthority %s: %w", ca.Name, err)
 	}
 
-	// A Certificate that is itself being deleted is not in use any more, so it
-	// must not hold the CA back. Counting those too deadlocks namespace
-	// deletion: everything is marked for deletion at once, the Certificate
-	// finalizers need the CA service to revoke on, and the CA waits for exactly
-	// those Certificates to disappear.
+	// Only Certificates that can outlive the CA may hold it back.
+	//
+	// One that is already being deleted is on its way out: counting it would
+	// stall namespace deletion, where everything is marked at once and the
+	// Certificate finalizers need the very CA service that is going away.
+	//
+	// One the CA owns cannot outlive it either -- garbage collection removes it
+	// together with its owner. The operator-signing Certificate is exactly that,
+	// and counting it deadlocks outright: the CA waits for a Certificate that
+	// only disappears once the CA is gone. That is what made `helm uninstall
+	// --wait` hang until its own timeout.
 	blocking := make([]string, 0, len(certs))
 	for i := range certs {
-		if certs[i].DeletionTimestamp.IsZero() {
-			blocking = append(blocking, certs[i].Name)
+		cert := &certs[i]
+		if !cert.DeletionTimestamp.IsZero() || metav1.IsControlledBy(cert, ca) {
+			continue
 		}
+		blocking = append(blocking, cert.Name)
 	}
 
 	if len(blocking) > 0 {

--- a/internal/controller/certificateauthority_deletion_test.go
+++ b/internal/controller/certificateauthority_deletion_test.go
@@ -221,3 +221,87 @@ func TestCAReconcile_DeletionBlockedByLiveCertificateAmongTerminating(t *testing
 		t.Errorf("the live certificate should be named as blocking: %q", cond.Message)
 	}
 }
+
+// TestCAReconcile_DeletionNotBlockedByOwnedCertificate is the deadlock that
+// made `helm uninstall --wait` hang.
+//
+// The operator-signing Certificate is created by the CA controller and carries
+// a controller reference to the CA, so garbage collection removes it together
+// with its owner. Counting it as blocking means the CA waits for a Certificate
+// that can only disappear once the CA itself is gone -- and unlike during
+// namespace deletion, nothing else marks it for deletion to break the cycle.
+func TestCAReconcile_DeletionNotBlockedByOwnedCertificate(t *testing.T) {
+	now := metav1.Now()
+	ca := newCertificateAuthority("production-ca")
+	ca.UID = "ca-uid"
+	ca.DeletionTimestamp = &now
+	ca.Finalizers = []string{certificateAuthorityFinalizer}
+
+	owned := newCertificate("production-ca-operator-signing", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	ownedBy(ca, owned)
+
+	c := setupTestClient(ca, owned)
+	r := newCertificateAuthorityReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("production-ca"))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a CA must not wait for a Certificate it owns, got %v", res.RequeueAfter)
+	}
+
+	got := &openvoxv1alpha1.CertificateAuthority{}
+	getErr := c.Get(testCtx(), types.NamespacedName{Name: "production-ca", Namespace: testNamespace}, got)
+	switch {
+	case apierrors.IsNotFound(getErr):
+	case getErr != nil:
+		t.Fatalf("reading CertificateAuthority: %v", getErr)
+	case controllerutil.ContainsFinalizer(got, certificateAuthorityFinalizer):
+		t.Error("the finalizer must be released when the only certificate is owned by the CA")
+	}
+}
+
+// TestCAReconcile_DeletionStillBlockedByIndependentCertificate keeps the
+// protection: a Certificate the user created stands on its own and does block.
+func TestCAReconcile_DeletionStillBlockedByIndependentCertificate(t *testing.T) {
+	now := metav1.Now()
+	ca := newCertificateAuthority("production-ca")
+	ca.UID = "ca-uid"
+	ca.DeletionTimestamp = &now
+	ca.Finalizers = []string{certificateAuthorityFinalizer}
+
+	owned := newCertificate("production-ca-operator-signing", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	ownedBy(ca, owned)
+	independent := newCertificate("web-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+
+	c := setupTestClient(ca, owned, independent)
+	r := newCertificateAuthorityReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("production-ca"))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Error("expected the controller to keep waiting for the independent certificate")
+	}
+
+	got := &openvoxv1alpha1.CertificateAuthority{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "production-ca", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("the CertificateAuthority must still exist: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, certificateAuthorityFinalizer) {
+		t.Fatal("the finalizer must not be released while an independent certificate exists")
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionCADeletionBlocked)
+	if cond == nil {
+		t.Fatal("expected a DeletionBlocked condition")
+	}
+	if strings.Contains(cond.Message, "operator-signing") {
+		t.Errorf("a certificate owned by the CA must not be listed as blocking: %q", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "web-cert") {
+		t.Errorf("the independent certificate should be named: %q", cond.Message)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the teardown deadlock introduced by the CA protection finalizer in #549.
Reproduced and verified against a live cluster.

**#559 did not fix it, and my reasoning behind it was wrong.** That PR assumed
the blocker was a *terminating* Certificate; the actual blocker is the
operator-signing Certificate, which is not terminating at all. The change in
#559 is still correct, it just addressed a different case.

## What actually happens

The CA controller creates a `<ca>-operator-signing` Certificate and gives it a
controller reference to the CA
(`certificateauthority_signing.go`, `SetControllerReference(ca, newCert, ...)`),
so garbage collection removes it together with its owner.

`helm uninstall --wait` deletes the CA. That Certificate is not helm-managed, so
it stays. The finalizer then counts it as blocking -- and it can only disappear
once the CA is gone. Nothing marks it for deletion independently, so the cycle
never breaks. Helm waits out its timeout, and only the `kubectl delete namespace`
that follows breaks the deadlock by marking everything at once.

Measured on the cluster:

```
19:44:43  delete certificateauthority
19:45:18  ca=1  certs=[...-operator-signing]  blocked="1 Certificate(s) still reference this CA"
   ...    unchanged for 90s
19:47:04  delete the operator-signing certificate by hand
19:47:05  ca=0                                             <- released within a second
```

The full CI sequence reproduced locally took **5m39s**, matching the e2e
failures. During all of it the `cleanup-attempts` annotation stayed empty, which
is what ruled out the retry-timeout theory this PR originally carried.

## Fix

Only Certificates that can outlive the CA hold it back. A Certificate the CA
owns cannot -- it is garbage-collected with its owner.

A second, smaller change in the first commit: a Certificate skips revocation
when its CA is already terminating. There is nothing left to revoke against and
the CA Service is going away, so the attempt would only burn the HTTP timeout on
each of its retries. Not required for the deadlock, but it keeps namespace
teardown from paying `5 x 30s + 4 x 15s` per certificate in the window where the
CA still exists.

Deletion behaviour after this PR:

| Situation | Result |
|---|---|
| CA sees a Certificate it owns | does not block (this PR) |
| CA sees a terminating Certificate | does not block (#559) |
| CA sees a Certificate the user created | still refuses to be deleted |
| Certificate sees a terminating CA | skips revocation (first commit here) |
| Certificate sees a healthy CA | still revokes before releasing |

## Tests

- `TestCAReconcile_DeletionNotBlockedByOwnedCertificate` -- the deadlock
- `TestCAReconcile_DeletionStillBlockedByIndependentCertificate` -- the
  protection is intact, and the owned certificate is not named in the condition
- `TestCertReconcile_CleanupSkippedWhenCAIsTerminating`
- `TestCertReconcile_CleanupStillRunsForLiveCA`

All four fail against the previous implementation.

## Verification

`make test`, `make lint` and `make check-manifests` are green. Controller
coverage 83.0% -> 83.5%.

The deadlock itself was reproduced and the fix mechanism confirmed on the e2e
cluster, not only in unit tests. A full e2e run is still needed to confirm the
groups beyond `e2e-base`, which have never executed against #549.
