### PR TITLE
test(e2e): delete the OpenVox Certificate, not cert-manager's

### DIFF
--- a/tests/e2e/webhook-smoke/chainsaw-test.yaml
+++ b/tests/e2e/webhook-smoke/chainsaw-test.yaml
@@ -70,5 +70,5 @@ spec:
         - script:
             timeout: 2m
             content: |
-              kubectl delete certificateauthority --all -n e2e-webhook-smoke --ignore-not-found 2>/dev/null || true
+              kubectl delete certificateauthority --all -n e2e-webhook-smoke --timeout=120s --ignore-not-found 2>/dev/null || true
               kubectl delete namespace e2e-webhook-smoke --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/webhook-validation-config/chainsaw-test.yaml
+++ b/tests/e2e/webhook-validation-config/chainsaw-test.yaml
@@ -84,5 +84,5 @@ spec:
             timeout: 2m
             content: |
               kubectl delete config --all -n e2e-webhook-val-config --ignore-not-found 2>/dev/null || true
-              kubectl delete certificateauthority --all -n e2e-webhook-val-config --ignore-not-found 2>/dev/null || true
+              kubectl delete certificateauthority --all -n e2e-webhook-val-config --timeout=120s --ignore-not-found 2>/dev/null || true
               kubectl delete namespace e2e-webhook-val-config --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/webhook-validation-database/chainsaw-test.yaml
+++ b/tests/e2e/webhook-validation-database/chainsaw-test.yaml
@@ -158,7 +158,11 @@ spec:
             timeout: 2m
             content: |
               kubectl delete database --all -n e2e-webhook-val-db --ignore-not-found 2>/dev/null || true
-              kubectl delete certificate --all -n e2e-webhook-val-db --ignore-not-found 2>/dev/null || true
-              kubectl delete certificateauthority --all -n e2e-webhook-val-db --ignore-not-found 2>/dev/null || true
+              # cert-manager is installed in this group and also serves a
+              # Certificate kind, so the bare name resolves to theirs and
+              # silently deletes nothing. The OpenVox Certificate then survives
+              # and blocks the CertificateAuthority finalizer forever.
+              kubectl delete certificates.openvox.voxpupuli.org --all -n e2e-webhook-val-db --timeout=120s --ignore-not-found 2>/dev/null || true
+              kubectl delete certificateauthority --all -n e2e-webhook-val-db --timeout=120s --ignore-not-found 2>/dev/null || true
               kubectl delete secret wh-db-pg-creds -n e2e-webhook-val-db --ignore-not-found 2>/dev/null || true
               kubectl delete namespace e2e-webhook-val-db --ignore-not-found 2>/dev/null || true

--- a/tests/e2e/webhook-validation-server/chainsaw-test.yaml
+++ b/tests/e2e/webhook-validation-server/chainsaw-test.yaml
@@ -130,6 +130,10 @@ spec:
               kubectl delete server --all -n e2e-webhook-val-server --ignore-not-found 2>/dev/null || true
               kubectl delete pool --all -n e2e-webhook-val-server --ignore-not-found 2>/dev/null || true
               kubectl delete config --all -n e2e-webhook-val-server --ignore-not-found 2>/dev/null || true
-              kubectl delete certificate --all -n e2e-webhook-val-server --ignore-not-found 2>/dev/null || true
-              kubectl delete certificateauthority --all -n e2e-webhook-val-server --ignore-not-found 2>/dev/null || true
+              # cert-manager is installed in this group and also serves a
+              # Certificate kind, so the bare name resolves to theirs and
+              # silently deletes nothing. The OpenVox Certificate then survives
+              # and blocks the CertificateAuthority finalizer forever.
+              kubectl delete certificates.openvox.voxpupuli.org --all -n e2e-webhook-val-server --timeout=120s --ignore-not-found 2>/dev/null || true
+              kubectl delete certificateauthority --all -n e2e-webhook-val-server --timeout=120s --ignore-not-found 2>/dev/null || true
               kubectl delete namespace e2e-webhook-val-server --ignore-not-found 2>/dev/null || true


### PR DESCRIPTION
`webhook-validation-server` ran for four hours in [33593414582](https://github.com/slauger/openvox-operator/actions/runs/33593414582) before I cancelled it. Every assertion in the test had already passed; it hung in teardown.

## Root cause

The webhooks group is the only one that installs cert-manager, and cert-manager serves a `Certificate` kind of its own:

```
certificates   cert,certs   cert-manager.io/v1               Certificate
certificates   cert         openvox.voxpupuli.org/v1alpha1   Certificate
```

`kubectl delete certificate --all` resolves to cert-manager's resource and deletes nothing, with no error. The OpenVox Certificate survives its own cleanup step, and the next line, `kubectl delete certificateauthority --all`, blocks on the CA finalizer -- which correctly refuses to release while a Certificate still references the CA.

Confirmed on the cluster: the namespace was `Active`, `wh-server-ca` carried `deletionTimestamp=06:01:09Z` with the `ca-protection` finalizer, and `wh-server-cert` had no deletion timestamp at all. Deleting the Certificate by its qualified name released the CA within a second.

## Why the step timeout did not save it

`kubectl delete` waits indefinitely by default, and chainsaw's `timeout: 2m` cannot stop it: the kubectl started through `sh -c` outlives the step's cancelled context and holds the pipe open. The cancellation log ends with `Terminate orphan process: pid (2192) (kubectl)`.

## Changes

- Use `certificates.openvox.voxpupuli.org` in the two tests that create their own Certificate (`webhook-validation-server`, `webhook-validation-database`), with a comment so it is not simplified back.
- Bound every CA and Certificate delete in the four webhook tests with `--timeout=120s`, so a blocked finalizer fails the step rather than hanging the job.

`cert-rotation` already used the qualified name. `webhook-smoke` and `webhook-validation-config` create no Certificate of their own; the operator-signing Certificate is owned by the CA and is excluded from blocking by #560.

## Why it surfaced only now

The webhooks group had never run to completion -- every earlier run failed in an earlier group and skipped it.

`chainsaw lint` passes on all four files.