### PR TITLE
fix(ci): generate the PR description instead of depending on a retired API

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -101,19 +101,60 @@ jobs:
           echo "fix_count=$FIX_COUNT" >> $GITHUB_OUTPUT
           echo "breaking=$BREAKING" >> $GITHUB_OUTPUT
 
-      - name: Analyze changes with AI
+      - name: Build change summary
         if: steps.check-pr.outputs.count == '0' || steps.check-pr.outputs.is_auto == 'true'
         id: analyze
+        env:
+          # Optional. Without a key the categorised commit list below is the
+          # description. GitHub Models, which this step used to call, was
+          # retired on 2026-07-30, so there is no free default endpoint left.
+          # Any OpenAI-compatible chat/completions URL works, for example
+          # https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+          # or https://api.groq.com/openai/v1/chat/completions
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_API_URL: ${{ vars.LLM_API_URL }}
+          LLM_MODEL: ${{ vars.LLM_MODEL }}
         run: |
-          COMMITS=$(git log main..HEAD --pretty=format:"- %s (%h)" --no-merges)
           FILES_CHANGED=$(git diff main..HEAD --stat)
 
-          BUMP="${{ steps.version.outputs.bump }}"
-          CURRENT="${{ steps.version.outputs.current }}"
-          NEXT="${{ steps.version.outputs.next }}"
+          # Group the commits the way semantic-release categorises them, so the
+          # description is useful on its own rather than a flat list.
+          {
+            emit_group() {
+              BODY=$(git log main..HEAD --pretty=format:"- %s (%h)" --no-merges \
+                | grep -E "^- $2(\(.+\))?!?: " || true)
+              if [ -n "$BODY" ]; then
+                printf '### %s\n\n%s\n\n' "$1" "$BODY"
+              fi
+            }
+            emit_group "Features" "feat"
+            emit_group "Fixes" "fix"
+            emit_group "Performance" "perf"
+            emit_group "Refactoring" "refactor"
+            emit_group "Tests" "test"
+            emit_group "Documentation" "docs"
+            emit_group "Build and CI" "(build|ci)"
+            emit_group "Chores" "chore"
 
-          cat > /tmp/prompt.txt <<PROMPT
-          Create a pull request title and description for merging develop into main.
+            OTHER=$(git log main..HEAD --pretty=format:"- %s (%h)" --no-merges \
+              | grep -vE "^- (feat|fix|perf|refactor|test|docs|build|ci|chore)(\(.+\))?!?: " || true)
+            if [ -n "$OTHER" ]; then
+              printf '### Other\n\n%s\n\n' "$OTHER"
+            fi
+
+            printf '<details>\n<summary>Files changed</summary>\n\n```\n%s\n```\n</details>\n' "$FILES_CHANGED"
+          } > /tmp/pr_description.txt
+
+          if [ -z "${LLM_API_KEY}" ]; then
+            echo "::notice::No LLM_API_KEY configured, using the generated change summary"
+          else
+            COMMITS=$(git log main..HEAD --pretty=format:"- %s (%h)" --no-merges)
+            CURRENT="${{ steps.version.outputs.current }}"
+            NEXT="${{ steps.version.outputs.next }}"
+            BUMP="${{ steps.version.outputs.bump }}"
+
+            cat > /tmp/prompt.txt <<PROMPT
+          Write a pull request description for merging develop into main.
 
           Project: OpenVox Operator - a Kubernetes Operator for deploying and managing OpenVox (Puppet) environments on Kubernetes/OpenShift using rootless containers.
 
@@ -125,9 +166,7 @@ jobs:
           Files changed (summary):
           $FILES_CHANGED
 
-          IMPORTANT: The FIRST line of your response must be a concise PR title (max 60 chars, no markdown, no prefix like "Title:"). It should summarize the most important changes. Examples: "Add Database CRD and update CI workflows", "Fix auth handling and bump dependencies".
-
-          Then leave one blank line and write the description. You MUST cover ALL commits listed above - do not skip any.
+          Write the description only, with no title line and no preamble.
           ## Summary
           - 5-8 bullet points explaining WHAT changed and WHY
 
@@ -138,53 +177,46 @@ jobs:
           - How to verify these changes
           PROMPT
 
-          REQUEST_JSON=$(jq -n \
-            --arg system "You are a technical writer creating concise PR descriptions for a Kubernetes Operator project written in Go with Helm charts. Focus on WHY changes were made, not just WHAT changed. Be professional and concise. The very first line of your response MUST be a short PR title without any markdown formatting." \
-            --arg user "$(cat /tmp/prompt.txt)" \
-            '{
-              "messages": [
-                {"role": "system", "content": $system},
-                {"role": "user", "content": $user}
-              ],
-              "model": "openai/gpt-4.1",
-              "temperature": 0.7,
-              "max_tokens": 4000
-            }')
+            REQUEST_JSON=$(jq -n \
+              --arg system "You are a technical writer creating concise PR descriptions for a Kubernetes Operator project written in Go with Helm charts. Focus on WHY changes were made, not just WHAT changed. Be professional and concise." \
+              --arg user "$(cat /tmp/prompt.txt)" \
+              --arg model "${LLM_MODEL:-gpt-4.1}" \
+              '{
+                "messages": [
+                  {"role": "system", "content": $system},
+                  {"role": "user", "content": $user}
+                ],
+                "model": $model,
+                "temperature": 0.7,
+                "max_tokens": 4000
+              }')
 
-          # The step runs under `bash -e`, so a failing curl aborts it outright
-          # and the fallback below never runs. Keep the exit code instead.
-          CURL_EXIT=0
-          API_RESPONSE=$(echo "$REQUEST_JSON" | curl -sS --max-time 120 -X POST \
-            "https://models.github.ai/inference/chat/completions" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ github.token }}" \
-            -d @- 2>/tmp/curl_err.txt) || CURL_EXIT=$?
+            # This step runs under `bash -e`, so a failing curl would abort it
+            # and the generated summary would never be used. Keep the exit code.
+            CURL_EXIT=0
+            API_RESPONSE=$(echo "$REQUEST_JSON" | curl -sS --max-time 120 -X POST \
+              "${LLM_API_URL}" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${LLM_API_KEY}" \
+              -d @- 2>/tmp/curl_err.txt) || CURL_EXIT=$?
 
-          ANALYSIS=$(printf '%s' "$API_RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)
+            ANALYSIS=$(printf '%s' "$API_RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)
 
-          if [ -z "$ANALYSIS" ]; then
-            echo "::warning::AI analysis failed, using fallback description"
-            # Without this the next outage looks identical to a model that
-            # simply returned nothing.
-            echo "curl exit code: ${CURL_EXIT}"
-            if [ -s /tmp/curl_err.txt ]; then
-              sed 's/^/curl: /' /tmp/curl_err.txt
+            if [ -n "$ANALYSIS" ]; then
+              printf '%s\n' "$ANALYSIS" > /tmp/pr_description.txt
+            else
+              # Without this the next outage looks the same as a model that
+              # simply returned nothing.
+              echo "::warning::LLM request failed, using the generated change summary"
+              echo "curl exit code: ${CURL_EXIT}"
+              if [ -s /tmp/curl_err.txt ]; then
+                sed 's/^/curl: /' /tmp/curl_err.txt
+              fi
+              printf '%s' "$API_RESPONSE" | head -c 500 | sed 's/^/response: /'
+              echo
             fi
-            printf '%s' "$API_RESPONSE" | head -c 500 | sed 's/^/response: /'
-            echo
-            ANALYSIS="Release ${NEXT:-develop -> main}
-
-          ## Changes
-
-          $COMMITS
-
-          ## Files changed
-          \`\`\`
-          $FILES_CHANGED
-          \`\`\`"
           fi
 
-          echo "$ANALYSIS" > /tmp/pr_description.txt
           echo "description_file=/tmp/pr_description.txt" >> $GITHUB_OUTPUT
 
       - name: Build PR title and body
@@ -227,11 +259,12 @@ jobs:
             fi
           fi
 
-          # Build body: skip first line (title) from AI output
-          AI_DESCRIPTION=$(tail -n +2 /tmp/pr_description.txt)
+          # The title is derived from the release prediction above, so the
+          # description file holds the body and nothing else.
+          DESCRIPTION=$(cat /tmp/pr_description.txt)
 
           cat > /tmp/pr_body.txt <<EOF
-          $AI_DESCRIPTION
+          $DESCRIPTION
 
           ---
 
@@ -243,7 +276,8 @@ jobs:
 
           **Source:** \`develop\` | **Target:** \`main\` | **Trigger:** Successful CI on develop
 
-          > Auto-generated by GitHub Actions & AI - updated automatically on new commits.
+          > Auto-generated by GitHub Actions - updated automatically on new commits.
+          > Replace this text, for example with a Copilot-written summary, and it will be left alone.
           EOF
 
       - name: Update existing PR

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -146,21 +146,32 @@ jobs:
                 {"role": "system", "content": $system},
                 {"role": "user", "content": $user}
               ],
-              "model": "gpt-4.1",
+              "model": "openai/gpt-4.1",
               "temperature": 0.7,
               "max_tokens": 4000
             }')
 
-          API_RESPONSE=$(echo "$REQUEST_JSON" | curl -s -X POST \
-            "https://models.inference.ai.azure.com/chat/completions" \
+          # The step runs under `bash -e`, so a failing curl aborts it outright
+          # and the fallback below never runs. Keep the exit code instead.
+          CURL_EXIT=0
+          API_RESPONSE=$(echo "$REQUEST_JSON" | curl -sS --max-time 120 -X POST \
+            "https://models.github.ai/inference/chat/completions" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ github.token }}" \
-            -d @-)
+            -d @- 2>/tmp/curl_err.txt) || CURL_EXIT=$?
 
-          ANALYSIS=$(echo "$API_RESPONSE" | jq -r '.choices[0].message.content // empty')
+          ANALYSIS=$(printf '%s' "$API_RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)
 
           if [ -z "$ANALYSIS" ]; then
             echo "::warning::AI analysis failed, using fallback description"
+            # Without this the next outage looks identical to a model that
+            # simply returned nothing.
+            echo "curl exit code: ${CURL_EXIT}"
+            if [ -s /tmp/curl_err.txt ]; then
+              sed 's/^/curl: /' /tmp/curl_err.txt
+            fi
+            printf '%s' "$API_RESPONSE" | head -c 500 | sed 's/^/response: /'
+            echo
             ANALYSIS="Release ${NEXT:-develop -> main}
 
           ## Changes


### PR DESCRIPTION
The "Auto PR (develop -> main)" workflow has been failing since 2 September ([33621992436](https://github.com/slauger/openvox-operator/actions/runs/33621992436)), which is why #540 described three dependency commits while carrying more than sixty.

## What broke

GitHub Models was [retired on 30 July 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/) -- playground, catalog, inference API and BYOK, including for existing customers. The endpoint went with it:

```
models.inference.ai.azure.com is an alias for modelmesh-nexus-global-main.trafficmanager.net.
Host modelmesh-nexus-global-main.trafficmanager.net not found: 3(NXDOMAIN)
```

curl exits 6 on that, which is exactly the exit code the failing job reported. The successor host `models.github.ai` answers HTTP 410 `github_models_retirement_brownout` for every path, so there is no free endpoint to migrate to.

## Why the fallback did not save it

The step already had a fallback for "the model returned nothing", but it could never run: GitHub Actions executes `run:` under `bash -e`, so the failing curl aborted the step several lines before the check. Reproduced against the dead host:

| | before | after |
|---|---|---|
| output | *none* | fallback + diagnostics |
| step exit | **6** | 0 |

## Changes

**The description is now generated, not requested.** Commits are grouped the way semantic-release categorises them, with the file list in a collapsed block. No external service, no key, no outage surface. Verified against the current develop: 51 commits in, 51 listed, across Features, Fixes, Refactoring, Tests, Documentation and Chores.

**The LLM call is opt-in.** With no `LLM_API_KEY` secret the step logs a notice and uses the generated summary. With one it posts to `LLM_API_URL` -- any OpenAI-compatible `chat/completions` endpoint, so Gemini, Groq, Cerebras or a paid provider all work by setting two repository variables and one secret. No code change needed to bring summaries back.

**Failures are diagnosable.** The exit code, curl's stderr and the first 500 bytes of the response are logged. The previous warning said only "AI analysis failed", which is why a vanished endpoint looked identical to a model returning nothing.

Also: the description file now holds the body only, so the consumer no longer strips its first line (which would have eaten the first heading), and `--max-time 120` keeps a hung request from stalling the job.

## Manual descriptions still win

Unchanged behaviour, worth stating: the workflow only touches a PR whose body carries the `Auto-generated by GitHub Actions` marker. Replacing the text -- by hand or with the Copilot button in the UI -- opts that PR out permanently. The footer now says so.

This is already the case for #540, whose body I replaced with a reviewed release description including upgrade notes. The workflow will leave it alone.