### PR TITLE
test(e2e): assert the image under test, and fix the facts assertion timeout

### DIFF
--- a/tests/e2e/database-cnpg/chainsaw-test.yaml
+++ b/tests/e2e/database-cnpg/chainsaw-test.yaml
@@ -172,29 +172,49 @@ spec:
     - name: Assert the agent's facts landed in PuppetDB
       try:
         - script:
-            timeout: 3m
+            timeout: 4m
             content: |
               set -eu
               NS=e2e-database-cnpg
               CERTNAME=agent-db-facts-test
+              QUERY=http://127.0.0.1:8080/pdb/query/v4
+
               # PuppetDB ingests commands asynchronously, so poll the query API (plain
               # HTTP on localhost inside the puppetdb pod) until the node's facts appear.
+              #
+              # The budget is a wall-clock deadline rather than an iteration count.
+              # Thirty iterations of sleep 5 plus the kubectl exec overhead ran past
+              # the step timeout, so the script was killed before it could print the
+              # diagnostic below -- the one output that tells a missing fact apart
+              # from a query API that never answered.
+              DEADLINE=$(( $(date +%s) + 150 ))
+              reachable=0
               found=0
-              for i in $(seq 1 30); do
-                OUT=$(kubectl exec deploy/openvox-stack-db-puppetdb -n "${NS}" -- \
-                  curl -sf "http://127.0.0.1:8080/pdb/query/v4/facts" 2>/dev/null || true)
-                if echo "${OUT}" | grep -q "\"${CERTNAME}\""; then
-                  found=1
-                  echo "OK: PuppetDB has facts for ${CERTNAME}"
-                  break
+              while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+                if OUT=$(kubectl exec deploy/openvox-stack-db-puppetdb -n "${NS}" -- \
+                     curl -sf --max-time 10 "${QUERY}/facts" 2>/dev/null); then
+                  reachable=1
+                  if echo "${OUT}" | grep -q "\"${CERTNAME}\""; then
+                    found=1
+                    echo "OK: PuppetDB has facts for ${CERTNAME}"
+                    break
+                  fi
                 fi
-                echo "waiting for facts to be ingested (${i})..."
+                echo "waiting for facts to be ingested ($(( DEADLINE - $(date +%s) ))s left)..."
                 sleep 5
               done
+
               if [ "${found}" -ne 1 ]; then
-                echo "ERROR: no facts for ${CERTNAME} in PuppetDB (routes.yaml facts terminus not effective)"
+                if [ "${reachable}" -ne 1 ]; then
+                  echo "ERROR: the PuppetDB query API never answered, so nothing can be concluded about the facts"
+                else
+                  echo "ERROR: no facts for ${CERTNAME} in PuppetDB (routes.yaml facts terminus not effective)"
+                fi
+                echo "--- nodes known to PuppetDB ---"
                 kubectl exec deploy/openvox-stack-db-puppetdb -n "${NS}" -- \
-                  curl -sf "http://127.0.0.1:8080/pdb/query/v4/nodes" 2>/dev/null || true
+                  curl -sf --max-time 10 "${QUERY}/nodes" 2>/dev/null || echo "(the nodes query failed as well)"
+                echo "--- pods in ${NS} ---"
+                kubectl get pods -n "${NS}" 2>&1 || true
                 exit 1
               fi
 

--- a/tests/e2e/multi-server/chainsaw-test.yaml
+++ b/tests/e2e/multi-server/chainsaw-test.yaml
@@ -74,6 +74,42 @@ spec:
               fi
               echo "Found expected 3 server pods."
 
+    - name: Assert Server pods run the image under test
+      description: |
+        spec.image on the Config reached no Server until #549 removed the nested
+        default from ImageSpec, so the suite silently ran against
+        openvox-server-8:latest instead of the image built for this run. This
+        step makes that regression fail here instead of passing quietly.
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              set -eu
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              EXPECTED="${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8}:${IMAGE_TAG}"
+
+              ACTUAL=$(kubectl get pods -n e2e-multi-server \
+                -l openvox.voxpupuli.org/server=openvox-stack-multi-server \
+                -o jsonpath='{.items[*].spec.containers[?(@.name=="openvox-server")].image}')
+
+              if [ -z "${ACTUAL}" ]; then
+                echo "no Server pods found, cannot verify the image under test"
+                exit 1
+              fi
+
+              for image in ${ACTUAL}; do
+                if [ "${image}" != "${EXPECTED}" ]; then
+                  echo "Server pod runs ${image}, expected ${EXPECTED}"
+                  echo "spec.image on the Config is not reaching the Server."
+                  exit 1
+                fi
+              done
+
+              echo "Server pods run ${EXPECTED}"
+      catch:
+        - events: {}
+
     - name: Check operator logs for errors (warning only)
       try:
         - script:

--- a/tests/e2e/single-node/chainsaw-test.yaml
+++ b/tests/e2e/single-node/chainsaw-test.yaml
@@ -57,6 +57,42 @@ spec:
                 ready: 1
                 desired: 1
 
+    - name: Assert Server pods run the image under test
+      description: |
+        spec.image on the Config reached no Server until #549 removed the nested
+        default from ImageSpec, so the suite silently ran against
+        openvox-server-8:latest instead of the image built for this run. This
+        step makes that regression fail here instead of passing quietly.
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              set -eu
+              IMAGE_TAG=${IMAGE_TAG:-$(git describe --always)}
+              IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/slauger}
+              EXPECTED="${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8}:${IMAGE_TAG}"
+
+              ACTUAL=$(kubectl get pods -n e2e-single-node \
+                -l openvox.voxpupuli.org/server=openvox-stack-single-ca \
+                -o jsonpath='{.items[*].spec.containers[?(@.name=="openvox-server")].image}')
+
+              if [ -z "${ACTUAL}" ]; then
+                echo "no Server pods found, cannot verify the image under test"
+                exit 1
+              fi
+
+              for image in ${ACTUAL}; do
+                if [ "${image}" != "${EXPECTED}" ]; then
+                  echo "Server pod runs ${image}, expected ${EXPECTED}"
+                  echo "spec.image on the Config is not reaching the Server."
+                  exit 1
+                fi
+              done
+
+              echo "Server pods run ${EXPECTED}"
+      catch:
+        - events: {}
+
     - name: Check operator logs for errors (warning only)
       try:
         - script:


### PR DESCRIPTION
Two e2e corrections.

## 1. The suite was not testing the image it believed it was (#550)

`ImageSpec` carried `+kubebuilder:default` for both repository and tag. A nested default is applied whether or not the parent object was specified, so every Server came back from the API server fully populated and `resolveImage` always took the override branch. `spec.image` on the Config never reached a Server.

The chart's `servers[]` entries set no image and the e2e tests configure it on the Config:

```
--set config.image.repository=${IMAGE_REGISTRY}/openvox-server-${OPENVOX_MAJOR:-8}
--set config.image.tag="${IMAGE_TAG}"
```

Neither value arrived. The suite ran against `openvox-server-8:latest` instead of the build under test, and nothing failed when it did. #549 removed the default; this adds the assertion that would have caught it, in `single-node` and `multi-server`.

## 2. The facts assertion could not report its own failure

The polling loop in `database-cnpg` runs thirty iterations of `sleep 5` plus `kubectl exec` overhead, which exceeds the step's three-minute timeout. chainsaw kills the script before it reaches the diagnostic, so a failure produces twenty-odd `waiting for facts` lines and nothing else -- no nodes query, no hint of the cause. That is what the last run looked like.

The loop is now budgeted by wall clock with headroom under a four-minute timeout, so the diagnostic always runs, and it distinguishes two failure modes that used to look identical: a query API that never answered says nothing about the facts, while one that answered without the node is a real routing failure. `curl` gets an explicit `--max-time` so a hung exec cannot eat the budget either.

## Verification

`chainsaw lint` passes on all three files. The e2e verification against the cluster is pending -- I will dispatch the E2E workflow on this branch once the run on develop has finished, since both share one cluster.

Closes #550