### PR TITLE
fix(api): make pullSecrets and the Server pull policy take effect

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -397,11 +397,16 @@ type ImageSpec struct {
 	Tag string `json:"tag,omitempty"`
 
 	// PullPolicy defines the image pull policy.
-	// +kubebuilder:default="IfNotPresent"
+	//
+	// A nested default would be materialised into every Server, which is what
+	// made the Server-level override unreachable: the field was never empty, so
+	// it could not express "inherit". Unset falls back to the Config and then
+	// to IfNotPresent.
 	// +optional
 	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
 
 	// PullSecrets is a list of image pull secrets.
+	// On Server an entry overrides the Config's list rather than adding to it.
 	// +optional
 	PullSecrets []corev1.LocalObjectReference `json:"pullSecrets,omitempty"`
 }

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_configs.yaml
@@ -149,11 +149,18 @@ spec:
                   in this Config.
                 properties:
                   pullPolicy:
-                    default: IfNotPresent
-                    description: PullPolicy defines the image pull policy.
+                    description: |-
+                      PullPolicy defines the image pull policy.
+
+                      A nested default would be materialised into every Server, which is what
+                      made the Server-level override unreachable: the field was never empty, so
+                      it could not express "inherit". Unset falls back to the Config and then
+                      to IfNotPresent.
                     type: string
                   pullSecrets:
-                    description: PullSecrets is a list of image pull secrets.
+                    description: |-
+                      PullSecrets is a list of image pull secrets.
+                      On Server an entry overrides the Config's list rather than adding to it.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_databases.yaml
@@ -67,11 +67,18 @@ spec:
                 description: Image defines the container image for the Database.
                 properties:
                   pullPolicy:
-                    default: IfNotPresent
-                    description: PullPolicy defines the image pull policy.
+                    description: |-
+                      PullPolicy defines the image pull policy.
+
+                      A nested default would be materialised into every Server, which is what
+                      made the Server-level override unreachable: the field was never empty, so
+                      it could not express "inherit". Unset falls back to the Config and then
+                      to IfNotPresent.
                     type: string
                   pullSecrets:
-                    description: PullSecrets is a list of image pull secrets.
+                    description: |-
+                      PullSecrets is a list of image pull secrets.
+                      On Server an entry overrides the Config's list rather than adding to it.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_servers.yaml
@@ -3385,11 +3385,18 @@ spec:
                 description: Image overrides the Config's default image.
                 properties:
                   pullPolicy:
-                    default: IfNotPresent
-                    description: PullPolicy defines the image pull policy.
+                    description: |-
+                      PullPolicy defines the image pull policy.
+
+                      A nested default would be materialised into every Server, which is what
+                      made the Server-level override unreachable: the field was never empty, so
+                      it could not express "inherit". Unset falls back to the Config and then
+                      to IfNotPresent.
                     type: string
                   pullSecrets:
-                    description: PullSecrets is a list of image pull secrets.
+                    description: |-
+                      PullSecrets is a list of image pull secrets.
+                      On Server an entry overrides the Config's list rather than adding to it.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the

--- a/config/crd/bases/openvox.voxpupuli.org_configs.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_configs.yaml
@@ -149,11 +149,18 @@ spec:
                   in this Config.
                 properties:
                   pullPolicy:
-                    default: IfNotPresent
-                    description: PullPolicy defines the image pull policy.
+                    description: |-
+                      PullPolicy defines the image pull policy.
+
+                      A nested default would be materialised into every Server, which is what
+                      made the Server-level override unreachable: the field was never empty, so
+                      it could not express "inherit". Unset falls back to the Config and then
+                      to IfNotPresent.
                     type: string
                   pullSecrets:
-                    description: PullSecrets is a list of image pull secrets.
+                    description: |-
+                      PullSecrets is a list of image pull secrets.
+                      On Server an entry overrides the Config's list rather than adding to it.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the

--- a/config/crd/bases/openvox.voxpupuli.org_databases.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_databases.yaml
@@ -67,11 +67,18 @@ spec:
                 description: Image defines the container image for the Database.
                 properties:
                   pullPolicy:
-                    default: IfNotPresent
-                    description: PullPolicy defines the image pull policy.
+                    description: |-
+                      PullPolicy defines the image pull policy.
+
+                      A nested default would be materialised into every Server, which is what
+                      made the Server-level override unreachable: the field was never empty, so
+                      it could not express "inherit". Unset falls back to the Config and then
+                      to IfNotPresent.
                     type: string
                   pullSecrets:
-                    description: PullSecrets is a list of image pull secrets.
+                    description: |-
+                      PullSecrets is a list of image pull secrets.
+                      On Server an entry overrides the Config's list rather than adding to it.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the

--- a/config/crd/bases/openvox.voxpupuli.org_servers.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_servers.yaml
@@ -3385,11 +3385,18 @@ spec:
                 description: Image overrides the Config's default image.
                 properties:
                   pullPolicy:
-                    default: IfNotPresent
-                    description: PullPolicy defines the image pull policy.
+                    description: |-
+                      PullPolicy defines the image pull policy.
+
+                      A nested default would be materialised into every Server, which is what
+                      made the Server-level override unreachable: the field was never empty, so
+                      it could not express "inherit". Unset falls back to the Config and then
+                      to IfNotPresent.
                     type: string
                   pullSecrets:
-                    description: PullSecrets is a list of image pull secrets.
+                    description: |-
+                      PullSecrets is a list of image pull secrets.
+                      On Server an entry overrides the Config's list rather than adding to it.
                     items:
                       description: |-
                         LocalObjectReference contains enough information to let you locate the

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -210,6 +210,15 @@ Controls Puppet Server metrics.conf settings.
 | `Running` | ConfigMap created, ready for use |
 | `Error` | Reconciliation failed |
 
+### Image resolution
+
+`repository` and `tag` on a Server override the Config's values individually;
+an unset field falls back to the Config. `pullPolicy` follows the same rule and
+defaults to `IfNotPresent` when neither sets it. `pullSecrets` is different: a
+non-empty list on the Server *replaces* the Config's rather than extending it,
+so a Server pulling from another registry does not carry the Config's
+credentials along. Secrets for code images are always added on top.
+
 ## Created Resources
 
 | Resource | Name | Description |

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -111,7 +111,18 @@ When enabled, the default policy allows TCP/8140 from all sources (agents may co
 | `phase` | string | Current lifecycle phase |
 | `ready` | int32 | Number of ready replicas |
 | `desired` | int32 | Desired number of replicas |
-| `conditions` | []Condition | `SSLBootstrapped`, `Ready` |
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from |
+| `conditions` | []Condition | See below |
+
+### Conditions
+
+| Type | Reason | Meaning |
+|---|---|---|
+| `SSLBootstrapped` | `CertificateSigned` | The referenced Certificate is signed, so the pods have TLS material |
+| `SSLBootstrapped` | `CertificateNotFound` | `spec.certificateRef` points at a Certificate that does not exist |
+| `SSLBootstrapped` | `CertificateNotSigned` | The Certificate exists but has not been signed yet |
+| `Ready` | `ReplicasReady` | At least one replica is ready |
+| `Ready` | `ReplicasNotReady` | No replica is ready yet |
 
 ## Phases
 
@@ -183,6 +194,15 @@ Key differences:
 | webserver.conf | `webserver-ca.conf` (CRL from PVC) | `webserver.conf` (CRL from Secret mount) |
 | ca.cfg | `ca-enabled.cfg` | `ca-disabled.cfg` |
 | Strategy | Recreate | RollingUpdate |
+
+### Image resolution
+
+`repository` and `tag` on a Server override the Config's values individually;
+an unset field falls back to the Config. `pullPolicy` follows the same rule and
+defaults to `IfNotPresent` when neither sets it. `pullSecrets` is different: a
+non-empty list on the Server *replaces* the Config's rather than extending it,
+so a Server pulling from another registry does not carry the Config's
+credentials along. Secrets for code images are always added on top.
 
 ## Created Resources
 

--- a/internal/controller/certificateauthority_job.go
+++ b/internal/controller/certificateauthority_job.go
@@ -177,11 +177,12 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 					// otherwise owned by root; overridable via ca.spec.securityContext.
 					SecurityContext: buildPodSecurityContext(
 						CASetupRunAsUser, CASetupRunAsGroup, CASetupFSGroup, ca.Spec.SecurityContext),
+					ImagePullSecrets: appendPullSecrets(nil, cfg.Spec.Image.PullSecrets...),
 					Containers: []corev1.Container{
 						{
 							Name:            "ca-setup",
 							Image:           image,
-							ImagePullPolicy: cfg.Spec.Image.PullPolicy,
+							ImagePullPolicy: configImagePullPolicy(cfg),
 							Command:         []string{"/bin/bash", "-c", script},
 							Env:             envVars,
 							Resources:       resolveCAJobResources(ca),

--- a/internal/controller/database_deployment.go
+++ b/internal/controller/database_deployment.go
@@ -185,7 +185,7 @@ func (r *DatabaseReconciler) buildPodSpec(db *openvoxv1alpha1.Database, cert *op
 	container := corev1.Container{
 		Name:            "openvox-db",
 		Image:           image,
-		ImagePullPolicy: db.Spec.Image.PullPolicy,
+		ImagePullPolicy: pullPolicyOrDefault(db.Spec.Image.PullPolicy),
 		Env:             env,
 		Ports: []corev1.ContainerPort{
 			{Name: "https", ContainerPort: DatabaseHTTPSPort, Protocol: corev1.ProtocolTCP},
@@ -229,7 +229,7 @@ chmod 640 /ssl/private_keys/%s.pem`, certname, certname, certname)
 	initContainer := corev1.Container{
 		Name:            "tls-init",
 		Image:           image,
-		ImagePullPolicy: db.Spec.Image.PullPolicy,
+		ImagePullPolicy: pullPolicyOrDefault(db.Spec.Image.PullPolicy),
 		Command:         []string{"sh", "-c", sslInitScript},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "ssl", MountPath: "/ssl"},
@@ -260,6 +260,7 @@ chmod 640 /ssl/private_keys/%s.pem`, certname, certname, certname)
 		InitContainers:    []corev1.Container{initContainer},
 		Containers:        []corev1.Container{container},
 		Volumes:           volumes,
+		ImagePullSecrets:  appendPullSecrets(nil, db.Spec.Image.PullSecrets...),
 	}
 
 	return podSpec

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -251,6 +251,59 @@ func resolveImage(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) s
 	return fmt.Sprintf("%s:%s", cfg.Spec.Image.Repository, cfg.Spec.Image.Tag)
 }
 
+// resolveImagePullPolicy returns the pull policy for a Server, preferring its
+// own value and falling back to the Config, then to IfNotPresent.
+func resolveImagePullPolicy(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) corev1.PullPolicy {
+	if server.Spec.Image.PullPolicy != "" {
+		return server.Spec.Image.PullPolicy
+	}
+	return configImagePullPolicy(cfg)
+}
+
+// configImagePullPolicy returns the Config's pull policy, or the Kubernetes
+// default when it is unset.
+func configImagePullPolicy(cfg *openvoxv1alpha1.Config) corev1.PullPolicy {
+	if cfg.Spec.Image.PullPolicy != "" {
+		return cfg.Spec.Image.PullPolicy
+	}
+	return corev1.PullIfNotPresent
+}
+
+// pullPolicyOrDefault returns the given policy, or IfNotPresent when unset.
+func pullPolicyOrDefault(p corev1.PullPolicy) corev1.PullPolicy {
+	if p != "" {
+		return p
+	}
+	return corev1.PullIfNotPresent
+}
+
+// resolveImagePullSecrets returns the pull secrets for a Server. A list on the
+// Server replaces the Config's rather than extending it, so a Server pulling
+// from a different registry does not drag the Config's credentials along.
+func resolveImagePullSecrets(server *openvoxv1alpha1.Server, cfg *openvoxv1alpha1.Config) []corev1.LocalObjectReference {
+	if len(server.Spec.Image.PullSecrets) > 0 {
+		return server.Spec.Image.PullSecrets
+	}
+	return cfg.Spec.Image.PullSecrets
+}
+
+// appendPullSecrets adds refs that are not already present, so callers can
+// combine sources without producing duplicates.
+func appendPullSecrets(existing []corev1.LocalObjectReference, add ...corev1.LocalObjectReference) []corev1.LocalObjectReference {
+	seen := make(map[string]bool, len(existing))
+	for _, e := range existing {
+		seen[e.Name] = true
+	}
+	for _, a := range add {
+		if a.Name == "" || seen[a.Name] {
+			continue
+		}
+		seen[a.Name] = true
+		existing = append(existing, a)
+	}
+	return existing
+}
+
 // serverRoleEnabled reports whether the Server runs the catalog server role.
 // The spec field defaults to true, so an unset value enables the role.
 func serverRoleEnabled(server *openvoxv1alpha1.Server) bool {

--- a/internal/controller/image_pull_settings_test.go
+++ b/internal/controller/image_pull_settings_test.go
@@ -1,0 +1,252 @@
+package controller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// serverPrereqsWith returns the standard Server prerequisites with a
+// caller-supplied Config, so a test can vary the image settings.
+func serverPrereqsWith(cfg *openvoxv1alpha1.Config) []client.Object {
+	objs := serverPrereqs()
+	for i := range objs {
+		if _, ok := objs[i].(*openvoxv1alpha1.Config); ok {
+			objs[i] = cfg
+			return objs
+		}
+	}
+	panic("serverPrereqs no longer contains a Config")
+}
+
+// pullSecretNames flattens the pod's pull secrets for comparison.
+func pullSecretNames(refs []corev1.LocalObjectReference) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+func equalStrings(got []string, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestPullSecrets_ReachTheServerPod covers a field that was declared on
+// ImageSpec but read nowhere: pull secrets configured on the Config never
+// reached any pod, so a private registry could not work at all.
+func TestPullSecrets_ReachTheServerPod(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	cfg.Spec.Image.PullSecrets = []corev1.LocalObjectReference{{Name: "registry-creds"}}
+	server := newServer("test-server")
+
+	c := setupTestClient(append(serverPrereqsWith(cfg), server)...)
+	r := newServerReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("reading the Deployment: %v", err)
+	}
+	if got := pullSecretNames(deploy.Spec.Template.Spec.ImagePullSecrets); !equalStrings(got, "registry-creds") {
+		t.Errorf("expected the Config's pull secret on the pod, got %v", got)
+	}
+}
+
+// TestPullSecrets_ServerOverridesConfig pins the documented precedence: a list
+// on the Server replaces the Config's rather than extending it.
+func TestPullSecrets_ServerOverridesConfig(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	cfg.Spec.Image.PullSecrets = []corev1.LocalObjectReference{{Name: "config-creds"}}
+	server := newServer("test-server")
+	server.Spec.Image.PullSecrets = []corev1.LocalObjectReference{{Name: "server-creds"}}
+
+	c := setupTestClient(append(serverPrereqsWith(cfg), server)...)
+	r := newServerReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("reading the Deployment: %v", err)
+	}
+	if got := pullSecretNames(deploy.Spec.Template.Spec.ImagePullSecrets); !equalStrings(got, "server-creds") {
+		t.Errorf("expected the Server's list to replace the Config's, got %v", got)
+	}
+}
+
+// TestPullPolicy_ServerOverridesConfig covers the second half of the same
+// problem: the Server's pull policy was read from the Config unconditionally,
+// so the field on the Server did nothing.
+func TestPullPolicy_ServerOverridesConfig(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	cfg.Spec.Image.PullPolicy = corev1.PullIfNotPresent
+	server := newServer("test-server")
+	server.Spec.Image.PullPolicy = corev1.PullAlways
+
+	c := setupTestClient(append(serverPrereqsWith(cfg), server)...)
+	r := newServerReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("reading the Deployment: %v", err)
+	}
+	for _, ctr := range deploy.Spec.Template.Spec.Containers {
+		if ctr.ImagePullPolicy != corev1.PullAlways {
+			t.Errorf("container %s: expected Always from the Server, got %q", ctr.Name, ctr.ImagePullPolicy)
+		}
+	}
+}
+
+// TestPullPolicy_InheritsFromConfig is the counterpart: an unset Server policy
+// must still take the Config's value.
+func TestPullPolicy_InheritsFromConfig(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	cfg.Spec.Image.PullPolicy = corev1.PullAlways
+	server := newServer("test-server") // no pull policy of its own
+
+	c := setupTestClient(append(serverPrereqsWith(cfg), server)...)
+	r := newServerReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, deploy); err != nil {
+		t.Fatalf("reading the Deployment: %v", err)
+	}
+	for _, ctr := range deploy.Spec.Template.Spec.Containers {
+		if ctr.ImagePullPolicy != corev1.PullAlways {
+			t.Errorf("container %s: expected Always inherited from the Config, got %q", ctr.Name, ctr.ImagePullPolicy)
+		}
+	}
+}
+
+// TestPullPolicy_DefaultsWhenUnsetEverywhere guards the fallback that replaced
+// the CRD default. The default had to go: materialised into every Server, it
+// made the field never empty and the override unreachable.
+func TestPullPolicy_DefaultsWhenUnsetEverywhere(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	server := newServer("test-server")
+
+	if got := resolveImagePullPolicy(server, cfg); got != corev1.PullIfNotPresent {
+		t.Errorf("expected IfNotPresent when nothing is set, got %q", got)
+	}
+}
+
+// TestPullSecrets_ReachTheDatabasePod and the CA job cover the other two
+// workloads that build pods from an ImageSpec.
+func TestPullSecrets_ReachTheDatabasePod(t *testing.T) {
+	db := newDatabase("puppetdb")
+	db.Spec.Image.PullSecrets = []corev1.LocalObjectReference{{Name: "registry-creds"}}
+
+	cert := newCertificate("puppetdb-cert", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	ca := newCertificateAuthority("production-ca")
+	r := newDatabaseReconciler(setupTestClient(db, cert, ca))
+	podSpec := r.buildPodSpec(db, cert, ca, "example/db:1")
+	if got := pullSecretNames(podSpec.ImagePullSecrets); !equalStrings(got, "registry-creds") {
+		t.Errorf("expected the pull secret on the Database pod, got %v", got)
+	}
+}
+
+// TestSSLBootstrapped_ReportsAMissingCertificate covers a condition that was
+// declared, documented in docs/reference/server.md, and never set. A Server
+// waiting for its Certificate left no trace in the status at all.
+func TestSSLBootstrapped_ReportsAMissingCertificate(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	server := newServer("test-server") // certificateRef points at a Certificate that does not exist
+
+	c := setupTestClient(cfg, server)
+	r := newServerReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &openvoxv1alpha1.Server{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading the Server back: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionSSLBootstrapped)
+	if cond == nil {
+		t.Fatal("expected an SSLBootstrapped condition while the Certificate is missing")
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != "CertificateNotFound" {
+		t.Errorf("expected False/CertificateNotFound, got %s/%s", cond.Status, cond.Reason)
+	}
+}
+
+// TestSSLBootstrapped_ReportsAnUnsignedCertificate is the second waiting state.
+func TestSSLBootstrapped_ReportsAnUnsignedCertificate(t *testing.T) {
+	cfg := newConfig("production", withAuthorityRef("production-ca"))
+	cert := newCertificate("production-cert", "production-ca", openvoxv1alpha1.CertificatePhasePending)
+	server := newServer("test-server")
+
+	c := setupTestClient(cfg, cert, server)
+	r := newServerReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &openvoxv1alpha1.Server{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading the Server back: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionSSLBootstrapped)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "CertificateNotSigned" {
+		t.Errorf("expected False/CertificateNotSigned, got %+v", cond)
+	}
+}
+
+// TestSSLBootstrapped_TrueOnceSigned closes the loop.
+func TestSSLBootstrapped_TrueOnceSigned(t *testing.T) {
+	server := newServer("test-server")
+	c := setupTestClient(append(serverPrereqs(), server)...)
+	r := newServerReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("test-server")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &openvoxv1alpha1.Server{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-server", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading the Server back: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionSSLBootstrapped)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("expected SSLBootstrapped=True once the Certificate is signed, got %+v", cond)
+	}
+}
+
+// TestPullSecrets_ReachTheCASetupJob covers the third workload.
+func TestPullSecrets_ReachTheCASetupJob(t *testing.T) {
+	ca := newCertificateAuthority("test-ca")
+	cfg := caPrereqs("test-ca")
+	cfg.Spec.Image.PullSecrets = []corev1.LocalObjectReference{{Name: "registry-creds"}}
+
+	r := newCertificateAuthorityReconciler(setupTestClient(ca, cfg))
+	job := r.buildCASetupJob(testCtx(), ca, cfg, "test-ca-setup", nil)
+
+	if got := pullSecretNames(job.Spec.Template.Spec.ImagePullSecrets); !equalStrings(got, "registry-creds") {
+		t.Errorf("expected the pull secret on the CA setup job, got %v", got)
+	}
+}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -108,6 +108,8 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.CertificateRef, Namespace: server.Namespace}, cert); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("waiting for Certificate", "certificateRef", server.Spec.CertificateRef)
+			r.reportSSLBootstrapped(ctx, server, metav1.ConditionFalse, "CertificateNotFound",
+				fmt.Sprintf("Certificate %s does not exist", server.Spec.CertificateRef))
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("getting Certificate %s: %w", server.Spec.CertificateRef, err)
@@ -117,6 +119,13 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		logger.Info("waiting for Certificate to be signed", "certificate", cert.Name, "phase", cert.Status.Phase)
 		if statusErr := updateStatusWithRetry(ctx, r.Client, server, func() {
 			server.Status.Phase = openvoxv1alpha1.ServerPhaseWaitingForCert
+			meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionSSLBootstrapped,
+				Status:             metav1.ConditionFalse,
+				Reason:             "CertificateNotSigned",
+				Message:            fmt.Sprintf("Certificate %s is in phase %q", cert.Name, cert.Status.Phase),
+				ObservedGeneration: server.Generation,
+			})
 		}); statusErr != nil {
 			logger.Error(statusErr, "failed to update Server status", "name", server.Name)
 		}
@@ -168,6 +177,16 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		server.Status.Desired = replicas
 		server.Status.Ready = ready
 
+		// Reaching this point means the Certificate exists and is signed, so the
+		// pods have TLS material to mount.
+		meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionSSLBootstrapped,
+			Status:             metav1.ConditionTrue,
+			Reason:             "CertificateSigned",
+			Message:            fmt.Sprintf("Certificate %s is signed and mounted", cert.Name),
+			ObservedGeneration: server.Generation,
+		})
+
 		serverReplicasDesired.WithLabelValues(server.Name, server.Namespace).Set(float64(replicas))
 		serverReplicasReady.WithLabelValues(server.Name, server.Namespace).Set(float64(ready))
 
@@ -198,6 +217,25 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonServerRunning, "Reconcile", "Server reconciled successfully")
 	}
 	return ctrl.Result{}, nil
+}
+
+// reportSSLBootstrapped records the condition on its own, for the early
+// returns that happen before the single status write at the end of Reconcile.
+// A dependency the Server is waiting for used to leave no trace in the status
+// at all, so "nothing happens" looked the same as "nothing is wrong".
+func (r *ServerReconciler) reportSSLBootstrapped(ctx context.Context, server *openvoxv1alpha1.Server,
+	status metav1.ConditionStatus, reason, message string) {
+	if err := updateStatusWithRetry(ctx, r.Client, server, func() {
+		meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionSSLBootstrapped,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: server.Generation,
+		})
+	}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to record the SSLBootstrapped condition", "name", server.Name)
+	}
 }
 
 func (r *ServerReconciler) reconcilePDB(ctx context.Context, server *openvoxv1alpha1.Server) error {

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -456,7 +456,7 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 	container := corev1.Container{
 		Name:            "openvox-server",
 		Image:           image,
-		ImagePullPolicy: cfg.Spec.Image.PullPolicy,
+		ImagePullPolicy: resolveImagePullPolicy(server, cfg),
 		Env:             env,
 		EnvFrom:         server.Spec.EnvFrom,
 		Ports: []corev1.ContainerPort{
@@ -508,7 +508,7 @@ chmod 640 /ssl/private_keys/puppet.pem`
 	initContainer := corev1.Container{
 		Name:            "tls-init",
 		Image:           image,
-		ImagePullPolicy: cfg.Spec.Image.PullPolicy,
+		ImagePullPolicy: resolveImagePullPolicy(server, cfg),
 		Command:         []string{"sh", "-c", sslInitScript},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "ssl", MountPath: "/ssl"},
@@ -544,16 +544,13 @@ chmod 640 /ssl/private_keys/puppet.pem`
 		Volumes:                   volumes,
 	}
 
-	// Add imagePullSecrets for code images if configured (deduplicated across entries)
+	// The server image and the code images can live in different registries, so
+	// both sets of credentials end up on the pod, deduplicated.
+	podSpec.ImagePullSecrets = appendPullSecrets(nil, resolveImagePullSecrets(server, cfg)...)
 	if serverRoleEnabled(server) {
-		seen := make(map[string]bool)
 		for _, e := range resolveCode(server, cfg) {
-			if e.ImagePullSecret != "" && !seen[e.ImagePullSecret] {
-				seen[e.ImagePullSecret] = true
-				podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, corev1.LocalObjectReference{
-					Name: e.ImagePullSecret,
-				})
-			}
+			podSpec.ImagePullSecrets = appendPullSecrets(podSpec.ImagePullSecrets,
+				corev1.LocalObjectReference{Name: e.ImagePullSecret})
 		}
 	}
 


### PR DESCRIPTION
Three fields from the second review pass that were declared but never reached a pod. Each test was run against the old code first; eight of the ten fail there.

## pullSecrets reached nothing

`ImageSpec.PullSecrets` was read nowhere. The only `imagePullSecrets` on any pod came from code image entries (`server_deployment.go`), so a private registry for the server, database or CA setup image could not work at all -- the field existed on all three CRDs and did nothing.

All three pod specs now carry them, deduplicated against the code image secrets, which can point at a different registry.

## Server.image.pullPolicy was ignored

Both container specs read `cfg.Spec.Image.PullPolicy` unconditionally, so the field on the Server did nothing.

Fixing it required removing the nested kubebuilder default, for the same reason #549 removed it from `repository` and `tag`: a nested default is materialised into every Server whether or not the parent object was specified, so the field was never empty and could not express "inherit". The fallback now lives in code:

```
Server.image.pullPolicy -> Config.image.pullPolicy -> IfNotPresent
```

**Upgrade note.** Existing Servers carry `pullPolicy: IfNotPresent` materialised from the old default, so they will keep overriding the Config until the field is cleared. Same shape as the `repository`/`tag` note in #540. For chart users a `helm upgrade` clears it.

## SSLBootstrapped was a promise, not a condition

`ConditionSSLBootstrapped` existed as a constant and was documented in `docs/reference/server.md` as one of the two Server conditions, but nothing ever set it.

It now reports whether the referenced Certificate is usable:

| Reason | Meaning |
|---|---|
| `CertificateSigned` | signed, pods have TLS material |
| `CertificateNotFound` | `certificateRef` points at nothing |
| `CertificateNotSigned` | exists, not signed yet |

That also closes a gap several review perspectives found independently: a Server waiting for a dependency left no trace in its status, so "nothing happens" looked the same as "nothing is wrong".

## Also

Documented the resolution rules in the Config and Server references, including that `pullSecrets` on a Server *replaces* the Config's list rather than extending it -- deliberate, so a Server pulling from another registry does not drag the Config's credentials along.

`make test`, `make manifests` and golangci-lint 2.13.2 are clean.

## Not included

The cluster-wide unfiltered Secret cache from the same review is a separate change (informer scoping plus an uncached reader for user-supplied Secrets) and gets its own issue.