### PR TITLE
fix(controller): make status, metrics and hostname conflicts honest

### DIFF
--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -24,6 +24,10 @@ This passes `--metrics-bind-address=0` to the operator and removes the metrics p
 | `openvox_server_replicas_desired` | Gauge | `name`, `namespace` | Desired number of replicas for a Server CR |
 | `openvox_server_replicas_ready` | Gauge | `name`, `namespace` | Number of ready replicas for a Server CR |
 | `openvox_certificate_expiry_timestamp_seconds` | Gauge | `name`, `namespace` | Unix timestamp when a certificate or CA expires |
+| `openvox_crl_last_refresh_timestamp_seconds` | Gauge | `name`, `namespace` | Unix timestamp of the last successful CRL refresh for a CertificateAuthority |
+
+All series are removed when the resource they describe is deleted, so alerts
+do not keep firing for objects that no longer exist.
 
 ### Controller-Runtime Metrics
 
@@ -108,6 +112,22 @@ Alert when a certificate expires within 30 days:
         annotations:
           summary: "OpenVox certificate {{ $labels.name }} expires soon"
           description: "{{ $labels.name }} in {{ $labels.namespace }} expires in {{ $value | humanizeDuration }}"
+```
+
+### Stale CRL
+
+A CRL that is no longer refreshed means revoked agents keep being accepted.
+Alert when the last successful refresh is more than a day old:
+
+```yaml
+      - alert: OpenVoxCRLStale
+        expr: time() - openvox_crl_last_refresh_timestamp_seconds > 24 * 3600
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "OpenVox CRL for {{ $labels.name }} is stale"
+          description: "The CRL of {{ $labels.name }} in {{ $labels.namespace }} was last refreshed {{ $value | humanizeDuration }} ago, so revoked agents may still be accepted"
 ```
 
 ### CA Expiring

--- a/docs/reference/pool.md
+++ b/docs/reference/pool.md
@@ -55,6 +55,23 @@ spec:
 |---|---|---|
 | `serviceName` | string | Name of the created Kubernetes Service |
 | `endpoints` | int32 | Number of pods behind the Service |
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from |
+| `conditions` | []Condition | See below |
+
+### Conditions
+
+The `Ready` condition reports whether the Pool can actually carry traffic:
+
+| Reason | Status | Meaning |
+|---|---|---|
+| `EndpointsAvailable` | True | At least one ready Server pod is behind the Service |
+| `NoEndpoints` | False | The Service exists but no ready Server pod selects it |
+| `HostnameConflict` | False | Another Pool holds `route.hostname`, so no TLSRoute is created |
+
+A hostname can only be claimed by one Pool. When several ask for the same one,
+the oldest Pool keeps it and the others report `HostnameConflict` naming the
+holder. This is not retried: it resolves when the holder gives up the hostname
+or is deleted, or when the losing Pool is given a different one.
 
 ## Created Resources
 

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -82,6 +82,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	cert := &openvoxv1alpha1.Certificate{}
 	if err := r.Get(ctx, req.NamespacedName, cert); err != nil {
 		if errors.IsNotFound(err) {
+			forgetCertificateMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("getting Certificate %s: %w", req.NamespacedName, err)
@@ -115,6 +116,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
 				}
 			}
+			forgetCertificateMetrics(cert.Name, cert.Namespace)
 			patch := client.MergeFrom(cert.DeepCopy())
 			controllerutil.RemoveFinalizer(cert, certificateFinalizer)
 			if err := r.Patch(ctx, cert, patch); err != nil {

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -66,6 +66,7 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, req.NamespacedName, ca); err != nil {
 		if errors.IsNotFound(err) {
+			forgetCertificateAuthorityMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("getting CertificateAuthority %s: %w", req.NamespacedName, err)
@@ -281,6 +282,7 @@ func (r *CertificateAuthorityReconciler) handleDeletion(ctx context.Context, ca 
 	}
 
 	logger.Info("no Certificates left, releasing CertificateAuthority finalizer", "name", ca.Name)
+	forgetCertificateAuthorityMetrics(ca.Name, ca.Namespace)
 	patch := client.MergeFrom(ca.DeepCopy())
 	controllerutil.RemoveFinalizer(ca, certificateAuthorityFinalizer)
 	if err := r.Patch(ctx, ca, patch); err != nil {

--- a/internal/controller/certificateauthority_crl.go
+++ b/internal/controller/certificateauthority_crl.go
@@ -46,6 +46,8 @@ func (r *CertificateAuthorityReconciler) reconcileCRLRefresh(ctx context.Context
 		return ctrl.Result{}, fmt.Errorf("updating CRL secret: %w", err)
 	}
 
+	crlLastRefreshTimestamp.WithLabelValues(ca.Name, ca.Namespace).Set(float64(time.Now().Unix()))
+
 	logger.Info("CRL secret refreshed", "secret", crlSecretName, "nextRefresh", interval)
 	r.Recorder.Eventf(ca, nil, corev1.EventTypeNormal, EventReasonCRLRefreshed, "Reconcile", "CRL refreshed successfully, next refresh in %s", interval)
 	return ctrl.Result{RequeueAfter: interval}, nil

--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -164,7 +164,10 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// Update status
-	ready := r.getReadyReplicas(ctx, db)
+	ready, err := r.getReadyReplicas(ctx, db)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("reading ready replicas for Database %s: %w", db.Name, err)
+	}
 	if err := updateStatusWithRetry(ctx, r.Client, db, func() {
 		replicas := int32(1)
 		if db.Spec.Replicas != nil {
@@ -303,12 +306,18 @@ func (r *DatabaseReconciler) reconcileService(ctx context.Context, db *openvoxv1
 	return nil
 }
 
-func (r *DatabaseReconciler) getReadyReplicas(ctx context.Context, db *openvoxv1alpha1.Database) int32 {
+// getReadyReplicas reports how many replicas of the Database Deployment are
+// ready. A missing Deployment counts as zero; any other error is returned so a
+// transient lookup failure does not masquerade as an idle workload.
+func (r *DatabaseReconciler) getReadyReplicas(ctx context.Context, db *openvoxv1alpha1.Database) (int32, error) {
 	deploy := &appsv1.Deployment{}
 	if err := r.Get(ctx, types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, deploy); err != nil {
-		return 0
+		if errors.IsNotFound(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("getting Deployment %s: %w", db.Name, err)
 	}
-	return deploy.Status.ReadyReplicas
+	return deploy.Status.ReadyReplicas, nil
 }
 
 func (r *DatabaseReconciler) reconcilePDB(ctx context.Context, db *openvoxv1alpha1.Database) error {

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -29,6 +29,17 @@ var (
 		},
 		[]string{"name", "namespace"},
 	)
+
+	// crlLastRefreshTimestamp makes a stalled CRL refresh alertable. A CRL that
+	// is no longer being updated means revoked agents keep being accepted, and
+	// nothing else in the status surfaces that.
+	crlLastRefreshTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "openvox_crl_last_refresh_timestamp_seconds",
+			Help: "Unix timestamp of the last successful CRL refresh for a CertificateAuthority.",
+		},
+		[]string{"name", "namespace"},
+	)
 )
 
 func init() {
@@ -36,5 +47,33 @@ func init() {
 		serverReplicasDesired,
 		serverReplicasReady,
 		certificateExpiryTimestamp,
+		crlLastRefreshTimestamp,
 	)
+}
+
+// A gauge series outlives the resource it describes unless it is removed
+// explicitly: the client library keeps every label combination it has ever
+// seen. Without this an alert on a deleted Server keeps firing, expiry alerts
+// fire for certificates nobody holds any more, and a cluster with churn grows
+// its series count without bound.
+//
+// All of these are safe to call for a resource that never had a series.
+
+// forgetServerMetrics drops the replica gauges for a Server that is gone.
+func forgetServerMetrics(name, namespace string) {
+	serverReplicasDesired.DeleteLabelValues(name, namespace)
+	serverReplicasReady.DeleteLabelValues(name, namespace)
+}
+
+// forgetCertificateMetrics drops the expiry gauge for a Certificate that is
+// gone.
+func forgetCertificateMetrics(name, namespace string) {
+	certificateExpiryTimestamp.DeleteLabelValues(name, namespace)
+}
+
+// forgetCertificateAuthorityMetrics drops the gauges a CertificateAuthority
+// reports under its own name.
+func forgetCertificateAuthorityMetrics(name, namespace string) {
+	certificateExpiryTimestamp.DeleteLabelValues(name, namespace)
+	crlLastRefreshTimestamp.DeleteLabelValues(name, namespace)
 }

--- a/internal/controller/metrics_cleanup_test.go
+++ b/internal/controller/metrics_cleanup_test.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// TestMetrics_ServerSeriesRemovedOnDeletion covers the series that used to
+// outlive its Server: an alert on replicas_ready == 0 kept firing for a
+// resource that no longer existed.
+func TestMetrics_ServerSeriesRemovedOnDeletion(t *testing.T) {
+	serverReplicasDesired.Reset()
+	serverReplicasReady.Reset()
+	serverReplicasDesired.WithLabelValues("gone", testNamespace).Set(3)
+	serverReplicasReady.WithLabelValues("gone", testNamespace).Set(3)
+
+	// The Server is absent from the client, which is what the controller sees
+	// once the object has been collected.
+	r := newServerReconciler(setupTestClient())
+	if _, err := r.Reconcile(testCtx(), testRequest("gone")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if n := testutil.CollectAndCount(serverReplicasDesired); n != 0 {
+		t.Errorf("openvox_server_replicas_desired still reports %d series for a deleted Server", n)
+	}
+	if n := testutil.CollectAndCount(serverReplicasReady); n != 0 {
+		t.Errorf("openvox_server_replicas_ready still reports %d series for a deleted Server", n)
+	}
+}
+
+// TestMetrics_ServerSeriesOfOtherResourcesSurvive guards the cleanup against
+// being too eager: only the deleted Server loses its series.
+func TestMetrics_ServerSeriesOfOtherResourcesSurvive(t *testing.T) {
+	serverReplicasReady.Reset()
+	serverReplicasReady.WithLabelValues("gone", testNamespace).Set(1)
+	serverReplicasReady.WithLabelValues("still-there", testNamespace).Set(2)
+
+	r := newServerReconciler(setupTestClient())
+	if _, err := r.Reconcile(testCtx(), testRequest("gone")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if n := testutil.CollectAndCount(serverReplicasReady); n != 1 {
+		t.Errorf("expected exactly the surviving Server series, got %d", n)
+	}
+	if v := testutil.ToFloat64(serverReplicasReady.WithLabelValues("still-there", testNamespace)); v != 2 {
+		t.Errorf("the surviving Server lost its value: got %v, want 2", v)
+	}
+}
+
+// TestMetrics_CertificateExpirySeriesRemovedOnDeletion stops expiry alerts from
+// firing for certificates nobody holds any more.
+func TestMetrics_CertificateExpirySeriesRemovedOnDeletion(t *testing.T) {
+	certificateExpiryTimestamp.Reset()
+	certificateExpiryTimestamp.WithLabelValues("gone", testNamespace).Set(1)
+
+	r := newCertificateReconciler(setupTestClient())
+	if _, err := r.Reconcile(testCtx(), testRequest("gone")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if n := testutil.CollectAndCount(certificateExpiryTimestamp); n != 0 {
+		t.Errorf("openvox_certificate_expiry_timestamp_seconds still reports %d series for a deleted Certificate", n)
+	}
+}
+
+// TestMetrics_CARemovesSeriesWhenFinalizerIsReleased takes the path a real
+// deletion goes through, rather than the NotFound safety net: the CA is
+// terminating, nothing references it, and the finalizer is released.
+func TestMetrics_CARemovesSeriesWhenFinalizerIsReleased(t *testing.T) {
+	certificateExpiryTimestamp.Reset()
+	crlLastRefreshTimestamp.Reset()
+	certificateExpiryTimestamp.WithLabelValues("production-ca", testNamespace).Set(1)
+	crlLastRefreshTimestamp.WithLabelValues("production-ca", testNamespace).Set(1)
+
+	now := metav1.Now()
+	ca := newCertificateAuthority("production-ca")
+	ca.DeletionTimestamp = &now
+	ca.Finalizers = []string{certificateAuthorityFinalizer}
+
+	r := newCertificateAuthorityReconciler(setupTestClient(ca))
+	if _, err := r.Reconcile(testCtx(), testRequest("production-ca")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if n := testutil.CollectAndCount(certificateExpiryTimestamp); n != 0 {
+		t.Errorf("the CA expiry series survived the finalizer release: %d series left", n)
+	}
+	if n := testutil.CollectAndCount(crlLastRefreshTimestamp); n != 0 {
+		t.Errorf("the CRL refresh series survived the finalizer release: %d series left", n)
+	}
+}
+
+// TestMetrics_CASeriesSurviveBlockedDeletion is the counterpart: while the
+// deletion is held back by a Certificate, the CA still exists and its series
+// must keep reporting.
+func TestMetrics_CASeriesSurviveBlockedDeletion(t *testing.T) {
+	certificateExpiryTimestamp.Reset()
+	crlLastRefreshTimestamp.Reset()
+	certificateExpiryTimestamp.WithLabelValues("production-ca", testNamespace).Set(1)
+	crlLastRefreshTimestamp.WithLabelValues("production-ca", testNamespace).Set(1)
+
+	now := metav1.Now()
+	ca := newCertificateAuthority("production-ca")
+	ca.DeletionTimestamp = &now
+	ca.Finalizers = []string{certificateAuthorityFinalizer}
+	cert := newCertificate("production-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+
+	r := newCertificateAuthorityReconciler(setupTestClient(ca, cert))
+	if _, err := r.Reconcile(testCtx(), testRequest("production-ca")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if n := testutil.CollectAndCount(certificateExpiryTimestamp); n != 1 {
+		t.Errorf("the CA expiry series was dropped while the CA still exists: %d series left", n)
+	}
+	if n := testutil.CollectAndCount(crlLastRefreshTimestamp); n != 1 {
+		t.Errorf("the CRL refresh series was dropped while the CA still exists: %d series left", n)
+	}
+}

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -79,56 +79,46 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("reconciling Service: %w", err)
 	}
 
-	// Reconcile TLSRoute
+	// Reconcile TLSRoute. conflictWith names the Pool that owns the requested
+	// hostname when it is not this one, so the single status update below can
+	// report it.
+	var conflictWith string
 	if pool.Spec.Route != nil && pool.Spec.Route.Enabled {
 		if !r.GatewayAPIAvailable {
 			logger.Info("TLSRoute requested but Gateway API CRDs not available, skipping")
 		} else {
-			// Check for hostname conflicts
-			allPools := &openvoxv1alpha1.PoolList{}
-			if err := r.List(ctx, allPools, client.InNamespace(pool.Namespace)); err != nil {
-				return ctrl.Result{}, fmt.Errorf("listing Pools for hostname conflict check: %w", err)
+			owner, err := r.hostnameOwner(ctx, pool)
+			if err != nil {
+				return ctrl.Result{}, err
 			}
-			hasConflict := false
-			for i := range allPools.Items {
-				other := &allPools.Items[i]
-				if other.Name == pool.Name {
-					continue
+
+			if owner.Name != pool.Name {
+				// Losing the hostname is a permanent condition: nothing about
+				// it improves by waiting, only a spec change resolves it. It is
+				// reported and left alone rather than retried, and the loser
+				// gives up any TLSRoute it may still hold from an earlier round.
+				conflictWith = owner.Name
+				logger.Info("hostname already claimed by another Pool, skipping TLSRoute",
+					"hostname", pool.Spec.Route.Hostname, "owner", owner.Name)
+				if err := r.deleteOwnedTLSRoute(ctx, pool); err != nil {
+					return ctrl.Result{}, err
 				}
-				if other.Spec.Route != nil && other.Spec.Route.Enabled && other.Spec.Route.Hostname == pool.Spec.Route.Hostname {
-					logger.Error(fmt.Errorf("hostname %q already used by Pool %q", pool.Spec.Route.Hostname, other.Name),
-						"hostname conflict detected, skipping TLSRoute reconciliation")
-					hasConflict = true
-					break
+			} else {
+				if err := r.reconcileTLSRoute(ctx, pool); err != nil {
+					return ctrl.Result{}, fmt.Errorf("reconciling TLSRoute: %w", err)
 				}
-			}
 
-			if hasConflict {
-				r.Recorder.Eventf(pool, nil, corev1.EventTypeWarning, EventReasonHostnameConflict, "Reconcile", "Hostname %q is already used by another Pool", pool.Spec.Route.Hostname)
-				return ctrl.Result{}, fmt.Errorf("hostname conflict: %q is already used by another Pool", pool.Spec.Route.Hostname)
-			}
-
-			if err := r.reconcileTLSRoute(ctx, pool); err != nil {
-				return ctrl.Result{}, fmt.Errorf("reconciling TLSRoute: %w", err)
-			}
-
-			if pool.Spec.Route.InjectDNSAltName {
-				if err := r.injectDNSAltNames(ctx, pool); err != nil {
-					return ctrl.Result{}, fmt.Errorf("injecting DNS alt names: %w", err)
+				if pool.Spec.Route.InjectDNSAltName {
+					if err := r.injectDNSAltNames(ctx, pool); err != nil {
+						return ctrl.Result{}, fmt.Errorf("injecting DNS alt names: %w", err)
+					}
 				}
 			}
 		}
 	} else if r.GatewayAPIAvailable {
 		// Cleanup: delete owned TLSRoute if route is disabled
-		existing := &gwapiv1.TLSRoute{}
-		if err := r.Get(ctx, types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}, existing); err == nil {
-			if metav1.IsControlledBy(existing, pool) {
-				logger.Info("deleting orphaned TLSRoute", "name", pool.Name)
-				if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
-					return ctrl.Result{}, fmt.Errorf("deleting orphaned TLSRoute: %w", err)
-				}
-				r.Recorder.Eventf(pool, nil, corev1.EventTypeNormal, EventReasonTLSRouteDeleted, "Reconcile", "TLSRoute %s deleted", pool.Name)
-			}
+		if err := r.deleteOwnedTLSRoute(ctx, pool); err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -137,6 +127,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("counting endpoints for Pool %s: %w", pool.Name, err)
 	}
+	previousConditions := pool.Status.DeepCopy().Conditions
 	if err := updateStatusWithRetry(ctx, r.Client, pool, func() {
 		pool.Status.ObservedGeneration = pool.Generation
 		pool.Status.ServiceName = pool.Name
@@ -145,7 +136,16 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		// A Pool is only useful once something is behind its Service. Reporting
 		// that separately from "the Service exists" is what tells an operator
 		// whether traffic can actually reach a server.
-		if endpoints > 0 {
+		switch {
+		case conflictWith != "":
+			meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionPoolReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "HostnameConflict",
+				Message:            hostnameConflictMessage(pool.Spec.Route.Hostname, conflictWith),
+				ObservedGeneration: pool.Generation,
+			})
+		case endpoints > 0:
 			meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
 				Type:               openvoxv1alpha1.ConditionPoolReady,
 				Status:             metav1.ConditionTrue,
@@ -153,7 +153,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 				Message:            fmt.Sprintf("%d ready endpoint(s) behind Service %s", endpoints, pool.Name),
 				ObservedGeneration: pool.Generation,
 			})
-		} else {
+		default:
 			meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
 				Type:               openvoxv1alpha1.ConditionPoolReady,
 				Status:             metav1.ConditionFalse,
@@ -166,14 +166,107 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("updating Pool status %s: %w", pool.Name, err)
 	}
 
+	// The event follows the condition so it fires once per transition rather
+	// than on every reconcile.
+	if conflictWith != "" && !wasConflictingWith(previousConditions, pool.Spec.Route.Hostname, conflictWith) {
+		r.Recorder.Eventf(pool, nil, corev1.EventTypeWarning, EventReasonHostnameConflict, "Reconcile",
+			"%s", hostnameConflictMessage(pool.Spec.Route.Hostname, conflictWith))
+	}
+
 	return ctrl.Result{}, nil
+}
+
+// hostnameConflictMessage is shared by the condition and the event so the two
+// cannot drift apart, which is what makes the transition check below reliable.
+func hostnameConflictMessage(hostname, owner string) string {
+	return fmt.Sprintf("Hostname %q is already claimed by Pool %s", hostname, owner)
+}
+
+// wasConflictingWith reports whether the Pool already carried this exact
+// conflict before the status update.
+func wasConflictingWith(conditions []metav1.Condition, hostname, owner string) bool {
+	cond := meta.FindStatusCondition(conditions, openvoxv1alpha1.ConditionPoolReady)
+	return cond != nil &&
+		cond.Status == metav1.ConditionFalse &&
+		cond.Reason == "HostnameConflict" &&
+		cond.Message == hostnameConflictMessage(hostname, owner)
+}
+
+// hostnameOwner returns the Pool entitled to the route hostname this Pool asks
+// for, which may be the Pool itself.
+//
+// Listing and comparing is inherently racy: two Pools reconciled concurrently
+// can both observe a free hostname and both create a TLSRoute for it. Deciding
+// the winner by a property every observer agrees on -- the oldest
+// creationTimestamp, with the name as tie-breaker, since the API server stores
+// timestamps at second granularity -- makes them converge on the same Pool
+// instead of fighting over the route.
+func (r *PoolReconciler) hostnameOwner(ctx context.Context, pool *openvoxv1alpha1.Pool) (*openvoxv1alpha1.Pool, error) {
+	all := &openvoxv1alpha1.PoolList{}
+	if err := r.List(ctx, all, client.InNamespace(pool.Namespace)); err != nil {
+		return nil, fmt.Errorf("listing Pools for the hostname conflict check: %w", err)
+	}
+
+	owner := pool
+	for i := range all.Items {
+		other := &all.Items[i]
+		switch {
+		case other.Name == pool.Name:
+			continue
+		// A Pool on its way out releases its claim, otherwise a stuck deletion
+		// would keep the hostname hostage.
+		case !other.DeletionTimestamp.IsZero():
+			continue
+		case other.Spec.Route == nil || !other.Spec.Route.Enabled:
+			continue
+		case other.Spec.Route.Hostname != pool.Spec.Route.Hostname:
+			continue
+		}
+		if claimPrecedes(other, owner) {
+			owner = other
+		}
+	}
+	return owner, nil
+}
+
+// claimPrecedes orders two competing claims on the same hostname.
+func claimPrecedes(a, b *openvoxv1alpha1.Pool) bool {
+	if !a.CreationTimestamp.Equal(&b.CreationTimestamp) {
+		return a.CreationTimestamp.Before(&b.CreationTimestamp)
+	}
+	return a.Name < b.Name
+}
+
+// deleteOwnedTLSRoute removes the TLSRoute this Pool created, if it still owns
+// one. A route it does not control is left alone.
+func (r *PoolReconciler) deleteOwnedTLSRoute(ctx context.Context, pool *openvoxv1alpha1.Pool) error {
+	logger := log.FromContext(ctx)
+
+	existing := &gwapiv1.TLSRoute{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}, existing); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("getting TLSRoute %s: %w", pool.Name, err)
+	}
+	if !metav1.IsControlledBy(existing, pool) {
+		return nil
+	}
+
+	logger.Info("deleting orphaned TLSRoute", "name", pool.Name)
+	if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting orphaned TLSRoute: %w", err)
+	}
+	r.Recorder.Eventf(pool, nil, corev1.EventTypeNormal, EventReasonTLSRouteDeleted, "Reconcile", "TLSRoute %s deleted", pool.Name)
+	return nil
 }
 
 func (r *PoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&openvoxv1alpha1.Pool{}).
 		Owns(&corev1.Service{}).
-		Watches(&openvoxv1alpha1.Server{}, enqueuePoolsForServer(mgr.GetClient()))
+		Watches(&openvoxv1alpha1.Server{}, enqueuePoolsForServer(mgr.GetClient())).
+		Watches(&openvoxv1alpha1.Pool{}, handler.EnqueueRequestsFromMapFunc(poolsSharingHostname(mgr.GetClient())))
 
 	if r.GatewayAPIAvailable {
 		builder = builder.Owns(&gwapiv1.TLSRoute{})
@@ -203,6 +296,42 @@ func enqueuePoolsForServer(c client.Client) handler.EventHandler {
 		}
 		return requests
 	})
+}
+
+// enqueuePoolsSharingHostname returns a handler that enqueues the other Pools
+// competing for the same route hostname.
+//
+// Without it a Pool that lost the hostname would stay blocked forever: its own
+// spec never changes when the winner is deleted or gives up its route, and the
+// controller no longer retries the conflict on a backoff.
+func poolsSharingHostname(c client.Client) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []ctrl.Request {
+		changed, ok := obj.(*openvoxv1alpha1.Pool)
+		if !ok || changed.Spec.Route == nil || changed.Spec.Route.Hostname == "" {
+			return nil
+		}
+
+		pools := &openvoxv1alpha1.PoolList{}
+		if err := c.List(ctx, pools, client.InNamespace(changed.Namespace)); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list Pools in hostname watcher")
+			return nil
+		}
+
+		var requests []ctrl.Request
+		for i := range pools.Items {
+			other := &pools.Items[i]
+			if other.Name == changed.Name {
+				continue
+			}
+			if other.Spec.Route == nil || other.Spec.Route.Hostname != changed.Spec.Route.Hostname {
+				continue
+			}
+			requests = append(requests, ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: other.Name, Namespace: other.Namespace},
+			})
+		}
+		return requests
+	}
 }
 
 // poolServiceSelector builds the label selector for a Pool's Service.

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -133,7 +133,10 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// Update status
-	endpoints := r.countEndpoints(ctx, pool)
+	endpoints, err := r.countEndpoints(ctx, pool)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("counting endpoints for Pool %s: %w", pool.Name, err)
+	}
 	if err := updateStatusWithRetry(ctx, r.Client, pool, func() {
 		pool.Status.ObservedGeneration = pool.Generation
 		pool.Status.ServiceName = pool.Name
@@ -275,11 +278,16 @@ func (r *PoolReconciler) reconcileService(ctx context.Context, pool *openvoxv1al
 	return nil
 }
 
-func (r *PoolReconciler) countEndpoints(ctx context.Context, pool *openvoxv1alpha1.Pool) int32 {
+// countEndpoints reports how many ready endpoints back the Pool Service.
+//
+// An empty list is a real answer: nothing is behind the Service yet. A failed
+// list is not, so it is returned rather than rounded down to zero, which would
+// flip ConditionPoolReady to False on every API hiccup.
+func (r *PoolReconciler) countEndpoints(ctx context.Context, pool *openvoxv1alpha1.Pool) (int32, error) {
 	sliceList := &discoveryv1.EndpointSliceList{}
 	if err := r.List(ctx, sliceList, client.InNamespace(pool.Namespace),
 		client.MatchingLabels{"kubernetes.io/service-name": pool.Name}); err != nil {
-		return 0
+		return 0, fmt.Errorf("listing EndpointSlices for Service %s: %w", pool.Name, err)
 	}
 	var count int32
 	for _, slice := range sliceList.Items {
@@ -289,7 +297,7 @@ func (r *PoolReconciler) countEndpoints(ctx context.Context, pool *openvoxv1alph
 			}
 		}
 	}
-	return count
+	return count, nil
 }
 
 func (r *PoolReconciler) reconcileTLSRoute(ctx context.Context, pool *openvoxv1alpha1.Pool) error {

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -81,8 +81,11 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// Reconcile TLSRoute. conflictWith names the Pool that owns the requested
 	// hostname when it is not this one, so the single status update below can
-	// report it.
-	var conflictWith string
+	// report it. The hostname is captured alongside it because
+	// updateStatusWithRetry re-reads the whole object on every attempt: a Pool
+	// whose route was removed concurrently comes back with a nil Spec.Route,
+	// and the report must not dereference it.
+	var conflictWith, claimedHostname string
 	if pool.Spec.Route != nil && pool.Spec.Route.Enabled {
 		if !r.GatewayAPIAvailable {
 			logger.Info("TLSRoute requested but Gateway API CRDs not available, skipping")
@@ -98,6 +101,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 				// reported and left alone rather than retried, and the loser
 				// gives up any TLSRoute it may still hold from an earlier round.
 				conflictWith = owner.Name
+				claimedHostname = pool.Spec.Route.Hostname
 				logger.Info("hostname already claimed by another Pool, skipping TLSRoute",
 					"hostname", pool.Spec.Route.Hostname, "owner", owner.Name)
 				if err := r.deleteOwnedTLSRoute(ctx, pool); err != nil {
@@ -142,7 +146,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 				Type:               openvoxv1alpha1.ConditionPoolReady,
 				Status:             metav1.ConditionFalse,
 				Reason:             "HostnameConflict",
-				Message:            hostnameConflictMessage(pool.Spec.Route.Hostname, conflictWith),
+				Message:            hostnameConflictMessage(claimedHostname, conflictWith),
 				ObservedGeneration: pool.Generation,
 			})
 		case endpoints > 0:
@@ -168,9 +172,9 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// The event follows the condition so it fires once per transition rather
 	// than on every reconcile.
-	if conflictWith != "" && !wasConflictingWith(previousConditions, pool.Spec.Route.Hostname, conflictWith) {
+	if conflictWith != "" && !wasConflictingWith(previousConditions, claimedHostname, conflictWith) {
 		r.Recorder.Eventf(pool, nil, corev1.EventTypeWarning, EventReasonHostnameConflict, "Reconcile",
-			"%s", hostnameConflictMessage(pool.Spec.Route.Hostname, conflictWith))
+			"%s", hostnameConflictMessage(claimedHostname, conflictWith))
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -201,10 +201,16 @@ func TestPoolReconcile_TLSRouteHostnameConflict(t *testing.T) {
 		t.Fatalf("failed to create pool-b: %v", err)
 	}
 
-	// Reconcile pool-b should fail with hostname conflict
-	_, err := r.Reconcile(testCtx(), testRequest("puppet-b"))
-	if err == nil {
-		t.Fatal("expected hostname conflict error")
+	// The conflict is reported, not retried: nothing about a duplicate
+	// hostname improves by waiting, so returning an error would only produce
+	// an endless backoff loop.
+	if _, err := r.Reconcile(testCtx(), testRequest("puppet-b")); err != nil {
+		t.Fatalf("a hostname conflict must not fail the reconcile: %v", err)
+	}
+
+	route := &gwapiv1.TLSRoute{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet-b", Namespace: testNamespace}, route); err == nil {
+		t.Error("the losing Pool must not create a TLSRoute for a hostname it does not own")
 	}
 }
 

--- a/internal/controller/pool_hostname_conflict_test.go
+++ b/internal/controller/pool_hostname_conflict_test.go
@@ -1,0 +1,233 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+const conflictHostname = "puppet.example.com"
+
+// TestPoolConflict_ReportedAsConditionNotRetried is the core of the change: a
+// duplicate hostname is a permanent condition. Returning an error made
+// controller-runtime retry it with exponential backoff forever, which produced
+// nothing but a growing backlog of identical events.
+func TestPoolConflict_ReportedAsConditionNotRetried(t *testing.T) {
+	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+
+	c := setupTestClient(winner, loser)
+	r := newPoolReconciler(c, true)
+
+	res, err := r.Reconcile(testCtx(), testRequest("pool-b"))
+	if err != nil {
+		t.Fatalf("a hostname conflict must not fail the reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a hostname conflict must not be polled, got RequeueAfter %v", res.RequeueAfter)
+	}
+
+	got := &openvoxv1alpha1.Pool{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "pool-b", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading the Pool back: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionPoolReady)
+	if cond == nil {
+		t.Fatal("expected a PoolReady condition reporting the conflict")
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != "HostnameConflict" {
+		t.Errorf("expected Ready=False/HostnameConflict, got %s/%s", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "pool-a") {
+		t.Errorf("the condition must name the Pool holding the hostname, got %q", cond.Message)
+	}
+}
+
+// TestPoolConflict_OlderPoolKeepsTheHostname pins the tie-break. Both Pools see
+// the same list, so both must reach the same verdict, otherwise they take turns
+// creating and deleting the TLSRoute.
+func TestPoolConflict_OlderPoolKeepsTheHostname(t *testing.T) {
+	older := newPool("zzz-first", withRoute(true, conflictHostname, "gw"))
+	older.CreationTimestamp = metav1.NewTime(time.Unix(1_700_000_000, 0))
+	younger := newPool("aaa-second", withRoute(true, conflictHostname, "gw"))
+	younger.CreationTimestamp = metav1.NewTime(time.Unix(1_700_000_100, 0))
+
+	c := setupTestClient(older, younger)
+	r := newPoolReconciler(c, true)
+
+	// Reconcile both, in the order that would favour the younger one if the
+	// decision depended on who runs first.
+	for _, name := range []string{"aaa-second", "zzz-first"} {
+		if _, err := r.Reconcile(testCtx(), testRequest(name)); err != nil {
+			t.Fatalf("reconcile %s: %v", name, err)
+		}
+	}
+
+	route := &gwapiv1.TLSRoute{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "zzz-first", Namespace: testNamespace}, route); err != nil {
+		t.Errorf("the older Pool must keep the TLSRoute, got: %v", err)
+	}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "aaa-second", Namespace: testNamespace}, &gwapiv1.TLSRoute{}); err == nil {
+		t.Error("the younger Pool must not hold a TLSRoute for a hostname it lost")
+	}
+
+	// The name would have picked the other way round, which is what makes this
+	// a real check of the timestamp ordering.
+	loser := &openvoxv1alpha1.Pool{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "aaa-second", Namespace: testNamespace}, loser); err != nil {
+		t.Fatalf("reading the younger Pool back: %v", err)
+	}
+	if cond := meta.FindStatusCondition(loser.Status.Conditions, openvoxv1alpha1.ConditionPoolReady); cond == nil || cond.Reason != "HostnameConflict" {
+		t.Errorf("expected the younger Pool to report the conflict, got %+v", cond)
+	}
+}
+
+// TestPoolConflict_LoserGivesUpItsRoute covers the case that produced two
+// TLSRoutes for one hostname: a Pool that held the route before an older
+// claimant enabled its own must release it.
+func TestPoolConflict_LoserGivesUpItsRoute(t *testing.T) {
+	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+
+	c := setupTestClient(loser)
+	r := newPoolReconciler(c, true)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
+		t.Fatalf("reconcile pool-b: %v", err)
+	}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "pool-b", Namespace: testNamespace}, &gwapiv1.TLSRoute{}); err != nil {
+		t.Fatalf("pool-b should own the TLSRoute while it is alone: %v", err)
+	}
+
+	// pool-a takes the hostname on the tie-break.
+	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	if err := c.Create(testCtx(), winner); err != nil {
+		t.Fatalf("creating pool-a: %v", err)
+	}
+
+	if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
+		t.Fatalf("reconcile pool-b after the conflict appeared: %v", err)
+	}
+
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "pool-b", Namespace: testNamespace}, &gwapiv1.TLSRoute{}); err == nil {
+		t.Error("the losing Pool must release the TLSRoute it no longer owns")
+	}
+}
+
+// TestPoolConflict_TerminatingPoolReleasesTheHostname keeps a stuck deletion
+// from holding a hostname hostage.
+func TestPoolConflict_TerminatingPoolReleasesTheHostname(t *testing.T) {
+	now := metav1.Now()
+	leaving := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	leaving.DeletionTimestamp = &now
+	leaving.Finalizers = []string{"example.com/keep-around"}
+	successor := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+
+	c := setupTestClient(leaving, successor)
+	r := newPoolReconciler(c, true)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
+		t.Fatalf("reconcile pool-b: %v", err)
+	}
+
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "pool-b", Namespace: testNamespace}, &gwapiv1.TLSRoute{}); err != nil {
+		t.Errorf("a terminating Pool must not keep the hostname, got: %v", err)
+	}
+}
+
+// TestPoolConflict_EventFiresOncePerTransition guards against the event noise
+// the old backoff loop produced.
+func TestPoolConflict_EventFiresOncePerTransition(t *testing.T) {
+	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+
+	c := setupTestClient(winner, loser)
+	r := newPoolReconciler(c, true)
+	rec := events.NewFakeRecorder(100)
+	r.Recorder = rec
+
+	for i := 0; i < 3; i++ {
+		if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
+			t.Fatalf("reconcile %d: %v", i, err)
+		}
+	}
+
+	if n := countEvents(rec, EventReasonHostnameConflict); n != 1 {
+		t.Errorf("expected exactly one conflict event across three reconciles, got %d", n)
+	}
+}
+
+// countEvents drains the recorder and counts the events carrying the given
+// reason, so unrelated events from the same reconcile do not distort the count.
+func countEvents(rec *events.FakeRecorder, reason string) int {
+	n := 0
+	for {
+		select {
+		case e := <-rec.Events:
+			if strings.Contains(e, reason) {
+				n++
+			}
+		default:
+			return n
+		}
+	}
+}
+
+// TestPoolConflict_ResolvedWhenTheWinnerGivesUp closes the loop: once the
+// hostname is free the Pool must pick it up, which is what the sibling watch is
+// there to trigger.
+func TestPoolConflict_ResolvedWhenTheWinnerGivesUp(t *testing.T) {
+	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+
+	c := setupTestClient(winner, loser)
+	r := newPoolReconciler(c, true)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
+		t.Fatalf("reconcile pool-b: %v", err)
+	}
+
+	if err := c.Delete(testCtx(), winner); err != nil {
+		t.Fatalf("deleting pool-a: %v", err)
+	}
+
+	if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
+		t.Fatalf("reconcile pool-b after the conflict was resolved: %v", err)
+	}
+
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "pool-b", Namespace: testNamespace}, &gwapiv1.TLSRoute{}); err != nil {
+		t.Errorf("the Pool must take the hostname once it is free, got: %v", err)
+	}
+
+	got := &openvoxv1alpha1.Pool{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "pool-b", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading the Pool back: %v", err)
+	}
+	if cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionPoolReady); cond != nil && cond.Reason == "HostnameConflict" {
+		t.Error("the conflict condition must clear once the hostname is free")
+	}
+}
+
+// TestPoolsSharingHostname checks the watch that makes the resolution
+// above happen without polling.
+func TestPoolsSharingHostname(t *testing.T) {
+	changed := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	sibling := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+	unrelated := newPool("pool-c", withRoute(true, "other.example.com", "gw"))
+	noRoute := newPool("pool-d")
+
+	c := setupTestClient(changed, sibling, unrelated, noRoute)
+
+	got := poolsSharingHostname(c)(testCtx(), changed)
+	if !equalNames(got, "pool-b") {
+		t.Errorf("expected only the Pool competing for the same hostname, got %v", names(got))
+	}
+}

--- a/internal/controller/pool_hostname_conflict_test.go
+++ b/internal/controller/pool_hostname_conflict_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
@@ -229,5 +233,43 @@ func TestPoolsSharingHostname(t *testing.T) {
 	got := poolsSharingHostname(c)(testCtx(), changed)
 	if !equalNames(got, "pool-b") {
 		t.Errorf("expected only the Pool competing for the same hostname, got %v", names(got))
+	}
+}
+
+// TestPoolConflict_SurvivesRouteRemovedMidReconcile guards a nil dereference
+// that is easy to reintroduce: updateStatusWithRetry re-reads the whole object
+// on every attempt, so a Pool whose route is removed while the reconcile is in
+// flight comes back with a nil Spec.Route. Reporting the conflict must not
+// reach into it.
+func TestPoolConflict_SurvivesRouteRemovedMidReconcile(t *testing.T) {
+	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+
+	gets := 0
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(winner, loser).
+		WithStatusSubresource(&openvoxv1alpha1.Pool{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := cl.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				// The first read is the one the reconcile starts from; every
+				// later read models the spec having changed in the meantime.
+				if p, ok := obj.(*openvoxv1alpha1.Pool); ok {
+					gets++
+					if gets > 1 {
+						p.Spec.Route = nil
+					}
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	r := newPoolReconciler(c, true)
+	if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
 }

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -67,6 +67,9 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	server := &openvoxv1alpha1.Server{}
 	if err := r.Get(ctx, req.NamespacedName, server); err != nil {
 		if errors.IsNotFound(err) {
+			// The Server carries no finalizer, so this is the only point at
+			// which its gauges can be retired.
+			forgetServerMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("getting Server %s: %w", req.NamespacedName, err)

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -152,7 +152,10 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Update status
-	ready := r.getReadyReplicas(ctx, server)
+	ready, err := r.getReadyReplicas(ctx, server)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("reading ready replicas for Server %s: %w", server.Name, err)
+	}
 	if err := updateStatusWithRetry(ctx, r.Client, server, func() {
 		replicas := int32(1)
 		if server.Spec.Replicas != nil {
@@ -493,10 +496,19 @@ func intstrInt(val int) intstr.IntOrString {
 	return intstr.FromInt32(int32(val))
 }
 
-func (r *ServerReconciler) getReadyReplicas(ctx context.Context, server *openvoxv1alpha1.Server) int32 {
+// getReadyReplicas reports how many replicas of the Server Deployment are ready.
+//
+// A missing Deployment genuinely means nothing is ready, so it counts as zero.
+// Any other error is returned: reporting zero for a failed lookup would be
+// indistinguishable from an idle workload and would flip the status to Pending
+// on every API hiccup.
+func (r *ServerReconciler) getReadyReplicas(ctx context.Context, server *openvoxv1alpha1.Server) (int32, error) {
 	deploy := &appsv1.Deployment{}
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Name, Namespace: server.Namespace}, deploy); err != nil {
-		return 0
+		if errors.IsNotFound(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("getting Deployment %s: %w", server.Name, err)
 	}
-	return deploy.Status.ReadyReplicas
+	return deploy.Status.ReadyReplicas, nil
 }

--- a/internal/controller/status_transient_errors_test.go
+++ b/internal/controller/status_transient_errors_test.go
@@ -1,0 +1,208 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// apiTimeout mimics the transient failure an overloaded or restarting API
+// server returns for any group. It is deliberately not a NotFound.
+func apiTimeout(group, resource string) error {
+	return apierrors.NewServerTimeout(
+		schema.GroupResource{Group: group, Resource: resource}, "get", 1)
+}
+
+// newFailingDeploymentClient serves every request normally except Deployment
+// reads, which fail with a transient error.
+func newFailingDeploymentClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(&openvoxv1alpha1.Server{}, &openvoxv1alpha1.Database{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return apiTimeout("apps", "deployments")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+}
+
+// newFailingEndpointSliceClient serves every request normally except
+// EndpointSlice listings, which fail with a transient error.
+func newFailingEndpointSliceClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(&openvoxv1alpha1.Pool{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*discoveryv1.EndpointSliceList); ok {
+					return apiTimeout("discovery.k8s.io", "endpointslices")
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+}
+
+// TestServerGetReadyReplicas_MissingDeploymentIsZero pins the one case where
+// reporting zero is the honest answer: there is no Deployment, so nothing can
+// be ready.
+func TestServerGetReadyReplicas_MissingDeploymentIsZero(t *testing.T) {
+	server := newServer("puppetserver")
+	r := newServerReconciler(setupTestClient(server))
+
+	ready, err := r.getReadyReplicas(testCtx(), server)
+	if err != nil {
+		t.Fatalf("a missing Deployment must not be an error: %v", err)
+	}
+	if ready != 0 {
+		t.Errorf("expected 0 ready replicas without a Deployment, got %d", ready)
+	}
+}
+
+// TestServerGetReadyReplicas_TransientFailureIsAnError covers the case the
+// helper used to swallow: a failed lookup must not be reported as zero, which
+// would be indistinguishable from an idle workload.
+func TestServerGetReadyReplicas_TransientFailureIsAnError(t *testing.T) {
+	server := newServer("puppetserver")
+	r := newServerReconciler(newFailingDeploymentClient(server))
+
+	_, err := r.getReadyReplicas(testCtx(), server)
+	if err == nil {
+		t.Fatal("expected a transient Deployment lookup failure to be returned")
+	}
+	if apierrors.IsNotFound(err) {
+		t.Errorf("transient error was turned into NotFound: %v", err)
+	}
+}
+
+func TestDatabaseGetReadyReplicas_MissingDeploymentIsZero(t *testing.T) {
+	db := newDatabase("puppetdb")
+	r := newDatabaseReconciler(setupTestClient(db))
+
+	ready, err := r.getReadyReplicas(testCtx(), db)
+	if err != nil {
+		t.Fatalf("a missing Deployment must not be an error: %v", err)
+	}
+	if ready != 0 {
+		t.Errorf("expected 0 ready replicas without a Deployment, got %d", ready)
+	}
+}
+
+func TestDatabaseGetReadyReplicas_TransientFailureIsAnError(t *testing.T) {
+	db := newDatabase("puppetdb")
+	r := newDatabaseReconciler(newFailingDeploymentClient(db))
+
+	_, err := r.getReadyReplicas(testCtx(), db)
+	if err == nil {
+		t.Fatal("expected a transient Deployment lookup failure to be returned")
+	}
+	if apierrors.IsNotFound(err) {
+		t.Errorf("transient error was turned into NotFound: %v", err)
+	}
+}
+
+// TestPoolCountEndpoints_TransientFailureIsAnError distinguishes an empty
+// EndpointSlice list, which is a real answer, from a failed one, which is not.
+func TestPoolCountEndpoints_TransientFailureIsAnError(t *testing.T) {
+	pool := newPool("puppet")
+
+	r := newPoolReconciler(setupTestClient(pool), false)
+	count, err := r.countEndpoints(testCtx(), pool)
+	if err != nil {
+		t.Fatalf("an empty EndpointSlice list must not be an error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 endpoints, got %d", count)
+	}
+
+	failing := newPoolReconciler(newFailingEndpointSliceClient(pool), false)
+	if _, err := failing.countEndpoints(testCtx(), pool); err == nil {
+		t.Fatal("expected a failed EndpointSlice list to be returned")
+	}
+}
+
+// TestServerReconcile_TransientDeploymentFailureKeepsStatus is the regression
+// guard for the flapping this fixes: while Deployment reads fail, a Server that
+// was reported ready keeps that status instead of dropping to Pending and
+// emitting a transition event.
+func TestServerReconcile_TransientDeploymentFailureKeepsStatus(t *testing.T) {
+	server := newServer("test-server")
+	server.Status.Desired = 3
+	server.Status.Ready = 3
+	server.Status.Phase = openvoxv1alpha1.ServerPhaseRunning
+	meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+		Type:    openvoxv1alpha1.ConditionServerReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "ReplicasReady",
+		Message: "3/3 replicas ready",
+	})
+
+	c := newFailingDeploymentClient(append(serverPrereqs(), server)...)
+	r := newServerReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest(server.Name)); err == nil {
+		t.Fatal("expected the reconcile to fail while the Deployment cannot be read")
+	}
+
+	got := &openvoxv1alpha1.Server{}
+	if err := c.Get(testCtx(), client.ObjectKeyFromObject(server), got); err != nil {
+		t.Fatalf("getting the Server back: %v", err)
+	}
+	if got.Status.Ready != 3 {
+		t.Errorf("ready replicas were overwritten on a transient failure: got %d, want 3", got.Status.Ready)
+	}
+	if got.Status.Phase != openvoxv1alpha1.ServerPhaseRunning {
+		t.Errorf("phase flipped on a transient failure: got %q, want %q", got.Status.Phase, openvoxv1alpha1.ServerPhaseRunning)
+	}
+	if cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionServerReady); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Ready condition flipped on a transient failure: %+v", cond)
+	}
+}
+
+// TestPoolReconcile_TransientEndpointFailureKeepsCondition is the same guard
+// for the Pool condition added in #549.
+func TestPoolReconcile_TransientEndpointFailureKeepsCondition(t *testing.T) {
+	pool := newPool("puppet")
+	pool.Status.Endpoints = 2
+	meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
+		Type:    openvoxv1alpha1.ConditionPoolReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "EndpointsAvailable",
+		Message: "2 ready endpoint(s) behind Service puppet",
+	})
+
+	c := newFailingEndpointSliceClient(pool)
+	r := newPoolReconciler(c, false)
+
+	if _, err := r.Reconcile(testCtx(), testRequest(pool.Name)); err == nil {
+		t.Fatal("expected the reconcile to fail while EndpointSlices cannot be listed")
+	}
+
+	got := &openvoxv1alpha1.Pool{}
+	if err := c.Get(testCtx(), client.ObjectKeyFromObject(pool), got); err != nil {
+		t.Fatalf("getting the Pool back: %v", err)
+	}
+	if got.Status.Endpoints != 2 {
+		t.Errorf("endpoint count was overwritten on a transient failure: got %d, want 2", got.Status.Endpoints)
+	}
+	if cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionPoolReady); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("PoolReady condition flipped on a transient failure: %+v", cond)
+	}
+}


### PR DESCRIPTION
Three follow-ups from the review that produced #549. All three share a theme: the controller reported something it did not actually know.

## 1. Lookup failures were reported as zero (#556)

`ServerReconciler.getReadyReplicas`, `DatabaseReconciler.getReadyReplicas` and `PoolReconciler.countEndpoints` returned `0` when the underlying Get or List failed, so a transient API error was indistinguishable from an idle workload. A single failed call wrote `Ready=0`, flipped the phase to `Pending`, transitioned the Ready condition to `False` and emitted an event, all of which reverted on the next successful reconcile.

All three now return an error. A missing Deployment still counts as zero, and so does an empty EndpointSlice list, because those are real answers. Any other failure fails the reconcile so controller-runtime backs off and the previous status stays in place.

## 2. Prometheus series outlived their resources (#554)

The gauges were never removed, so an alert on `openvox_server_replicas_ready == 0` kept firing for a deleted Server, expiry alerts fired for certificates nobody held, and a cluster with churn grew its series count without bound.

Server gauges are retired on the NotFound path, the only signal available without a finalizer. Certificate and CertificateAuthority retire theirs when the finalizer is released, with NotFound as a safety net for force-deleted objects.

Also adds `openvox_crl_last_refresh_timestamp_seconds`, which the review found missing: a CRL that stops being refreshed means revoked agents keep being accepted, and nothing surfaced that. Documented in the monitoring guide with an alert rule.

## 3. Hostname conflicts were retried forever (#557)

The Pool collision check returned an error, so controller-runtime retried with exponential backoff indefinitely. Only a spec change can resolve a duplicate hostname, so the loop produced nothing but identical events.

It is now reported as `Ready=False` / `HostnameConflict` naming the holder, with one warning event per transition, and the reconcile returns cleanly.

The check was also racy: two Pools reconciled concurrently could each conclude the hostname was free and both create a TLSRoute. The winner is now decided by the oldest `creationTimestamp` with the name as tie-breaker, so every observer reaches the same verdict. A Pool that loses a hostname it previously held releases its TLSRoute, and a terminating Pool no longer keeps one hostage.

Since the conflict is no longer polled, Pools competing for a hostname watch each other, so one picks it up when the holder gives it up or is deleted. Without that watch a loser would stay blocked forever, because its own spec never changes.

## Verification

Each behavioural test was run against the old code first and fails there. `make test` and golangci-lint 2.13.2 are clean.

## Not included

The webhook-side duplicate rejection listed as optional in #557 is not part of this; the controller-side handling is what closes the endless-retry loop. The signing-error counter mentioned under Related in #554 needs a reason taxonomy across the signing paths and is left open.

Closes #554
Closes #556
Closes #557