### PR TITLE
docs: document the CRD update step for helm upgrade

### DIFF
--- a/charts/openvox-operator/README.md
+++ b/charts/openvox-operator/README.md
@@ -26,6 +26,20 @@ helm install openvox-operator oci://ghcr.io/slauger/charts/openvox-operator
 To deploy a complete OpenVox stack after installing the operator, use the
 [openvox-stack](https://github.com/slauger/openvox-operator/tree/main/charts/openvox-stack) chart.
 
+## Upgrading
+
+Helm does not update CRDs on `helm upgrade`. Apply the CRDs of the target
+version before upgrading the release, otherwise the operator runs against the
+schema that was installed first:
+
+```bash
+helm pull oci://ghcr.io/slauger/charts/openvox-operator --version "$VERSION" --untar
+kubectl apply -f openvox-operator/crds/
+helm upgrade openvox-operator oci://ghcr.io/slauger/charts/openvox-operator --version "$VERSION"
+```
+
+See [Installation](https://slauger.github.io/openvox-operator/getting-started/installation/) for details.
+
 ## Maintainers
 
 | Name | Email | Url |

--- a/charts/openvox-operator/README.md.gotmpl
+++ b/charts/openvox-operator/README.md.gotmpl
@@ -25,6 +25,20 @@ helm install openvox-operator oci://ghcr.io/slauger/charts/openvox-operator
 To deploy a complete OpenVox stack after installing the operator, use the
 [openvox-stack](https://github.com/slauger/openvox-operator/tree/main/charts/openvox-stack) chart.
 
+## Upgrading
+
+Helm does not update CRDs on `helm upgrade`. Apply the CRDs of the target
+version before upgrading the release, otherwise the operator runs against the
+schema that was installed first:
+
+```bash
+helm pull oci://ghcr.io/slauger/charts/openvox-operator --version "$VERSION" --untar
+kubectl apply -f openvox-operator/crds/
+helm upgrade openvox-operator oci://ghcr.io/slauger/charts/openvox-operator --version "$VERSION"
+```
+
+See [Installation](https://slauger.github.io/openvox-operator/getting-started/installation/) for details.
+
 {{ template "chart.maintainersSection" . }}
 {{ template "chart.sourcesSection" . }}
 {{ template "chart.valuesSection" . }}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -53,6 +53,34 @@ helm install openvox-operator \
 
 In namespace mode the operator uses Role/RoleBinding instead of ClusterRole/ClusterRoleBinding and only reconciles resources in the configured namespace.
 
+## Upgrading
+
+Helm installs the CRDs from the chart's `crds/` directory on the first install,
+but [does not update them on `helm upgrade`](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/).
+An operator upgraded with `helm upgrade` alone keeps running against the CRDs of
+whatever version was installed first: new spec fields are rejected, and status
+fields the operator writes are silently stripped by the API server. The symptom
+is a status that never fills in, which does not point at the CRDs.
+
+Apply the CRDs of the target version before upgrading the release:
+
+```bash
+VERSION=<target-version>
+
+helm pull oci://ghcr.io/slauger/charts/openvox-operator \
+  --version "$VERSION" --untar
+
+kubectl apply -f openvox-operator/crds/
+
+helm upgrade openvox-operator \
+  oci://ghcr.io/slauger/charts/openvox-operator \
+  --namespace openvox-system \
+  --version "$VERSION"
+```
+
+Applying the CRDs is additive and safe to repeat. Existing custom resources are
+left untouched; only the schema is updated.
+
 ## Next Steps
 
 Once the operator is running, follow the [Quick Start](quickstart.md) guide to deploy an OpenVox stack. The Quick Start uses the [`openvox-stack`](https://ghcr.io/slauger/charts/openvox-stack) Helm chart which bundles all required custom resources into a single install command.


### PR DESCRIPTION
Helm installs a chart's `crds/` directory on the first install and never updates it on `helm upgrade`. An operator upgraded with `helm upgrade` alone keeps running against the schema that was installed first: new spec fields are rejected, and status fields the operator writes are stripped by the API server. The symptom is a status that never fills in, which points away from the actual cause.

This is not hypothetical for #549, which added `observedGeneration` to all nine status types, `signedSpecHash` to Certificate and conditions to Pool.

## Changes

- New **Upgrading** section in `docs/getting-started/installation.md` with the `helm pull` / `kubectl apply -f crds/` / `helm upgrade` sequence, and a note that applying the CRDs is additive and safe to repeat.
- A short pointer in the operator chart README, via `README.md.gotmpl` and regenerated with helm-docs 1.14.2 (the version CI pins).

Documentation only, no behaviour change.

The separate CRD chart and the pre-upgrade hook Job remain open as the longer-term options, as does the missing upgrade e2e scenario; #555 keeps that record.

Closes #555