### PR TITLE
fix(chart): derive service names into the certificates that need them

### DIFF
--- a/charts/openvox-stack/templates/certificates.yaml
+++ b/charts/openvox-stack/templates/certificates.yaml
@@ -13,6 +13,15 @@ spec:
     {{- if ne $serverName "puppet" }}
     {{- $autoNames = append $autoNames "puppet" }}
     {{- end }}
+    {{- /* Agents reach a server through the Services of the Pools it joins, so
+           those names have to be in the certificate or the TLS handshake fails. */}}
+    {{- range $poolRef := ($entry.poolRefs | default list) }}
+    {{- range $pool := ($.Values.pools | default list) }}
+    {{- if eq $pool.name $poolRef }}
+    {{- $autoNames = append $autoNames (include "openvox-stack.poolName" (dict "root" $ "entry" $pool)) }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
     {{- $allNames := concat $autoNames ($entry.certificate.dnsAltNames | default list) | uniq }}
     {{- toYaml $allNames | nindent 4 }}
 {{- end }}

--- a/charts/openvox-stack/templates/database.yaml
+++ b/charts/openvox-stack/templates/database.yaml
@@ -19,10 +19,14 @@ metadata:
 spec:
   authorityRef: {{ include "openvox-stack.caName" . }}
   certname: {{ .Values.database.certificate.certname }}
-  {{- with .Values.database.certificate.dnsAltNames }}
   dnsAltNames:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- /* The server connects to the Database through its Service, using the FQDN
+           the operator publishes in status.url, so the certificate has to cover
+           those names. */}}
+    {{- $svc := .Values.database.name }}
+    {{- $autoNames := list $svc (printf "%s.%s.svc" $svc .Release.Namespace) (printf "%s.%s.svc.cluster.local" $svc .Release.Namespace) }}
+    {{- $allNames := concat $autoNames (.Values.database.certificate.dnsAltNames | default list) | uniq }}
+    {{- toYaml $allNames | nindent 4 }}
 ---
 apiVersion: openvox.voxpupuli.org/v1alpha1
 kind: Database

--- a/tests/e2e/database-cnpg/chainsaw-test.yaml
+++ b/tests/e2e/database-cnpg/chainsaw-test.yaml
@@ -223,7 +223,9 @@ spec:
               echo "No error-level log entries found."
       finally:
         - script:
-            timeout: 2m
+            # CNPG shuts PostgreSQL down gracefully, which alone takes several
+            # minutes; the default budget is not enough for this namespace.
+            timeout: 10m
             content: |
               kubectl logs -n e2e-database-cnpg job/puppet-agent-facts || true
               helm uninstall openvox-stack-db --namespace e2e-database-cnpg --wait 2>/dev/null || true


### PR DESCRIPTION
## Summary

Makes `database-cnpg` pass. Verified locally against the e2e cluster: the test
now completes with `Passed tests 1`.

Two certificates were missing the names they are presented under, so any TLS
connection that went through a Service failed. Neither is specific to the test.

## The server certificate did not cover its Pool Services

Agents connect to a server through the Services of the Pools it joins, but the
certificate only carried the server name and `puppet`:

```
Error: Server hostname 'openvox-stack-db-server' did not match server certificate;
expected one of puppet, DNS:puppet, DNS:openvox-stack-db-ca,
DNS:openvox-stack-db-ca-internal.e2e-database-cnpg.svc
```

Every other agent test hides this by listing the pool Service names in its
values file by hand -- see `agent-basic-values.yaml`, which carries four of
them. `database-cnpg` was added later (932aa8d, 6 Aug) without that list, so its
agent could never connect. The last green run of this test was 5 Aug, the day
before, and no complete e2e run has happened since.

## The Database certificate had no alt names at all

The Database controller publishes its Service FQDN in `status.url`
(`database_controller.go:181`) and the Config controller renders exactly that
into `puppetdb.conf`. The certificate was issued for `CN=puppetdb` only, so
catalogs compiled but every write to PuppetDB failed:

```
javax.net.ssl.SSLPeerUnverifiedException: Host name
'openvox-stack-db-puppetdb.e2e-database-cnpg.svc.cluster.local' does not match
the certificate subject provided by the peer (CN=puppetdb)
```

The agent run itself reported success, which is why this surfaced only as
"no facts in PuppetDB".

## Fix

The chart knows both sets of names, so it derives them:

- server certificates gain the Service name of every Pool in their `poolRefs`
- the Database certificate gains its Service name, `.svc` and `.svc.cluster.local`

Both are merged with anything the user supplied and deduplicated. That matters
now: `dnsAltNames` became a `listType=set` in #549, so a duplicate would be
rejected outright.

The manual lists in the existing values files stay valid and simply dedupe away.

## Teardown budget

The `database-cnpg` finally step goes from 2 to 10 minutes. Measured on the
cluster, the openvox resources are gone within seconds; what takes about five
minutes is CNPG shutting PostgreSQL down gracefully. That is CNPG's own
behaviour and not something to tune away in a chart users may copy.

## Verification

```
make e2e-run-test TEST=database-cnpg IMAGE_TAG=develop
- Passed  tests 1
- Failed  tests 0
```

`make helm-lint` and `make helm-unittest` are green. Rendering
`agent-basic-values.yaml` was checked to confirm the manual entries produce no
duplicates.

Relates to #550: this is the second case where the e2e suite passed without
exercising what it claimed to.
