### PR TITLE
ci: keep breaking changes at a minor bump while below 1.0

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,11 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        { "breaking": true, "release": "minor" }
+      ]
+    }],
     "@semantic-release/release-notes-generator",
     ["@semantic-release/github", {
       "successComment": false


### PR DESCRIPTION
The release of 2026-09-02 became **v1.0.0**, which was not intended. The cause is that the project's pre-1.0 intent lived nowhere in the repository.

## What happened

Three commits from the API hardening in #549 carry `BREAKING CHANGE:` footers:

- `3b71420` remove the shared image default from the API
- `1b5ccaa` declare list semantics for keyed list fields
- `732f631` make defaulted boolean fields nullable

The footers are factually correct -- each of those does break something. But the CRDs are `v1alpha1` and the project is deliberately pre-1.0, precisely so that breaking changes do not have to become a major release. semantic-release could not know that, applied the default convention, and 0.11.1 plus a breaking change is 1.0.0.

## The change

```json
["@semantic-release/commit-analyzer", {
  "releaseRules": [{ "breaking": true, "release": "minor" }]
}]
```

Remove this rule when 1.0.0 is a deliberate decision. From then on a breaking change should mean what it says.

## Verified, not assumed

Ran `semantic-release --dry-run` against a throwaway clone whose `v1.0.0` tag was removed, so it computes what would have happened *instead of* 1.0.0:

| config | result |
|---|---|
| with the rule | `Analysis of 74 commits complete: minor release` -> **0.12.0** |
| without it | `major release` -> **1.0.0** |

Same 74 commits, same `v0.11.1` baseline. The rule is the difference.

## Why this matters beyond the one number

Without it the next breaking change repeats the problem one level up. #516 carries a `BREAKING CHANGE` footer for the `pattern` -> `certnames` rename, so merging it today would produce **2.0.0**.

## Follow-up, not part of this PR

Withdrawing v1.0.0 and re-releasing as 0.12.0 needs this rule on `main` as well, plus deleting the published tag, release and chart versions. Tracked separately.