### PR TITLE
fix(certificate): refuse to share a certname, and require an explicit one

### DIFF
--- a/api/v1alpha1/certificate_immutability_test.go
+++ b/api/v1alpha1/certificate_immutability_test.go
@@ -66,22 +66,35 @@ func TestCertificateCertnameIsImmutable(t *testing.T) {
 		}
 	})
 
-	t.Run("the defaulted certname survives an unrelated update", func(t *testing.T) {
+	// The shared "puppet" default used to make two Certificates collide by
+	// default rather than by mistake: a certname identifies exactly one entry
+	// on the CA. There is no default any more, and an omitted certname is a
+	// validation error rather than a silent collision.
+	t.Run("an omitted certname is rejected", func(t *testing.T) {
 		cert := &Certificate{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cert-", Namespace: "default"},
 			Spec:       CertificateSpec{AuthorityRef: "production-ca"},
 		}
+		err := k8sClient.Create(ctx, cert)
+		if err == nil {
+			t.Cleanup(func() { _ = k8sClient.Delete(ctx, cert) })
+			t.Fatalf("expected a Certificate without a certname to be rejected, got certname %q", cert.Spec.Certname)
+		}
+		if !strings.Contains(err.Error(), "certname") {
+			t.Errorf("expected the error to name the certname field, got: %v", err)
+		}
+	})
+
+	t.Run("an unrelated update leaves the certname alone", func(t *testing.T) {
+		cert := newCert()
 		if err := k8sClient.Create(ctx, cert); err != nil {
 			t.Fatalf("creating Certificate: %v", err)
 		}
 		t.Cleanup(func() { _ = k8sClient.Delete(ctx, cert) })
-		if cert.Spec.Certname != "puppet" {
-			t.Fatalf("expected the default certname, got %q", cert.Spec.Certname)
-		}
 
 		cert.Spec.RenewBefore = "30d"
 		if err := k8sClient.Update(ctx, cert); err != nil {
-			t.Errorf("an update that leaves the defaulted certname alone must pass, got: %v", err)
+			t.Errorf("an update that does not touch the certname must pass, got: %v", err)
 		}
 	})
 }

--- a/api/v1alpha1/certificate_types.go
+++ b/api/v1alpha1/certificate_types.go
@@ -141,6 +141,10 @@ type CertificateStatus struct {
 // Condition types for Certificate.
 const (
 	ConditionCertSigned = "CertSigned"
+
+	// ConditionCertnameConflict reports that another Certificate already claims
+	// this certname against the same CertificateAuthority.
+	ConditionCertnameConflict = "CertnameConflict"
 )
 
 func init() {

--- a/api/v1alpha1/certificate_types.go
+++ b/api/v1alpha1/certificate_types.go
@@ -63,10 +63,15 @@ type CertificateSpec struct {
 	// The name is baked into the issued certificate and into the entry the CA
 	// keeps for it. Changing it would leave that entry behind under the old
 	// name, so the finalizer could no longer clean it up on deletion.
-	// +kubebuilder:default="puppet"
+	//
+	// There is deliberately no default. A certname identifies exactly one entry
+	// on the CA, so a shared default made two Certificates collide by default
+	// rather than by mistake. "puppet" is also only the right identity for the
+	// main server: PuppetDB and any further certificate need their own. The
+	// names agents connect through belong in DNSAltNames, not here.
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="certname is immutable"
-	// +optional
-	Certname string `json:"certname,omitempty"`
+	Certname string `json:"certname"`
 
 	// DNSAltNames is a list of DNS subject alternative names for the certificate.
 	// Order is irrelevant and duplicates are rejected.

--- a/api/v1alpha1/list_types_test.go
+++ b/api/v1alpha1/list_types_test.go
@@ -21,6 +21,7 @@ func TestListSemantics(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cert-", Namespace: "default"},
 			Spec: CertificateSpec{
 				AuthorityRef: "production-ca",
+				Certname:     "web.example.com",
 				DNSAltNames:  []string{"puppet.example.com", "puppet.example.com"},
 			},
 		}
@@ -39,6 +40,7 @@ func TestListSemantics(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-cert-", Namespace: "default"},
 			Spec: CertificateSpec{
 				AuthorityRef: "production-ca",
+				Certname:     "web.example.com",
 				DNSAltNames:  []string{"a.example.com", "b.example.com"},
 			},
 		}

--- a/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
+++ b/charts/openvox-operator/crds/openvox.voxpupuli.org_certificates.yaml
@@ -64,13 +64,19 @@ spec:
                   signs this certificate.
                 type: string
               certname:
-                default: puppet
                 description: |-
                   Certname is the certificate common name. Immutable after creation.
 
                   The name is baked into the issued certificate and into the entry the CA
                   keeps for it. Changing it would leave that entry behind under the old
                   name, so the finalizer could no longer clean it up on deletion.
+
+                  There is deliberately no default. A certname identifies exactly one entry
+                  on the CA, so a shared default made two Certificates collide by default
+                  rather than by mistake. "puppet" is also only the right identity for the
+                  main server: PuppetDB and any further certificate need their own. The
+                  names agents connect through belong in DNSAltNames, not here.
+                minLength: 1
                 type: string
                 x-kubernetes-validations:
                 - message: certname is immutable
@@ -114,6 +120,7 @@ spec:
                 type: string
             required:
             - authorityRef
+            - certname
             type: object
           status:
             description: CertificateStatus defines the observed state of Certificate.

--- a/charts/openvox-stack/templates/certificates.yaml
+++ b/charts/openvox-stack/templates/certificates.yaml
@@ -1,4 +1,7 @@
 {{- range $entry := .Values.servers }}
+{{- if not $entry.certificate.certname }}
+{{- fail (printf "servers[%s].certificate.certname is required: a certname identifies exactly one entry on the CA, so two servers sharing one cannot both be signed" $entry.name) }}
+{{- end }}
 ---
 apiVersion: openvox.voxpupuli.org/v1alpha1
 kind: Certificate

--- a/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
+++ b/config/crd/bases/openvox.voxpupuli.org_certificates.yaml
@@ -64,13 +64,19 @@ spec:
                   signs this certificate.
                 type: string
               certname:
-                default: puppet
                 description: |-
                   Certname is the certificate common name. Immutable after creation.
 
                   The name is baked into the issued certificate and into the entry the CA
                   keeps for it. Changing it would leave that entry behind under the old
                   name, so the finalizer could no longer clean it up on deletion.
+
+                  There is deliberately no default. A certname identifies exactly one entry
+                  on the CA, so a shared default made two Certificates collide by default
+                  rather than by mistake. "puppet" is also only the right identity for the
+                  main server: PuppetDB and any further certificate need their own. The
+                  names agents connect through belong in DNSAltNames, not here.
+                minLength: 1
                 type: string
                 x-kubernetes-validations:
                 - message: certname is immutable
@@ -114,6 +120,7 @@ spec:
                 type: string
             required:
             - authorityRef
+            - certname
             type: object
           status:
             description: CertificateStatus defines the observed state of Certificate.

--- a/docs/reference/certificate.md
+++ b/docs/reference/certificate.md
@@ -22,7 +22,7 @@ spec:
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `authorityRef` | string | **required** | Reference to the CertificateAuthority |
-| `certname` | string | `puppet` | Certificate common name (CN) |
+| `certname` | string | **required** | Certificate common name (CN) |
 | `dnsAltNames` | []string | - | DNS subject alternative names |
 | `renewBefore` | string | `60d` | Duration before expiration when the certificate should be renewed (e.g. `60d`, `720h`) |
 | `csrExtensions` | CSRExtensionsSpec | - | Puppet CSR extension attributes to embed in the CSR |
@@ -178,8 +178,14 @@ The operator therefore refuses the collision in three places:
 - a certificate returned by the CA is verified against the private key it was
   requested for, so a foreign certificate under the same name is never stored
 
-`certname` defaults to `puppet`, so two Certificates created without one collide
-by default rather than by mistake. Give each Certificate its own certname.
+`certname` is required and has no default. It used to default to `puppet`, which
+made two Certificates created without one collide by default rather than by
+mistake, and `puppet` is only the right identity for the main server anyway --
+PuppetDB and any further certificate need their own.
+
+The names agents connect through, such as a load balancer or a service address,
+belong in `dnsAltNames` rather than here. The chart derives the Service names of
+every Pool a server joins into that list automatically.
 
 ## Created Resources
 

--- a/docs/reference/certificate.md
+++ b/docs/reference/certificate.md
@@ -163,6 +163,24 @@ flowchart TD
 
 The controller discovers the CA Service automatically by finding Servers with `ca: true` in the same Config and the Pools whose selector matches them.
 
+## Certname uniqueness
+
+A certname identifies exactly one entry on the CertificateAuthority. Two
+Certificates that claim the same certname against the same CA are
+indistinguishable to it, with two consequences: the second CSR is rejected, and
+deleting either one revokes the entry both rely on.
+
+The operator therefore refuses the collision in three places:
+
+- the admission webhook rejects a duplicate at creation, naming the other resource
+- the controller refuses to sign and reports `CertnameConflict`, since webhooks
+  are disabled by default
+- a certificate returned by the CA is verified against the private key it was
+  requested for, so a foreign certificate under the same name is never stored
+
+`certname` defaults to `puppet`, so two Certificates created without one collide
+by default rather than by mistake. Give each Certificate its own certname.
+
 ## Created Resources
 
 | Resource | Name | Description |

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -43,6 +43,7 @@ const (
 	EventReasonCertificateRenewed          = "CertificateRenewed"
 	EventReasonCertificateExpiringSoon     = "CertificateExpiringSoon"
 	EventReasonCertificateCleaned          = "CertificateCleaned"
+	EventReasonCertnameConflict            = "CertnameConflict"
 )
 
 // Maximum requeue interval for renewal checks (caps the time-based backoff).
@@ -265,6 +266,17 @@ func (r *CertificateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // and returns RequeueAfter if the cert isn't signed yet.
 func (r *CertificateReconciler) reconcileCertSigning(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	// The webhook rejects a duplicate certname at admission, but webhooks are
+	// off by default, so the guarantee has to hold here too. Signing under a
+	// certname another Certificate owns cannot succeed -- the CA has one entry
+	// per name -- and deleting either resource would revoke the entry the other
+	// depends on.
+	if other, err := r.otherCertificateUsingCertname(ctx, cert); err != nil {
+		return ctrl.Result{}, err
+	} else if other != "" {
+		return r.reportCertnameConflict(ctx, cert, other)
+	}
 
 	// Resolve CA base URL: external URL or internal CA Service
 	var caBaseURL string
@@ -588,4 +600,81 @@ func (r *CertificateReconciler) renewalDue(cert *openvoxv1alpha1.Certificate) bo
 		return false
 	}
 	return !r.isWithinRenewalCooldown(cert)
+}
+
+// otherCertificateUsingCertname returns the name of another live Certificate in
+// the namespace that claims the same certname against the same
+// CertificateAuthority, or "" when there is none.
+//
+// The CRD defaults certname to "puppet", so two Certificates created without
+// one collide by default rather than by mistake.
+func (r *CertificateReconciler) otherCertificateUsingCertname(ctx context.Context,
+	cert *openvoxv1alpha1.Certificate) (string, error) {
+	certList := &openvoxv1alpha1.CertificateList{}
+	if err := r.List(ctx, certList,
+		client.InNamespace(cert.Namespace),
+		client.MatchingFields{IndexCertname: certnameOf(cert)}); err != nil {
+		return "", fmt.Errorf("listing Certificates by certname in namespace %s: %w", cert.Namespace, err)
+	}
+
+	claimants := make([]string, 0, len(certList.Items))
+	for i := range certList.Items {
+		other := &certList.Items[i]
+		switch {
+		case other.Name == cert.Name:
+			continue
+		// A Certificate on its way out releases the name: its finalizer cleans
+		// the CA entry.
+		case !other.DeletionTimestamp.IsZero():
+			continue
+		case other.Spec.AuthorityRef != cert.Spec.AuthorityRef:
+			continue
+		}
+		claimants = append(claimants, other.Name)
+	}
+	if len(claimants) == 0 {
+		return "", nil
+	}
+
+	// Stable output so the reported conflict does not flip between reconciles.
+	sort.Strings(claimants)
+	return claimants[0], nil
+}
+
+// reportCertnameConflict records the conflict and stops. Retrying cannot help:
+// only a spec change or the removal of the other Certificate frees the name.
+func (r *CertificateReconciler) reportCertnameConflict(ctx context.Context,
+	cert *openvoxv1alpha1.Certificate, other string) (ctrl.Result, error) {
+	msg := fmt.Sprintf("certname %q is already claimed by Certificate %s against CertificateAuthority %s",
+		certnameOf(cert), other, cert.Spec.AuthorityRef)
+
+	existing := meta.FindStatusCondition(cert.Status.Conditions, openvoxv1alpha1.ConditionCertnameConflict)
+	alreadyReported := existing != nil && existing.Status == metav1.ConditionTrue && existing.Message == msg
+
+	if err := updateStatusWithRetry(ctx, r.Client, cert, func() {
+		cert.Status.Phase = openvoxv1alpha1.CertificatePhaseError
+		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionCertnameConflict,
+			Status:             metav1.ConditionTrue,
+			Reason:             "DuplicateCertname",
+			Message:            msg,
+			ObservedGeneration: cert.Generation,
+		})
+		meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+			Type:               openvoxv1alpha1.ConditionCertSigned,
+			Status:             metav1.ConditionFalse,
+			Reason:             "CertnameConflict",
+			Message:            msg,
+			ObservedGeneration: cert.Generation,
+		})
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("reporting the certname conflict for %s: %w", cert.Name, err)
+	}
+
+	if !alreadyReported {
+		log.FromContext(ctx).Info("refusing to sign, certname already claimed",
+			"certname", certnameOf(cert), "claimedBy", other)
+		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertnameConflict, "Reconcile", "%s", msg)
+	}
+	return ctrl.Result{}, nil
 }

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -196,10 +196,7 @@ func buildCSRExtensions(spec *openvoxv1alpha1.CSRExtensionsSpec) ([]pkix.Extensi
 func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	certname := cert.Spec.Certname
-	if certname == "" {
-		certname = "puppet"
-	}
+	certname := certnameOf(cert)
 
 	pendingSecretName := fmt.Sprintf("%s-tls-pending", cert.Name)
 
@@ -309,10 +306,7 @@ func parsePrivateKey(der []byte) (*rsa.PrivateKey, error) {
 
 // fetchSignedCert checks if the CA has signed the certificate. Returns the PEM cert or nil.
 func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) ([]byte, error) {
-	certname := cert.Spec.Certname
-	if certname == "" {
-		certname = "puppet"
-	}
+	certname := certnameOf(cert)
 
 	httpClient, err := caHTTPClientForCA(ctx, r.Client, ca, namespace)
 	if err != nil {
@@ -397,10 +391,7 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 		// Check absolute timeout based on pending Secret creation time
 		elapsed := time.Since(pendingSecret.CreationTimestamp.Time)
 		if !pendingSecret.CreationTimestamp.IsZero() && elapsed >= CSRPollAbsoluteTimeout {
-			certname := cert.Spec.Certname
-			if certname == "" {
-				certname = "puppet"
-			}
+			certname := certnameOf(cert)
 			timeoutMsg := fmt.Sprintf("CSR polling timed out after %s", elapsed.Truncate(time.Minute))
 			if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
 				cert.Status.Phase = openvoxv1alpha1.CertificatePhaseError
@@ -439,10 +430,7 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 
 		// After threshold, transition to WaitingForSigning phase
 		if attempts >= CSRPollWaitingThreshold {
-			certname := cert.Spec.Certname
-			if certname == "" {
-				certname = "puppet"
-			}
+			certname := certnameOf(cert)
 			waitMsg := fmt.Sprintf("CSR submitted but not yet signed after %d attempts", attempts)
 			if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
 				cert.Status.Phase = openvoxv1alpha1.CertificatePhaseWaitingForSigning
@@ -823,10 +811,7 @@ func (r *CertificateReconciler) cleanCertViaAPI(ctx context.Context, cert *openv
 // signCSRViaAPI signs a pending CSR via the Puppet CA HTTP API using mTLS with the
 // operator-signing certificate (authorized by CN-based auth.conf rules).
 func (r *CertificateReconciler) signCSRViaAPI(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) error {
-	certname := cert.Spec.Certname
-	if certname == "" {
-		certname = "puppet"
-	}
+	certname := certnameOf(cert)
 
 	// Load CA public cert for TLS server verification
 	caCertPEM, err := getCAPublicCert(ctx, r.Client, ca, namespace)

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -261,6 +261,52 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 	return ctrl.Result{}, nil
 }
 
+// certMatchesKey reports whether the certificate was issued for the given
+// private key. It is the last line of defence against adopting a certificate
+// that belongs to a different Certificate sharing the same certname.
+func certMatchesKey(certPEM, keyPEM []byte) (bool, error) {
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return false, fmt.Errorf("decoding certificate PEM")
+	}
+	parsed, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return false, fmt.Errorf("parsing certificate: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return false, fmt.Errorf("decoding private key PEM")
+	}
+	key, err := parsePrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return false, err
+	}
+
+	pub, ok := parsed.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return false, fmt.Errorf("unsupported certificate public key type %T", parsed.PublicKey)
+	}
+	return pub.Equal(&key.PublicKey), nil
+}
+
+// parsePrivateKey accepts both PKCS#1 and PKCS#8 encodings, since the format
+// depends on who generated the key.
+func parsePrivateKey(der []byte) (*rsa.PrivateKey, error) {
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("unsupported private key type %T", parsed)
+	}
+	return key, nil
+}
+
 // fetchSignedCert checks if the CA has signed the certificate. Returns the PEM cert or nil.
 func (r *CertificateReconciler) fetchSignedCert(ctx context.Context, cert *openvoxv1alpha1.Certificate, ca *openvoxv1alpha1.CertificateAuthority, caBaseURL, namespace string) ([]byte, error) {
 	certname := cert.Spec.Certname
@@ -312,7 +358,12 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 		return result, err
 	}
 
-	// Step 2: Check if cert is signed (non-blocking, single attempt)
+	// Step 2: Check if cert is signed (non-blocking, single attempt).
+	//
+	// The CA is queried by certname, so a foreign certificate issued under the
+	// same name comes back here. Storing it would pair someone else's
+	// certificate with our private key, and the mismatch would only surface as
+	// a failed TLS handshake at runtime.
 	signedCertPEM, err := r.fetchSignedCert(ctx, cert, ca, caBaseURL, namespace)
 	if err != nil {
 		logger.Info("failed to fetch signed cert, will retry", "error", err)
@@ -420,6 +471,35 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 		return ctrl.Result{}, fmt.Errorf("reading pending key Secret: %w", err)
 	}
 	keyPEM := pendingSecret.Data["key.pem"]
+
+	// The CA was queried by certname, so what came back is whatever holds that
+	// name - not necessarily what we asked to be signed. Pairing a foreign
+	// certificate with our key would produce a Secret that only fails much
+	// later, during a TLS handshake, with an error that points nowhere near
+	// here.
+	matches, matchErr := certMatchesKey(signedCertPEM, keyPEM)
+	if matchErr != nil {
+		return ctrl.Result{}, fmt.Errorf("verifying the signed certificate against the pending key: %w", matchErr)
+	}
+	if !matches {
+		msg := fmt.Sprintf("the CA returned a certificate for certname %q that was issued for a different key; "+
+			"another Certificate is most likely using the same certname", certnameOf(cert))
+		if statusErr := updateStatusWithRetry(ctx, r.Client, cert, func() {
+			cert.Status.Phase = openvoxv1alpha1.CertificatePhaseError
+			meta.SetStatusCondition(&cert.Status.Conditions, metav1.Condition{
+				Type:               openvoxv1alpha1.ConditionCertSigned,
+				Status:             metav1.ConditionFalse,
+				Reason:             "CertnameConflict",
+				Message:            msg,
+				ObservedGeneration: cert.Generation,
+			})
+		}); statusErr != nil {
+			logger.Error(statusErr, "failed to record the certname conflict")
+		}
+		r.Recorder.Eventf(cert, nil, corev1.EventTypeWarning, EventReasonCertnameConflict, "Reconcile", "%s", msg)
+		// Nothing improves by retrying: only a spec change frees the certname.
+		return ctrl.Result{}, nil
+	}
 
 	tlsSecretName := fmt.Sprintf("%s-tls", cert.Name)
 	if err := r.createOrUpdateTLSSecret(ctx, cert, ca, tlsSecretName, signedCertPEM, keyPEM); err != nil {

--- a/internal/controller/certificate_signing_test.go
+++ b/internal/controller/certificate_signing_test.go
@@ -148,6 +148,49 @@ func generateTestCertWithExpiry(t *testing.T, validity time.Duration) ([]byte, [
 	return certPEM, keyPEM
 }
 
+// issueForCSR signs a submitted CSR with the test CA, so the returned
+// certificate carries the requester's public key. A canned certificate pairs a
+// foreign key with the controller's, which is exactly what certMatchesKey
+// refuses -- and what a shared certname would produce against a real CA.
+func issueForCSR(t *testing.T, caCertPEM, caKeyPEM, csrPEM []byte) []byte {
+	t.Helper()
+
+	csrBlock, _ := pem.Decode(csrPEM)
+	if csrBlock == nil {
+		t.Fatalf("decoding submitted CSR")
+	}
+	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parsing submitted CSR: %v", err)
+	}
+
+	caBlock, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parsing CA certificate: %v", err)
+	}
+	keyBlock, _ := pem.Decode(caKeyPEM)
+	caKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parsing CA key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      csr.Subject,
+		DNSNames:     csr.DNSNames,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, csr.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("signing the submitted CSR: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
 func TestBuildExternalCAHTTPClient_Minimal(t *testing.T) {
 	ext := &openvoxv1alpha1.ExternalCASpec{
 		URL: "https://puppet-ca.example.com:8140",
@@ -970,14 +1013,20 @@ func TestFetchSignedCert_EmptyCertname(t *testing.T) {
 func TestSignCertificate_FullFlow(t *testing.T) {
 	certPEM, keyPEM := generateTestCert(t)
 
-	// Server handles CSR submit and cert fetch
+	// Server handles CSR submit and cert fetch. It signs the submitted CSR
+	// rather than returning a canned certificate: the controller now refuses a
+	// certificate that was issued for a different key, which is what stops it
+	// from adopting a foreign certificate that shares its certname.
+	var issued []byte
 	server := newTestTLSServer(t, certPEM, keyPEM, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/certificate_request/"):
+			csrPEM, _ := io.ReadAll(r.Body)
+			issued = issueForCSR(t, certPEM, keyPEM, csrPEM)
 			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/certificate/"):
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(certPEM)
+			_, _ = w.Write(issued)
 		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/certificate_status/"):
 			w.WriteHeader(http.StatusNoContent)
 		default:

--- a/internal/controller/certname_conflict_test.go
+++ b/internal/controller/certname_conflict_test.go
@@ -1,0 +1,204 @@
+package controller
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
+)
+
+// TestCertnameOf_DefaultsLikeTheCRD pins the reason this collision is easy to
+// hit: an unset certname is not "none", it is "puppet".
+func TestCertnameOf_DefaultsLikeTheCRD(t *testing.T) {
+	cert := &openvoxv1alpha1.Certificate{}
+	if got := certnameOf(cert); got != "puppet" {
+		t.Errorf("expected the CRD default puppet, got %q", got)
+	}
+	cert.Spec.Certname = "web01.example.com"
+	if got := certnameOf(cert); got != "web01.example.com" {
+		t.Errorf("expected the explicit certname, got %q", got)
+	}
+}
+
+// TestCertnameConflict_RefusesToSign is the guarantee: the CA keeps one entry
+// per certname, so a second Certificate claiming the same name must not sign
+// under it. Without this the second resource adopts the first one's
+// certificate, and deleting either revokes the entry both rely on.
+func TestCertnameConflict_RefusesToSign(t *testing.T) {
+	ca := newCertificateAuthority("production-ca")
+	meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
+		Type: openvoxv1alpha1.ConditionCAReady, Status: metav1.ConditionTrue,
+		Reason: "Ready", Message: "ready",
+	})
+	first := newCertificate("web-a", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	first.Spec.Certname = "shared.example.com"
+	second := newCertificate("web-b", "production-ca", openvoxv1alpha1.CertificatePhasePending)
+	second.Spec.Certname = "shared.example.com"
+
+	c := setupTestClient(ca, first, second)
+	r := newCertificateReconciler(c)
+
+	res, err := r.Reconcile(testCtx(), testRequest("web-b"))
+	if err != nil {
+		t.Fatalf("a certname conflict must not fail the reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a certname conflict is permanent and must not be polled, got %v", res.RequeueAfter)
+	}
+
+	got := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "web-b", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading the Certificate back: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionCertnameConflict)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected a CertnameConflict condition, got %+v", cond)
+	}
+	if got.Status.Phase != openvoxv1alpha1.CertificatePhaseError {
+		t.Errorf("expected phase Error, got %q", got.Status.Phase)
+	}
+
+	// No TLS Secret may be produced under a name it does not own.
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "web-b-tls", Namespace: testNamespace},
+		newSecret("web-b-tls", nil)); err == nil {
+		t.Error("the conflicting Certificate must not produce a TLS Secret")
+	}
+}
+
+// TestCertnameConflict_DefaultCertnameCollides is the accidental case: two
+// Certificates created without a certname both land on "puppet".
+func TestCertnameConflict_DefaultCertnameCollides(t *testing.T) {
+	ca := newCertificateAuthority("production-ca")
+	meta.SetStatusCondition(&ca.Status.Conditions, metav1.Condition{
+		Type: openvoxv1alpha1.ConditionCAReady, Status: metav1.ConditionTrue,
+		Reason: "Ready", Message: "ready",
+	})
+	first := newCertificate("web-a", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	first.Spec.Certname = ""
+	second := newCertificate("web-b", "production-ca", openvoxv1alpha1.CertificatePhasePending)
+	second.Spec.Certname = ""
+
+	c := setupTestClient(ca, first, second)
+	r := newCertificateReconciler(c)
+	if _, err := r.Reconcile(testCtx(), testRequest("web-b")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &openvoxv1alpha1.Certificate{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "web-b", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("reading the Certificate back: %v", err)
+	}
+	if cond := meta.FindStatusCondition(got.Status.Conditions, openvoxv1alpha1.ConditionCertnameConflict); cond == nil {
+		t.Error("two Certificates without an explicit certname both use puppet and must conflict")
+	}
+}
+
+// TestCertnameConflict_DifferentAuthoritiesDoNotCollide bounds the rule: the
+// name only has to be unique per CA, since each CA keeps its own entries.
+func TestCertnameConflict_DifferentAuthoritiesDoNotCollide(t *testing.T) {
+	first := newCertificate("web-a", "ca-one", openvoxv1alpha1.CertificatePhaseSigned)
+	second := newCertificate("web-b", "ca-two", openvoxv1alpha1.CertificatePhasePending)
+
+	c := setupTestClient(first, second)
+	r := newCertificateReconciler(c)
+
+	other, err := r.otherCertificateUsingCertname(testCtx(), second)
+	if err != nil {
+		t.Fatalf("looking up claimants: %v", err)
+	}
+	if other != "" {
+		t.Errorf("certificates against different CAs must not conflict, got %q", other)
+	}
+}
+
+// TestCertnameConflict_TerminatingCertificateReleasesTheName keeps a deletion
+// in progress from blocking its replacement forever.
+func TestCertnameConflict_TerminatingCertificateReleasesTheName(t *testing.T) {
+	now := metav1.Now()
+	leaving := newCertificate("web-a", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+	leaving.DeletionTimestamp = &now
+	leaving.Finalizers = []string{certificateFinalizer}
+	successor := newCertificate("web-b", "production-ca", openvoxv1alpha1.CertificatePhasePending)
+
+	c := setupTestClient(leaving, successor)
+	r := newCertificateReconciler(c)
+
+	other, err := r.otherCertificateUsingCertname(testCtx(), successor)
+	if err != nil {
+		t.Fatalf("looking up claimants: %v", err)
+	}
+	if other != "" {
+		t.Errorf("a terminating Certificate must release its certname, got %q", other)
+	}
+}
+
+// --- key matching ---
+
+// selfSignedFor builds a certificate for a freshly generated key, so the pair
+// is internally consistent but unrelated to any other key.
+func selfSignedFor(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(7),
+		Subject:      pkix.Name{CommonName: "shared.example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+}
+
+// TestCertMatchesKey_AcceptsItsOwnPair and the rejection case below are the
+// last line of defence: with webhooks off and two Certificates racing, the CA
+// hands back whatever holds the certname. Pairing that with our own key would
+// only fail later, during a TLS handshake.
+func TestCertMatchesKey_AcceptsItsOwnPair(t *testing.T) {
+	certPEM, keyPEM := selfSignedFor(t)
+
+	ok, err := certMatchesKey(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("verifying a matching pair: %v", err)
+	}
+	if !ok {
+		t.Error("a certificate must match the key it was issued for")
+	}
+}
+
+func TestCertMatchesKey_RejectsAForeignCertificate(t *testing.T) {
+	foreignCert, _ := selfSignedFor(t)
+	_, ourKey := selfSignedFor(t)
+
+	ok, err := certMatchesKey(foreignCert, ourKey)
+	if err != nil {
+		t.Fatalf("verifying a mismatched pair: %v", err)
+	}
+	if ok {
+		t.Error("a certificate issued for another key must be rejected")
+	}
+}
+
+func TestCertMatchesKey_ReportsUnusableInput(t *testing.T) {
+	_, keyPEM := selfSignedFor(t)
+
+	if _, err := certMatchesKey([]byte("not a pem"), keyPEM); err == nil {
+		t.Error("expected an error for an undecodable certificate")
+	}
+}

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -304,6 +304,16 @@ func appendPullSecrets(existing []corev1.LocalObjectReference, add ...corev1.Loc
 	return existing
 }
 
+// certnameOf returns the certname a Certificate is issued under. The CRD
+// defaults it to "puppet", so an unset value is not "none" but a very common
+// collision candidate.
+func certnameOf(cert *openvoxv1alpha1.Certificate) string {
+	if cert.Spec.Certname != "" {
+		return cert.Spec.Certname
+	}
+	return "puppet"
+}
+
 // serverRoleEnabled reports whether the Server runs the catalog server role.
 // The spec field defaults to true, so an unset value enables the role.
 func serverRoleEnabled(server *openvoxv1alpha1.Server) bool {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -304,9 +304,11 @@ func appendPullSecrets(existing []corev1.LocalObjectReference, add ...corev1.Loc
 	return existing
 }
 
-// certnameOf returns the certname a Certificate is issued under. The CRD
-// defaults it to "puppet", so an unset value is not "none" but a very common
-// collision candidate.
+// certnameOf returns the certname a Certificate is issued under.
+//
+// The field is required and non-empty since the shared "puppet" default was
+// removed. The fallback only covers resources written while that default still
+// existed, which all carry "puppet" anyway.
 func certnameOf(cert *openvoxv1alpha1.Certificate) string {
 	if cert.Spec.Certname != "" {
 		return cert.Spec.Certname

--- a/internal/controller/indexers.go
+++ b/internal/controller/indexers.go
@@ -21,6 +21,11 @@ const (
 	IndexConfigRef      = "spec.configRef"
 	IndexCertificateRef = "spec.certificateRef"
 	IndexAuthorityRef   = "spec.authorityRef"
+
+	// IndexCertname makes the certname collision check a lookup rather than a
+	// full listing. A certname identifies exactly one entry on the CA, so two
+	// Certificates sharing one against the same CA are indistinguishable to it.
+	IndexCertname = "spec.certname"
 )
 
 // SetupFieldIndexers registers every field index the controllers rely on.
@@ -57,6 +62,10 @@ func fieldIndexes() []fieldIndex {
 		}},
 		{&openvoxv1alpha1.Certificate{}, IndexAuthorityRef, func(o client.Object) []string {
 			return nonEmpty(o.(*openvoxv1alpha1.Certificate).Spec.AuthorityRef)
+		}},
+		{&openvoxv1alpha1.Certificate{}, IndexCertname, func(o client.Object) []string {
+			c := o.(*openvoxv1alpha1.Certificate)
+			return nonEmpty(certnameOf(c))
 		}},
 		{&openvoxv1alpha1.Database{}, IndexCertificateRef, func(o client.Object) []string {
 			return nonEmpty(o.(*openvoxv1alpha1.Database).Spec.CertificateRef)

--- a/internal/webhook/certificate_webhook.go
+++ b/internal/webhook/certificate_webhook.go
@@ -93,8 +93,10 @@ func (v *CertificateValidator) validate(ctx context.Context, c *openvoxv1alpha1.
 	return nil, nil
 }
 
-// certnameOrDefault mirrors the CRD default, so the check compares the values
-// the CA will actually see rather than what the manifest happens to spell out.
+// certnameOrDefault resolves the certname the CA will see. Schema validation
+// runs before this webhook, so the field is already non-empty for anything
+// created since the default was removed; the fallback covers resources written
+// before that, which all carry "puppet".
 func certnameOrDefault(c *openvoxv1alpha1.Certificate) string {
 	if c.Spec.Certname != "" {
 		return c.Spec.Certname

--- a/internal/webhook/certificate_webhook.go
+++ b/internal/webhook/certificate_webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 
@@ -54,6 +55,17 @@ func (v *CertificateValidator) validate(ctx context.Context, c *openvoxv1alpha1.
 		}
 	}
 
+	// A certname identifies exactly one entry on the CA. Two Certificates
+	// sharing one against the same CA are indistinguishable to it: the second
+	// CSR is rejected, and deleting either one revokes the entry both rely on.
+	// The CRD default is "puppet", so the collision is easy to hit by accident.
+	if other, err := v.otherCertificateUsingCertname(ctx, c); err != nil {
+		errs = append(errs, field.InternalError(specPath.Child("certname"), err))
+	} else if other != "" {
+		errs = append(errs, field.Duplicate(specPath.Child("certname"),
+			certnameOrDefault(c)+" (already claimed by Certificate "+other+" against the same CertificateAuthority)"))
+	}
+
 	if err := validateDuration(c.Spec.RenewBefore, "renewBefore"); err != nil {
 		errs = append(errs, field.Invalid(specPath.Child("renewBefore"), c.Spec.RenewBefore, err.Error()))
 	}
@@ -79,4 +91,43 @@ func (v *CertificateValidator) validate(ctx context.Context, c *openvoxv1alpha1.
 		return nil, errs.ToAggregate()
 	}
 	return nil, nil
+}
+
+// certnameOrDefault mirrors the CRD default, so the check compares the values
+// the CA will actually see rather than what the manifest happens to spell out.
+func certnameOrDefault(c *openvoxv1alpha1.Certificate) string {
+	if c.Spec.Certname != "" {
+		return c.Spec.Certname
+	}
+	return "puppet"
+}
+
+// otherCertificateUsingCertname returns the name of another Certificate in the
+// namespace that claims the same certname against the same
+// CertificateAuthority, or "" when there is none.
+func (v *CertificateValidator) otherCertificateUsingCertname(ctx context.Context, c *openvoxv1alpha1.Certificate) (string, error) {
+	certList := &openvoxv1alpha1.CertificateList{}
+	if err := v.Client.List(ctx, certList, client.InNamespace(c.Namespace)); err != nil {
+		return "", fmt.Errorf("listing Certificates in namespace %s: %w", c.Namespace, err)
+	}
+
+	want := certnameOrDefault(c)
+	for i := range certList.Items {
+		other := &certList.Items[i]
+		if other.Name == c.Name {
+			continue
+		}
+		// A Certificate on its way out releases its claim; its finalizer cleans
+		// the CA entry.
+		if !other.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if other.Spec.AuthorityRef != c.Spec.AuthorityRef {
+			continue
+		}
+		if certnameOrDefault(other) == want {
+			return other.Name, nil
+		}
+	}
+	return "", nil
 }

--- a/internal/webhook/certificate_webhook_test.go
+++ b/internal/webhook/certificate_webhook_test.go
@@ -212,3 +212,79 @@ func TestCertificateValidator(t *testing.T) {
 		}
 	})
 }
+
+// TestCertificateValidator_RejectsDuplicateCertname closes the collision at
+// admission. The CA keeps one entry per certname, so two Certificates sharing
+// one against the same CA cannot both be signed - and deleting either revokes
+// the entry the other depends on.
+func TestCertificateValidator_RejectsDuplicateCertname(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+	existing := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-a", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "my-ca", Certname: "shared.example.com"},
+	}
+	c := setupTestClient(ca, existing)
+	v := &CertificateValidator{Client: c}
+
+	duplicate := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-b", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "my-ca", Certname: "shared.example.com"},
+	}
+	if _, err := v.ValidateCreate(context.Background(), duplicate); err == nil {
+		t.Error("expected a duplicate certname against the same CA to be rejected")
+	}
+
+	// Updating the existing resource must not report a conflict with itself.
+	if _, err := v.ValidateUpdate(context.Background(), nil, existing); err != nil {
+		t.Errorf("a Certificate must not conflict with itself: %v", err)
+	}
+}
+
+// TestCertificateValidator_DuplicateDefaultCertname covers the accidental case:
+// the CRD defaults certname to puppet, so two Certificates created without one
+// collide without anybody writing the same value twice.
+func TestCertificateValidator_DuplicateDefaultCertname(t *testing.T) {
+	ca := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ca", Namespace: "default"},
+	}
+	existing := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-a", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "my-ca"},
+	}
+	c := setupTestClient(ca, existing)
+	v := &CertificateValidator{Client: c}
+
+	duplicate := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-b", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "my-ca"},
+	}
+	if _, err := v.ValidateCreate(context.Background(), duplicate); err == nil {
+		t.Error("two Certificates without an explicit certname both use puppet and must be rejected")
+	}
+}
+
+// TestCertificateValidator_DifferentAuthorityIsFine bounds the rule.
+func TestCertificateValidator_DifferentAuthorityIsFine(t *testing.T) {
+	caOne := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "ca-one", Namespace: "default"},
+	}
+	caTwo := &openvoxv1alpha1.CertificateAuthority{
+		ObjectMeta: metav1.ObjectMeta{Name: "ca-two", Namespace: "default"},
+	}
+	existing := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-a", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "ca-one", Certname: "shared.example.com"},
+	}
+	c := setupTestClient(caOne, caTwo, existing)
+	v := &CertificateValidator{Client: c}
+
+	other := &openvoxv1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-b", Namespace: "default"},
+		Spec:       openvoxv1alpha1.CertificateSpec{AuthorityRef: "ca-two", Certname: "shared.example.com"},
+	}
+	if _, err := v.ValidateCreate(context.Background(), other); err != nil {
+		t.Errorf("each CA keeps its own entries, so the same certname is fine: %v", err)
+	}
+}


### PR DESCRIPTION
You were right on both counts: this should not be possible in the first place, and `puppet` was the wrong default. Two commits -- the guard, and the removal of the cause.

## Why it was possible

A certname identifies exactly one entry on the CA, and a real Puppet CA refuses a CSR for a name it has already issued. The operator had no such guarantee: the webhook validated the certname *format* but not its uniqueness, there was no index on it, and the CRD defaulted it to `puppet` -- so two Certificates created without one collided **by default rather than by mistake**.

## Two silent consequences

**Adoption of a foreign certificate.** Both `submitCSR` and `fetchSignedCert` address the CA by certname. With two Certificates racing, the second gets `already has a requested certificate`, which the code treats as success, and then fetches whatever holds that name. Nothing verified that the returned certificate belonged to the key we generated, so the TLS Secret would pair someone else's certificate with our private key. That fails at a TLS handshake much later, with an error pointing nowhere near here.

**Revocation of someone else's certificate.** `handleCertificateCleanup` revokes by certname, so deleting either Certificate revokes the entry the other one depends on.

To be clear about what was *not* wrong: there is no clean-before-sign anywhere, so the operator never took a certname away during signing.

## The guard, in three layers

Webhooks are disabled by default, so admission alone would not hold.

1. **Webhook** rejects a duplicate at creation, naming the holder.
2. **Controller** refuses to sign and reports `CertnameConflict` with phase `Error`. Permanently: retrying cannot free a name. Modelled on the Pool hostname conflict in #564.
3. **Key verification** compares the returned certificate's public key against the private key it was requested for, so a foreign certificate is never written to a Secret.

A terminating Certificate releases its claim, and uniqueness is per CertificateAuthority rather than per namespace, because each CA keeps its own entries.

## Removing the cause

`certname` is now required with `MinLength=1` and has no default.

Beyond the collision, the default was wrong on its own terms: a certname is an *identity*, and `puppet` is only the right identity for the main server. PuppetDB and any further certificate need their own. The names agents connect through -- a load balancer, a service address -- belong in `dnsAltNames`, which the chart already derives from the Pool Services a server joins since #561.

Nothing in the repository relied on the default:

- `certificates.yaml` writes the value unconditionally; `database.yaml` already **fails the render** without one
- all sixteen CI value files set it explicitly, and so does the sample
- the same `fail` guard now covers server entries, the one path that could still fall through

Existing resources are unaffected: they carry `certname: puppet` materialised from the default, and the field is immutable anyway. New manifests that omit it are rejected, which is the point. Worth a line in the #540 release notes.

## About the changed tests

`TestSignCertificate_FullFlow` now signs the submitted CSR instead of returning a canned certificate. It passed before **because** nothing verified the pairing. Two envtest cases that relied on the default were rewritten -- one of them now asserts the opposite, that an omitted certname is rejected.

## Verification

`make test` (with envtest), `make manifests`, `helm lint` and golangci-lint 2.13.2 are clean. The chart guard was verified to fire on a values file without a certname. Documented under "Certname uniqueness" in the Certificate reference.

Closes the B1 blocker from the second review pass (2026-09-03), which had no issue of its own.