### PR TITLE
test(e2e): expect the pool Service name in the gateway certificate

### DIFF
--- a/tests/e2e/pool-gateway/chainsaw-test.yaml
+++ b/tests/e2e/pool-gateway/chainsaw-test.yaml
@@ -80,6 +80,13 @@ spec:
                       - name: openvox-stack-gw-server
 
     - name: Verify DNS alt name injected into Certificate
+      description: |
+        The full expected set, in the order the chart and the operator build it:
+        the server name, the certname, then the Service name of every Pool the
+        server joins, and finally the route hostname the Pool controller
+        injects. This server has poolRefs [ca, server], so it is reachable
+        through both Services and needs both names; the ca Pool's Service name
+        equals the server name and is deduplicated away.
       try:
         - assert:
             resource:
@@ -91,6 +98,7 @@ spec:
                 dnsAltNames:
                   - openvox-stack-gw-ca
                   - puppet
+                  - openvox-stack-gw-server
                   - puppet.e2e.example.com
 
     - name: Verify no TLSRoute for CA pool


### PR DESCRIPTION
`pool-gateway` was the only failure in the first full E2E run since 6 August ([33570784524](https://github.com/slauger/openvox-operator/actions/runs/33570784524)):

```
* spec.dnsAltNames: Invalid value:
  ["openvox-stack-gw-ca","puppet","openvox-stack-gw-server","puppet.e2e.example.com"]:
  lengths of slices don't match

  dnsAltNames:
  - openvox-stack-gw-ca
  - puppet
+ - openvox-stack-gw-server
  - puppet.e2e.example.com
```

The extra name comes from #561, which derives the Service name of every Pool a server joins into its certificate. The `ca` server entry has `poolRefs: [ca, server]`, so it is reachable through both Services and needs both names. The `ca` Pool's Service name equals the server name and is deduplicated away, which is why only one name is added.

**The behaviour is correct and the expectation was stale.** A server reached through a Pool Service whose name is missing from its certificate fails the TLS handshake -- exactly what broke `database-cnpg` with `Server hostname 'openvox-stack-db-server' did not match server certificate`. That is what #561 set out to fix, and this test encodes the pre-fix list.

It surfaced only now because `e2e-base` had been red since 6 August, so the gateway group was skipped in every run in between.

## Why the order is pinned rather than sorted

The list is deterministic: `charts/openvox-stack/templates/certificates.yaml` appends the server name, then the certname, then one name per `poolRefs` entry in declaration order, then any explicit `dnsAltNames`, all through `uniq`. The Pool controller appends the route hostname last. The committed order matches the run's actual output exactly.

`chainsaw lint` passes. No other e2e test asserts `dnsAltNames`.

## Rest of the run

Everything else was green, including the twelve `e2e-base` tests and both `e2e-enc` tests. `database-cnpg` passed on the first polling iteration, confirming #561 fixed it. `e2e-webhooks-cm` was skipped because it depends on the gateway group.