### PR TITLE
fix(ca): bound the setup job retry loop and report the failure

### DIFF
--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -96,6 +96,10 @@ spec:
 | `OperatorSigningReady` | The auto-managed `{name}-operator-signing` Certificate is signed and its TLS Secret is available for mTLS-authenticated CSR signing. Not set for external CAs (which manage their own signing credentials). |
 | `DeletionBlocked` | Deletion is being held back because Certificates still reference this CertificateAuthority. The message lists them. |
 
+When the setup Job keeps failing, `CAReady` is set to `False` with reason
+`SetupFailed`, carrying the Job's own failure message. See
+[Setup failures](#setup-failures).
+
 ## Storage changes
 
 `spec.storage.size` can be increased if the storage class supports volume
@@ -165,6 +169,26 @@ there is any chance you will need it again.
 | `Ready` | CA Secrets created, Certificates can be signed |
 | `External` | External CA configured (no PVC, Job, or internal Service) |
 | `Error` | CA setup failed |
+
+## Setup failures
+
+A setup Job that cannot succeed -- a bad image reference, a broken PVC, an
+unschedulable pod -- is deleted and recreated by the controller. That retry is
+bounded: after five consecutive failures the controller stops, sets `CAReady` to
+`False` with reason `SetupFailed` and phase `Error`, and emits a
+`CASetupFailed` warning event.
+
+The failed Job is left in place; its logs are the only record of what went
+wrong:
+
+```bash
+kubectl logs -n <namespace> job/<ca-name>-setup
+```
+
+The attempt counter lives in the `openvox.voxpupuli.org/setup-attempts`
+annotation on the CertificateAuthority. It is cleared when the Job succeeds and
+when the image the Job runs changes, so correcting `spec.image` on the Config
+gives the setup another five attempts without any manual step.
 
 ## CA Secrets
 

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -42,6 +42,7 @@ const (
 	EventReasonOperatorSigningReady   = "OperatorSigningReady"
 	EventReasonCADeletionBlocked      = "CADeletionBlocked"
 	EventReasonMultipleConfigs        = "MultipleConfigs"
+	EventReasonCASetupFailed          = "CASetupFailed"
 )
 
 // certificateAuthorityFinalizer guards the CA private key and the CA data PVC,

--- a/internal/controller/certificateauthority_job.go
+++ b/internal/controller/certificateauthority_job.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -396,6 +398,99 @@ fi
 
 // --- Job lifecycle management ---
 
+// maxSetupAttempts bounds the delete/recreate loop above the Job's own
+// backoffLimit. A Job that cannot succeed -- a bad image reference, a broken
+// PVC, an unschedulable pod -- used to be recreated roughly every 15 seconds
+// forever, leaving the CertificateAuthority in Initializing with no indication
+// of why.
+const maxSetupAttempts = 5
+
+// AnnotationSetupAttempts counts consecutive unsuccessful CA setup jobs.
+const AnnotationSetupAttempts = "openvox.voxpupuli.org/setup-attempts"
+
+// setupAttempts reads the counter, treating anything unparseable as a fresh
+// start rather than failing the reconcile over an annotation.
+func setupAttempts(ca *openvoxv1alpha1.CertificateAuthority) int {
+	v, ok := ca.Annotations[AnnotationSetupAttempts]
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// recordSetupAttempts persists the counter. Passing 0 clears it.
+func (r *CertificateAuthorityReconciler) recordSetupAttempts(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, attempts int) error {
+	if setupAttempts(ca) == attempts {
+		return nil
+	}
+
+	patch := client.MergeFrom(ca.DeepCopy())
+	if attempts == 0 {
+		delete(ca.Annotations, AnnotationSetupAttempts)
+	} else {
+		if ca.Annotations == nil {
+			ca.Annotations = make(map[string]string)
+		}
+		ca.Annotations[AnnotationSetupAttempts] = strconv.Itoa(attempts)
+	}
+	if err := r.Patch(ctx, ca, patch); err != nil {
+		return fmt.Errorf("recording setup attempts on CertificateAuthority %s: %w", ca.Name, err)
+	}
+	return nil
+}
+
+// jobFailureMessage summarises why the Job gave up, for the condition a user
+// reads instead of the Job status they would otherwise have to dig out.
+func jobFailureMessage(c batchv1.JobCondition) string {
+	switch {
+	case c.Message != "":
+		return c.Message
+	case c.Reason != "":
+		return c.Reason
+	default:
+		return "the CA setup job failed without a reason"
+	}
+}
+
+// giveUpOnSetupJob records the terminal state and stops recreating the Job. The
+// failed Job is deliberately left in place: its logs are the only evidence of
+// what went wrong.
+func (r *CertificateAuthorityReconciler) giveUpOnSetupJob(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, jobName, failure string, attempts int) (ctrl.Result, error) {
+	message := fmt.Sprintf("CA setup job %s failed %d times, giving up: %s", jobName, attempts, failure)
+
+	existing := meta.FindStatusCondition(ca.Status.Conditions, openvoxv1alpha1.ConditionCAReady)
+	alreadyReported := existing != nil &&
+		existing.Status == metav1.ConditionFalse &&
+		existing.Reason == "SetupFailed" &&
+		existing.Message == message
+
+	if err := updateStatusWithRetry(ctx, r.Client, ca, func() {
+		ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseError
+		meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionCAReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             "SetupFailed",
+			Message:            message,
+			ObservedGeneration: ca.Generation,
+		})
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("reporting the CA setup failure for %s: %w", ca.Name, err)
+	}
+
+	if !alreadyReported {
+		log.FromContext(ctx).Info("giving up on the CA setup job", "name", jobName, "attempts", attempts, "failure", failure)
+		r.Recorder.Eventf(ca, nil, corev1.EventTypeWarning, EventReasonCASetupFailed, "Reconcile", "%s", message)
+	}
+
+	// Nothing here improves by waiting. A corrected spec changes the desired
+	// Job, and that comparison runs before this point on the next reconcile.
+	return ctrl.Result{}, nil
+}
+
 func (r *CertificateAuthorityReconciler) reconcileJob(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, jobName string, desiredJob *batchv1.Job, expectedSecretName string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -421,26 +516,56 @@ func (r *CertificateAuthorityReconciler) reconcileJob(ctx context.Context, ca *o
 		currentImage = existingJob.Spec.Template.Spec.Containers[0].Image
 	}
 	if currentImage != desiredImage {
+		// A corrected image is a fresh start, so the failure budget resets.
+		if err := r.recordSetupAttempts(ctx, ca, 0); err != nil {
+			return ctrl.Result{}, err
+		}
 		return r.deleteAndRequeueJob(ctx, existingJob, "image changed")
 	}
 
 	if existingJob.Status.Succeeded > 0 {
 		if !isSecretReady(ctx, r.Client, expectedSecretName, ca.Namespace, "ca_crt.pem") {
-			logger.Info("job succeeded but CA secret missing, recreating", "name", jobName)
-			return r.deleteAndRequeueJob(ctx, existingJob, "secret missing after success")
+			// This loops just as endlessly as an outright failure, so it draws
+			// from the same budget.
+			return r.retrySetupJob(ctx, ca, existingJob,
+				fmt.Sprintf("the job succeeded but Secret %s has no ca_crt.pem", expectedSecretName))
 		}
 		logger.Info("CA setup job completed successfully", "name", jobName)
+		if err := r.recordSetupAttempts(ctx, ca, 0); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
 	// Check permanent failure
 	for _, c := range existingJob.Status.Conditions {
 		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
-			return r.deleteAndRequeueJob(ctx, existingJob, "permanently failed")
+			return r.retrySetupJob(ctx, ca, existingJob, jobFailureMessage(c))
 		}
 	}
 
 	return ctrl.Result{RequeueAfter: RequeueIntervalLong}, nil
+}
+
+// retrySetupJob recreates the setup job while there is budget left, and reports
+// the failure once there is not.
+func (r *CertificateAuthorityReconciler) retrySetupJob(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, job *batchv1.Job, failure string) (ctrl.Result, error) {
+	attempts := setupAttempts(ca)
+	if attempts >= maxSetupAttempts {
+		// Already terminal: re-assert without spending another attempt, so the
+		// counter cannot grow on every reconcile.
+		return r.giveUpOnSetupJob(ctx, ca, job.Name, failure, attempts)
+	}
+
+	attempts++
+	if err := r.recordSetupAttempts(ctx, ca, attempts); err != nil {
+		return ctrl.Result{}, err
+	}
+	if attempts >= maxSetupAttempts {
+		return r.giveUpOnSetupJob(ctx, ca, job.Name, failure, attempts)
+	}
+
+	return r.deleteAndRequeueJob(ctx, job, fmt.Sprintf("%s (attempt %d/%d)", failure, attempts, maxSetupAttempts))
 }
 
 func (r *CertificateAuthorityReconciler) deleteAndRequeueJob(ctx context.Context, job *batchv1.Job, reason string) (ctrl.Result, error) {

--- a/internal/controller/certificateauthority_setup_backoff_test.go
+++ b/internal/controller/certificateauthority_setup_backoff_test.go
@@ -1,0 +1,230 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+const setupJobName = "test-ca-setup"
+
+// failedSetupJob builds a setup Job the API server has given up on, which is
+// what a bad image reference or an unschedulable pod eventually produces.
+func failedSetupJob(message string) *batchv1.Job {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: setupJobName, Namespace: testNamespace},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "setup", Image: "test:latest"}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{
+				Type:    batchv1.JobFailed,
+				Status:  corev1.ConditionTrue,
+				Reason:  "BackoffLimitExceeded",
+				Message: message,
+			}},
+		},
+	}
+	return job
+}
+
+// reloadCA re-reads the CertificateAuthority, the way each reconcile does.
+func reloadCA(t *testing.T, c client.Client, name string) *openvoxv1alpha1.CertificateAuthority {
+	t.Helper()
+	ca := &openvoxv1alpha1.CertificateAuthority{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: name, Namespace: testNamespace}, ca); err != nil {
+		t.Fatalf("reading CertificateAuthority %s: %v", name, err)
+	}
+	return ca
+}
+
+// TestSetupJob_StopsRecreatingAfterRepeatedFailures is the point of the change:
+// a Job that cannot succeed used to be deleted and recreated roughly every 15
+// seconds forever.
+func TestSetupJob_StopsRecreatingAfterRepeatedFailures(t *testing.T) {
+	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs("test-ca"))
+	r := newCertificateAuthorityReconciler(c)
+
+	for attempt := 1; attempt <= maxSetupAttempts; attempt++ {
+		// Each round the controller finds a fresh Job that has failed again.
+		job := failedSetupJob("pod has unbound immediate PersistentVolumeClaims")
+		if err := c.Create(testCtx(), job); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("seeding the failed job for attempt %d: %v", attempt, err)
+		}
+
+		ca := reloadCA(t, c, "test-ca")
+		result, err := r.reconcileJob(testCtx(), ca, setupJobName, job.DeepCopy(), "test-ca-ca")
+		if err != nil {
+			t.Fatalf("reconcileJob attempt %d: %v", attempt, err)
+		}
+
+		err = c.Get(testCtx(), types.NamespacedName{Name: setupJobName, Namespace: testNamespace}, &batchv1.Job{})
+		deleted := apierrors.IsNotFound(err)
+
+		if attempt < maxSetupAttempts {
+			if !deleted {
+				t.Fatalf("attempt %d should still retry, but the job was kept", attempt)
+			}
+			if result.RequeueAfter != RequeueIntervalMedium {
+				t.Errorf("attempt %d: expected a retry requeue, got %v", attempt, result.RequeueAfter)
+			}
+			continue
+		}
+
+		// The budget is spent.
+		if deleted {
+			t.Error("the failed job must be left in place once the controller gives up, its logs are the only evidence")
+		}
+		if result.RequeueAfter != 0 {
+			t.Errorf("giving up must not keep polling, got RequeueAfter %v", result.RequeueAfter)
+		}
+	}
+}
+
+// TestSetupJob_ReportsFailureInCondition covers the second half of the problem:
+// the CA sat in Initializing with no indication of why.
+func TestSetupJob_ReportsFailureInCondition(t *testing.T) {
+	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs("test-ca"))
+	r := newCertificateAuthorityReconciler(c)
+
+	ca := reloadCA(t, c, "test-ca")
+	ca.Annotations = map[string]string{AnnotationSetupAttempts: "4"}
+	if err := c.Update(testCtx(), ca); err != nil {
+		t.Fatalf("seeding the attempt counter: %v", err)
+	}
+
+	job := failedSetupJob("Job has reached the specified backoff limit")
+	if err := c.Create(testCtx(), job); err != nil {
+		t.Fatalf("seeding the failed job: %v", err)
+	}
+
+	if _, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+
+	got := reloadCA(t, c, "test-ca")
+	if got.Status.Phase != openvoxv1alpha1.CertificateAuthorityPhaseError {
+		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificateAuthorityPhaseError, got.Status.Phase)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionCAReady)
+	if cond == nil {
+		t.Fatal("expected a CAReady condition reporting the failure")
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != "SetupFailed" {
+		t.Errorf("expected CAReady=False/SetupFailed, got %s/%s", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "backoff limit") {
+		t.Errorf("the condition must carry the job's own failure message, got %q", cond.Message)
+	}
+}
+
+// TestSetupJob_CounterDoesNotGrowOnceTerminal keeps repeated reconciles from
+// inflating the counter and re-emitting the event.
+func TestSetupJob_CounterDoesNotGrowOnceTerminal(t *testing.T) {
+	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs("test-ca"))
+	r := newCertificateAuthorityReconciler(c)
+	rec := events.NewFakeRecorder(100)
+	r.Recorder = rec
+
+	ca := reloadCA(t, c, "test-ca")
+	ca.Annotations = map[string]string{AnnotationSetupAttempts: "4"}
+	if err := c.Update(testCtx(), ca); err != nil {
+		t.Fatalf("seeding the attempt counter: %v", err)
+	}
+
+	job := failedSetupJob("Job has reached the specified backoff limit")
+	if err := c.Create(testCtx(), job); err != nil {
+		t.Fatalf("seeding the failed job: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
+			t.Fatalf("reconcileJob %d: %v", i, err)
+		}
+	}
+
+	if n := setupAttempts(reloadCA(t, c, "test-ca")); n != maxSetupAttempts {
+		t.Errorf("the counter must stop at %d, got %d", maxSetupAttempts, n)
+	}
+	failures := 0
+	for drained := false; !drained; {
+		select {
+		case e := <-rec.Events:
+			if strings.Contains(e, EventReasonCASetupFailed) {
+				failures++
+			}
+		default:
+			drained = true
+		}
+	}
+	if failures != 1 {
+		t.Errorf("expected one failure event across three reconciles, got %d", failures)
+	}
+}
+
+// TestSetupJob_SuccessResetsTheBudget makes the failure budget per incident
+// rather than per CA lifetime.
+func TestSetupJob_SuccessResetsTheBudget(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.Annotations = map[string]string{AnnotationSetupAttempts: "3"}
+	caSecret := newSecret("test-ca-ca", map[string][]byte{"ca_crt.pem": []byte("cert")})
+
+	job := failedSetupJob("")
+	job.Status = batchv1.JobStatus{Succeeded: 1}
+
+	c := setupTestClient(ca, caPrereqs("test-ca"), caSecret, job)
+	r := newCertificateAuthorityReconciler(c)
+
+	if _, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+
+	if n := setupAttempts(reloadCA(t, c, "test-ca")); n != 0 {
+		t.Errorf("a successful job must clear the counter, got %d", n)
+	}
+}
+
+// TestSetupJob_ImageChangeResetsTheBudget is how a user recovers: correcting
+// the image the Job runs has to give it another chance.
+func TestSetupJob_ImageChangeResetsTheBudget(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	ca.Annotations = map[string]string{AnnotationSetupAttempts: "5"}
+
+	job := failedSetupJob("Job has reached the specified backoff limit")
+
+	c := setupTestClient(ca, caPrereqs("test-ca"), job)
+	r := newCertificateAuthorityReconciler(c)
+
+	desired := job.DeepCopy()
+	desired.Spec.Template.Spec.Containers[0].Image = "corrected:1.2.3"
+
+	res, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, desired, "test-ca-ca")
+	if err != nil {
+		t.Fatalf("reconcileJob: %v", err)
+	}
+	if res.RequeueAfter != RequeueIntervalMedium {
+		t.Errorf("a corrected image must be retried, got RequeueAfter %v", res.RequeueAfter)
+	}
+	if n := setupAttempts(reloadCA(t, c, "test-ca")); n != 0 {
+		t.Errorf("a corrected image must clear the counter, got %d", n)
+	}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: setupJobName, Namespace: testNamespace}, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Error("the stale job must be removed so the corrected one can be created")
+	}
+}


### PR DESCRIPTION
`reconcileJob` deleted and recreated the CA setup Job on every failure, with no attempt counter and no terminal state. A Job that cannot succeed -- a bad image reference, a broken PVC, an unschedulable pod -- produced a delete/create cycle roughly every 15 seconds indefinitely, while the CertificateAuthority sat in `Initializing` with no indication of why. The Job's own `backoffLimit` covers pod-level retries; this is the controller-level loop above it.

## Behaviour

Consecutive failures are counted in an `openvox.voxpupuli.org/setup-attempts` annotation, mirroring how `certificate_controller.go` tracks cleanup attempts. After five the controller stops recreating and reports:

- `CAReady=False`, reason `SetupFailed`, message carrying the Job's own failure text
- phase `Error`
- one `CASetupFailed` warning event, on the transition rather than per reconcile

The failed Job is deliberately left in place. Deleting it destroyed the only record of what went wrong; `kubectl logs job/<ca>-setup` now works.

## Recovery

The counter is cleared when the Job succeeds and when the image it runs changes, so correcting `spec.image` on the Config resumes the setup with a fresh budget and no manual step. Repeated reconciles in the terminal state neither inflate the counter nor re-emit the event.

The job-succeeded-but-secret-missing path draws from the same budget, since it loops just as endlessly as an outright failure.

## Verification

All five tests were run against the old code first; the three behavioural ones fail there. `make test` and golangci-lint 2.13.2 are clean. Documented under Setup failures in the CertificateAuthority reference.

Closes #553