### PR TITLE
docs: correct and complete the documentation against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Kubernetes Operator that maps [OpenVox Server](https://github.com/OpenVoxProje
 - 🔄 **Multi-Version Deployments** - Run different server versions side by side - canary deployments, rolling upgrades
 - 🔒 **Rootless & OpenShift Ready** - Random UID compatible, no root, no ezbake, no privilege escalation
 - 🪶 **Minimal Image** - UBI9-based, no agent Ruby, no ezbake packaging - smaller footprint, fewer updates
-- 🧠 **Auto-tuned JVM** - Heap size calculated from memory limits (90%) - no manual `-Xmx` tuning needed
+- 🧠 **JVM sizing** - Set `javaArgs` per Server or Database; see [Server](docs/reference/server.md) for the current default
 - 📦 **OCI Image Volumes** - Package Puppet code as OCI images, deploy immutably with automatic rollout (K8s 1.35+)
 - 🌐 **Gateway API** - SNI-based TLSRoute support - share a single LoadBalancer across environments via TLS passthrough
 - 🗄️ **Managed OpenVox DB** - Deploy OpenVox DB (PuppetDB) with external PostgreSQL - TLS, config, and credentials managed by the operator

--- a/docs/_snippets/features.md
+++ b/docs/_snippets/features.md
@@ -6,7 +6,7 @@
 - 🔄 **Multi-Version Deployments** - Run different server versions side by side - canary deployments, rolling upgrades
 - 🔒 **Rootless & OpenShift Ready** - Random UID compatible, no root, no ezbake, no privilege escalation
 - 🪶 **Minimal Image** - UBI9-based, no agent Ruby, no ezbake packaging - smaller footprint, fewer updates
-- 🧠 **Auto-tuned JVM** - Heap size calculated from memory limits (90%) - no manual `-Xmx` tuning needed
+- 🧠 **JVM sizing** - Set `javaArgs` per Server or Database; see [Server](reference/server.md) for the current default
 - 📦 **OCI Image Volumes** - Package Puppet code as OCI images, deploy immutably with automatic rollout (K8s 1.35+)
 - 🌐 **Gateway API** - SNI-based TLSRoute support - share a single LoadBalancer across environments via TLS passthrough
 - 🗄️ **Managed OpenVox DB** - Deploy OpenVox DB (PuppetDB) with external PostgreSQL - TLS, config, and credentials managed by the operator

--- a/docs/concepts/certificate-signing.md
+++ b/docs/concepts/certificate-signing.md
@@ -29,7 +29,7 @@ sequenceDiagram
     Operator->>K8s: Create PVC ({ca}-data)
     Operator->>K8s: Create Service ({ca}-internal)
     Operator->>K8s: Create ServiceAccount + RBAC
-    Operator->>K8s: Create Job ({ca}-setup)
+    Operator->>K8s: Create Job ({ca}-ca-setup)
     Job->>PVC: Run puppetserver ca setup
     Job->>K8s: Create Secret {ca}-ca (public cert)
     Job->>K8s: Create Secret {ca}-ca-key (private key)

--- a/docs/concepts/code-deployment.md
+++ b/docs/concepts/code-deployment.md
@@ -58,9 +58,9 @@ metadata:
 spec:
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
   code:
-    image: ghcr.io/example/puppet-code:v1.0.0
+    - image: ghcr.io/example/puppet-code:v1.0.0
 ```
 
 ### Pull Policy
@@ -70,8 +70,8 @@ Control when the image is pulled via `imagePullPolicy`. Defaults to `IfNotPresen
 ```yaml
 spec:
   code:
-    image: ghcr.io/example/puppet-code:v1.0.0
-    imagePullPolicy: Always
+    - image: ghcr.io/example/puppet-code:v1.0.0
+      imagePullPolicy: Always
 ```
 
 Supported values: `Always`, `IfNotPresent`, `Never`.
@@ -83,7 +83,7 @@ For immutable, reproducible deployments you can reference images by digest inste
 ```yaml
 spec:
   code:
-    image: ghcr.io/example/puppet-code@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+    - image: ghcr.io/example/puppet-code@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
 ```
 
 A tag+digest combination also works:
@@ -91,7 +91,7 @@ A tag+digest combination also works:
 ```yaml
 spec:
   code:
-    image: ghcr.io/example/puppet-code:v1.0.0@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+    - image: ghcr.io/example/puppet-code:v1.0.0@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
 ```
 
 ### Rolling Out Code Changes
@@ -101,7 +101,7 @@ Update the image reference to deploy new code. The operator detects the change a
 ```yaml
 spec:
   code:
-    image: ghcr.io/example/puppet-code:v1.1.0
+    - image: ghcr.io/example/puppet-code:v1.1.0
 ```
 
 ### Private Registries
@@ -111,8 +111,8 @@ For private registries, create a pull secret and reference it:
 ```yaml
 spec:
   code:
-    image: registry.example.com/puppet-code:v1.0.0
-    imagePullSecret: registry-credentials
+    - image: registry.example.com/puppet-code:v1.0.0
+      imagePullSecret: registry-credentials
 ```
 
 ### Rollout Visibility
@@ -163,7 +163,7 @@ spec:
   configRef: production
   certificateRef: canary-cert
   code:
-    image: ghcr.io/example/puppet-code:v2.0.0-rc1
+    - image: ghcr.io/example/puppet-code:v2.0.0-rc1
 ```
 
 ## PVC
@@ -181,9 +181,9 @@ metadata:
 spec:
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
   code:
-    claimName: puppet-code
+    - claimName: puppet-code
 ```
 
 Like the image volume, the PVC is mounted at the configured `environmentPath` (default `/etc/puppetlabs/code/environments`), so its root must contain the environment directories directly (`production/`, `staging/`, ...).

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -74,7 +74,18 @@ spec:
     tag: "latest"
 ```
 
-The operator reads `Database.status.url` (e.g. `https://production-db.namespace.svc.cluster.local:8081`) and renders it into `puppetdb.conf`. When the Database is not yet `Running`, the Config controller waits.
+The operator reads `Database.status.url` (e.g. `https://production-db.namespace.svc.cluster.local:8081`) and renders it into `puppetdb.conf`.
+
+When the Database has no URL yet, the Config controller does **not** wait. It
+renders a `puppetdb.conf` without `server_urls` and carries on, so the servers
+start regardless. Combined with `soft_write_failure = true`, which the operator
+always sets, a server in that state compiles catalogs normally while reports
+and exported resources go nowhere and no error is raised.
+
+The Config is re-reconciled when the Database status changes, so this resolves
+by itself during bring-up. It becomes a problem only if the Database never
+reaches `Running`: the symptom is an empty PuppetDB with healthy-looking
+servers, not a failure.
 
 ### Via static `puppetdb.serverUrls`
 

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -71,7 +71,7 @@ spec:
   databaseRef: production-db   # operator reads Database.status.url
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
 ```
 
 The operator reads `Database.status.url` (e.g. `https://production-db.namespace.svc.cluster.local:8081`) and renders it into `puppetdb.conf`. When the Database is not yet `Running`, the Config controller waits.

--- a/docs/concepts/external-node-classification.md
+++ b/docs/concepts/external-node-classification.md
@@ -136,7 +136,7 @@ spec:
   nodeClassifierRef: pe-classifier
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
 ```
 
 This generates the following puppet.conf entries in the `[server]` section:

--- a/docs/concepts/gateway-api.md
+++ b/docs/concepts/gateway-api.md
@@ -107,6 +107,10 @@ spec:
 
 The `openvox-stack` chart provides a `gateway` section for shared Gateway settings:
 
+A Pool does not name its servers. The relationship runs the other way: each
+entry under `servers` lists the pools it joins via `poolRefs`, and the Pool
+selects those pods through its Service.
+
 ```yaml
 gateway:
   name: puppet-gateway
@@ -114,7 +118,6 @@ gateway:
 
 pools:
   - name: puppet
-    serverRef: ca
     service:
       type: ClusterIP
       port: 8140

--- a/docs/concepts/report-processing.md
+++ b/docs/concepts/report-processing.md
@@ -107,7 +107,7 @@ spec:
   authorityRef: production-ca
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
 ```
 
 ```yaml

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -13,7 +13,7 @@ spec:
   authorityRef: lab-ca
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
 ---
 apiVersion: openvox.voxpupuli.org/v1alpha1
 kind: CertificateAuthority
@@ -74,7 +74,7 @@ spec:
   databaseRef: production-db
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
   puppet:
     environmentTimeout: unlimited
     storeconfigs: true
@@ -232,7 +232,7 @@ spec:
   replicas: 3
   maxActiveInstances: 2
   code:
-    claimName: puppet-code
+    - claimName: puppet-code
   resources:
     requests:
       cpu: "1"
@@ -250,10 +250,10 @@ spec:
   certificateRef: canary-cert
   poolRefs: [puppet]
   image:
-    tag: "8.13.0"
+    tag: "latest"
   replicas: 1
   code:
-    claimName: puppet-code
+    - claimName: puppet-code
   resources:
     requests:
       cpu: "1"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -75,7 +75,7 @@ This guide sets up an OpenVox Server deployment. Choose between the Helm chart (
       authorityRef: lab-ca
       image:
         repository: ghcr.io/slauger/openvox-server-8
-        tag: "8.12.1"
+        tag: "latest"
     ---
     apiVersion: openvox.voxpupuli.org/v1alpha1
     kind: CertificateAuthority

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -162,6 +162,18 @@ NAME                                        TYPE        ENDPOINTS   AGE
 pool.openvox.voxpupuli.org/puppet           ClusterIP   1           2m
 ```
 
+!!! warning "Without a SigningPolicy nothing gets signed"
+
+    The operator points `autosign` at its own binary as soon as a
+    CertificateAuthority exists, and that binary denies every CSR it has no
+    matching policy for. An empty policy list therefore means deny-all, not
+    off.
+
+    Nothing surfaces this. The servers come up, the Config reports `Running`,
+    and every agent sits in `puppet agent --waitforcert` until it gives up.
+    Check with `kubectl get signingpolicy -n <namespace>`; if the list is
+    empty, see [SigningPolicy](../reference/signingpolicy.md).
+
 ## Next Steps
 
 See the [Examples](../examples/index.md) section for production setups with separate CA, server pools, canary deployments, and code deployment via OCI image volumes.

--- a/docs/guides/ca-import.md
+++ b/docs/guides/ca-import.md
@@ -28,7 +28,7 @@ If you have an existing CA and want the operator to manage it going forward, you
 
     ```bash
     # Find the PVC
-    kubectl get pvc -l openvox.voxpupuli.org/certificate-authority=production-ca
+    kubectl get pvc -l openvox.voxpupuli.org/certificateauthority=production-ca
 
     # Create a temporary pod to copy data
     kubectl run ca-import --image=busybox --restart=Never \

--- a/docs/guides/connecting-agents.md
+++ b/docs/guides/connecting-agents.md
@@ -1,0 +1,163 @@
+# Connecting Agents
+
+The operator manages the server side. Agents are ordinary Puppet agents: they
+are not Kubernetes resources, and nothing in the operator creates or tracks
+them. This page covers what they need from a stack deployed by the operator.
+
+## What an agent needs
+
+Three things, and they are the usual ones:
+
+| | |
+|---|---|
+| **A reachable server address** | the Service of a Pool the server joins, on port 8140 |
+| **A certname** | the identity the certificate is issued for |
+| **A signed certificate** | either autosigned by a [SigningPolicy](../reference/signingpolicy.md) or signed by hand |
+
+!!! warning "Without a SigningPolicy nothing is signed"
+
+    The operator points `autosign` at its own binary as soon as a
+    CertificateAuthority exists, and that binary denies every CSR no policy
+    matches. An empty policy list is deny-all, not off. Agents then sit in
+    `--waitforcert` while the servers look perfectly healthy.
+
+## Where to point the agent
+
+Agents talk to the Service of a Pool. With the default layout the CA server
+joins both pools (`poolRefs: [ca, server]`), so one address serves catalog
+requests and the CA:
+
+```bash
+puppet agent --test \
+  --server <release>-server \
+  --certname web01.example.com \
+  --waitforcert 30
+```
+
+If you separate the roles - the CA in the `ca` pool only, compilers in
+`server` - the agent needs both addresses, because catalog and CA no longer
+share one:
+
+```ini
+[main]
+server    = <release>-server
+ca_server = <release>-ca
+```
+
+## From inside the cluster
+
+Any Puppet agent works. This project also builds `openvox-agent-<major>`, but
+be aware of what it is: a **test artifact**. It is built by CI and not by the
+release workflow, so it carries only the `develop` tag - no `latest`, no
+version. For anything but a throwaway check, use your own agent image and pin
+it.
+
+The shape below is what the e2e suite runs:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: puppet-agent
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: puppet-agent
+          image: ghcr.io/slauger/openvox-agent-8:develop  # test artifact, see above
+          command: ["sh", "-c"]
+          args:
+            - |
+              puppet agent --test \
+                --server <release>-server \
+                --certname agent-01 \
+                --waitforcert 30
+              # 0 = no changes, 2 = changes applied; both are success
+              EXIT=$?
+              if [ $EXIT -eq 0 ] || [ $EXIT -eq 2 ]; then exit 0; else exit $EXIT; fi
+```
+
+The exit code check matters: `puppet agent --test` returns **2** when it
+applied changes, which is a success and not a failure.
+
+## From outside the cluster
+
+A Pool Service defaults to `ClusterIP`, which is unreachable from outside.
+Choose one:
+
+| Option | How |
+|---|---|
+| **LoadBalancer** | `pools[].service.type: LoadBalancer` |
+| **NodePort** | `pools[].service.type: NodePort`, optionally `nodePort` |
+| **Gateway API** | `pools[].route`, see [Gateway API](../concepts/gateway-api.md) |
+
+Whichever you pick, the name agents connect through must be in the server
+certificate. The chart derives the Service names of every Pool a server joins
+into `dnsAltNames` automatically; an external name such as a load balancer
+address has to be added explicitly:
+
+```yaml
+servers:
+  - name: ca
+    certificate:
+      certname: puppet
+      dnsAltNames:
+        - puppet.example.com
+```
+
+A missing name shows up as a TLS error on the agent, not as an operator
+problem:
+
+```
+Server hostname 'puppet.example.com' did not match server certificate
+```
+
+## Signing by hand
+
+Without a matching policy the CSR waits. List and sign on the CA pod:
+
+```bash
+kubectl exec -n <namespace> deploy/<ca-server> -- \
+  puppetserver ca list --all
+
+kubectl exec -n <namespace> deploy/<ca-server> -- \
+  puppetserver ca sign --certname web01.example.com
+```
+
+## Removing an agent
+
+Revoking is a CA operation, and the operator does not do it for you - it only
+manages the certificates that belong to its own resources:
+
+```bash
+kubectl exec -n <namespace> deploy/<ca-server> -- \
+  puppetserver ca clean --certname web01.example.com
+```
+
+The revocation reaches agents with the next CRL refresh, which runs on
+`spec.crlRefreshInterval` (default `5m`). Until then the revoked certificate is
+still accepted.
+
+## Verifying it worked
+
+The agent reports success itself, but two things are worth checking on the
+server side.
+
+**Did the catalog compile?**
+
+```bash
+kubectl logs -n <namespace> deploy/<ca-server> | grep -i "Compiled catalog"
+```
+
+**Did the facts reach PuppetDB?** Only when a Database is wired up:
+
+```bash
+kubectl exec -n <namespace> deploy/<database> -- \
+  curl -sf "http://127.0.0.1:8080/pdb/query/v4/nodes"
+```
+
+An empty result with a healthy agent run usually means `routes.yaml` is not
+routing the facts terminus to PuppetDB - see
+[Database](../reference/database.md).

--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -114,6 +114,24 @@ Alert when a certificate expires within 30 days:
           description: "{{ $labels.name }} in {{ $labels.namespace }} expires in {{ $value | humanizeDuration }}"
 ```
 
+### Missing CRL series
+
+A stale CRL is alertable only while the series exists. If the operator never
+refreshed the CRL - it crashed early, or the CA never became ready - there is
+no series at all and the staleness rule below stays silent. Alert on the
+absence separately:
+
+```yaml
+      - alert: OpenVoxCRLMetricMissing
+        expr: absent(openvox_crl_last_refresh_timestamp_seconds)
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No CRL refresh has been recorded"
+          description: "The operator has not refreshed any CRL since it started. Revocations are not reaching agents."
+```
+
 ### Stale CRL
 
 A CRL that is no longer refreshed means revoked agents keep being accepted.
@@ -131,6 +149,18 @@ Alert when the last successful refresh is more than a day old:
 ```
 
 ### CA Expiring
+
+!!! note "CAs and certificates share one metric"
+
+    `openvox_certificate_expiry_timestamp_seconds` is written by both the
+    Certificate and the CertificateAuthority controller, with the same
+    `name`/`namespace` labels and nothing that says which kind a series belongs
+    to. Telling them apart in a query means matching on the name.
+
+    The rule below uses `.*-ca`, which is a convention rather than a guarantee:
+    it also catches a Certificate that happens to end in `-ca`, and it misses a
+    CertificateAuthority named otherwise. Replace the matcher with your actual
+    CA names if you rely on the distinction.
 
 Alert when a CA certificate expires within 90 days:
 

--- a/docs/reference/certificate.md
+++ b/docs/reference/certificate.md
@@ -31,9 +31,12 @@ spec:
 
 | Field | Type | Description |
 |---|---|---|
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from. A value below `.metadata.generation` means the rest of this status has not caught up with the current spec yet |
 | `phase` | string | Current lifecycle phase |
 | `secretName` | string | Name of the Secret containing `cert.pem` and `key.pem` |
 | `notAfter` | time | Expiry time of the signed certificate |
+| `signedSpecHash` | string | Digest of what the current certificate was issued for: certname, effective alt names and CSR extensions. A mismatch triggers re-signing; empty means the hash was never recorded and is adopted rather than triggering one |
+| `effectiveDNSAltNames` | []string | The alt names the certificate is actually issued for: `spec.dnsAltNames` plus the route hostname of every Pool with `injectDNSAltName` that a Server using this Certificate joins |
 | `conditions` | []Condition | `CertSigned` |
 
 ## Deletion

--- a/docs/reference/certificate.md
+++ b/docs/reference/certificate.md
@@ -89,6 +89,17 @@ Certificates issued before this field existed carry an empty hash. The
 controller adopts the current spec as the baseline for them rather than
 re-signing every certificate after an operator upgrade.
 
+### Renewal reuses the private key
+
+A renewal submits a CSR for the key the certificate already has
+(`certificate_signing.go`: the existing `key.pem` is read from the TLS Secret
+and reused). The CA renews for the same public key, so the key material must
+not change between the old and the new certificate.
+
+The consequence is worth stating: renewal extends validity, it does not rotate
+the key. A key that must be replaced needs a new Certificate under a different
+name, since `certname` is immutable and the CA keeps one entry per name.
+
 ### CSR Poll Backoff
 
 When the CA does not immediately sign the CSR (e.g. autosigning is disabled), the controller enters `WaitingForSigning` after 10 unsuccessful poll attempts and retries with exponential backoff:

--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -81,6 +81,7 @@ spec:
 
 | Field | Type | Description |
 |---|---|---|
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from. A value below `.metadata.generation` means the rest of this status has not caught up with the current spec yet |
 | `phase` | string | Current lifecycle phase |
 | `caSecretName` | string | Name of the Secret containing `ca_crt.pem` (public CA certificate) |
 | `serviceName` | string | Name of the internal ClusterIP Service for operator communication. Empty when `spec.external` is set. |

--- a/docs/reference/certificateauthority.md
+++ b/docs/reference/certificateauthority.md
@@ -182,7 +182,7 @@ The failed Job is left in place; its logs are the only record of what went
 wrong:
 
 ```bash
-kubectl logs -n <namespace> job/<ca-name>-setup
+kubectl logs -n <namespace> job/<ca-name>-ca-setup
 ```
 
 The attempt counter lives in the `openvox.voxpupuli.org/setup-attempts`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -208,7 +208,17 @@ Controls Puppet Server metrics.conf settings.
 |---|---|
 | `Pending` | Config created, waiting for reconciliation |
 | `Running` | ConfigMap created, ready for use |
-| `Error` | Reconciliation failed |
+| `Error` | Defined in the API, but never set by the controller (see below) |
+
+`Error` is part of the API but the controller never assigns it. A failing
+reconcile leaves the phase at its previous value, reports the reason in the
+`ConfigReady` condition and emits a warning event. Watch the condition rather than
+the phase:
+
+```bash
+kubectl get config <name> -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}: {.message}{"\n"}{end}'
+```
+
 
 ### Image resolution
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -13,7 +13,7 @@ spec:
   authorityRef: production-ca
   image:
     repository: ghcr.io/slauger/openvox-server-8
-    tag: "8.12.1"
+    tag: "latest"
   puppet:
     environmentTimeout: "0"
     storeconfigs: true
@@ -223,6 +223,6 @@ credentials along. Secrets for code images are always added on top.
 
 | Resource | Name | Description |
 |---|---|---|
-| ConfigMap | `{name}` | puppet.conf, puppetserver.conf, auth.conf, webserver.conf, `routes.yaml` (facts terminus, when PuppetDB is the active backend), etc. |
+| ConfigMap | `{name}-config` | puppet.conf, puppetserver.conf, auth.conf, webserver.conf, `routes.yaml` (facts terminus, when PuppetDB is the active backend), etc. |
 | Secret | `{name}-enc` | ENC config for openvox-enc binary (only when `nodeClassifierRef` is set) |
 | ServiceAccount | `{name}-server` | Shared ServiceAccount for all Server pods (`automountServiceAccountToken: false`) |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -199,6 +199,7 @@ Controls Puppet Server metrics.conf settings.
 
 | Field | Type | Description |
 |---|---|---|
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from. A value below `.metadata.generation` means the rest of this status has not caught up with the current spec yet |
 | `phase` | string | Current lifecycle phase |
 | `conditions` | []Condition | `ConfigReady` |
 

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -99,7 +99,17 @@ When enabled, the default policy allows TCP/8081 only from pods with `app.kubern
 | `Pending` | Database created, resolving references |
 | `WaitingForCert` | Certificate not yet `Signed` |
 | `Running` | Deployment created and running |
-| `Error` | Reconciliation failed |
+| `Error` | Defined in the API, but never set by the controller (see below) |
+
+`Error` is part of the API but the controller never assigns it. A failing
+reconcile leaves the phase at its previous value, reports the reason in the
+`DatabaseReady` condition and emits a warning event. Watch the condition rather than
+the phase:
+
+```bash
+kubectl get database <name> -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}: {.message}{"\n"}{end}'
+```
+
 
 ## Pod Anatomy
 

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -86,6 +86,7 @@ When enabled, the default policy allows TCP/8081 only from pods with `app.kubern
 
 | Field | Type | Description |
 |---|---|---|
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from. A value below `.metadata.generation` means the rest of this status has not caught up with the current spec yet |
 | `phase` | string | Current lifecycle phase |
 | `url` | string | HTTPS endpoint of the Database Service (e.g. `https://production-db:8081`) |
 | `ready` | int32 | Number of ready replicas |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -52,17 +52,28 @@ These types are reused across multiple CRDs.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `repository` | string | `ghcr.io/slauger/openvox-server-8` | Container image repository |
-| `tag` | string | `latest` | Container image tag |
-| `pullPolicy` | string | `IfNotPresent` | Image pull policy |
+| `repository` | string | - | Container image repository |
+| `tag` | string | - | Container image tag |
+| `pullPolicy` | string | - | Image pull policy |
 | `pullSecrets` | []LocalObjectReference | - | Image pull secrets |
 
-`repository` and `tag` carry no API-level default. They are required on `Config`
-and `Database`; on `Server` both are optional and fall back to the referenced
-`Config`, which is what lets one Config drive a whole set of Servers.
+No field here carries an API-level default. That is deliberate: a nested
+default is applied whether or not the parent object was given, so a defaulted
+field can never express "inherit from the Config" - it is simply never empty.
 
-The defaults live in the Helm charts (`config.image.*`, `database.image.*`),
-where changing the registry is a values change rather than a CRD update.
+`repository` and `tag` are required on `Config` and `Database`. On `Server`
+both are optional and fall back to the referenced `Config`, which is what lets
+one Config drive a whole set of Servers.
+
+`pullPolicy` follows the same rule, falling back to the Config and then to
+`IfNotPresent`. `pullSecrets` behaves differently: a non-empty list on a
+`Server` *replaces* the Config's rather than extending it, so a Server pulling
+from another registry does not carry the Config's credentials along. Secrets
+for code images are always added on top.
+
+The registry defaults live in the Helm charts (`config.image.*`,
+`database.image.*`), where changing them is a values change rather than a CRD
+update.
 
 ### StorageSpec
 

--- a/docs/reference/nodeclassifier.md
+++ b/docs/reference/nodeclassifier.md
@@ -80,8 +80,10 @@ kind: Config
 metadata:
   name: production
 spec:
-  image: ...
   authorityRef: production-ca
+  image:
+    repository: ghcr.io/slauger/openvox-server-8
+    tag: "latest"
   nodeClassifierRef: foreman
 ```
 

--- a/docs/reference/nodeclassifier.md
+++ b/docs/reference/nodeclassifier.md
@@ -166,6 +166,7 @@ At most one authentication method may be configured.
 
 | Field | Type | Description |
 |---|---|---|
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from. A value below `.metadata.generation` means the rest of this status has not caught up with the current spec yet |
 | `phase` | string | Current lifecycle phase |
 | `conditions` | []Condition | `Ready` |
 

--- a/docs/reference/reportprocessor.md
+++ b/docs/reference/reportprocessor.md
@@ -175,6 +175,7 @@ Either `value` or `valueFrom` may be set, not both.
 
 | Field | Type | Description |
 |---|---|---|
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from. A value below `.metadata.generation` means the rest of this status has not caught up with the current spec yet |
 | `phase` | string | Current lifecycle phase |
 | `conditions` | []Condition | `Ready` |
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -33,7 +33,7 @@ spec:
 | `replicas` | int32 | `1` | Number of pod replicas |
 | `autoscaling` | [AutoscalingSpec](#autoscalingspec) | - | HPA configuration |
 | `resources` | ResourceRequirements | - | CPU/memory requests and limits |
-| `javaArgs` | string | `-Xms512m -Xmx1024m` | JVM arguments |
+| `javaArgs` | string | `-Xms512m -Xmx1024m` | JVM arguments. The controller can derive the heap from the memory limit, but the CRD default makes that path unreachable today - see [#592](https://github.com/slauger/openvox-operator/issues/592). Set this explicitly to size the heap |
 | `maxActiveInstances` | int32 | `1` | Number of JRuby instances per pod |
 | `code` | [[]CodeSpec](index.md#codespec) | - | Override the Config's code sources (replace, not merge). A list; see [CodeSpec](index.md#codespec) |
 | `topologySpreadConstraints` | []TopologySpreadConstraint | - | Pod spread constraints across topology domains |

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -131,7 +131,17 @@ When enabled, the default policy allows TCP/8140 from all sources (agents may co
 | `Pending` | Server created, resolving references |
 | `WaitingForCert` | Certificate not yet `Signed` |
 | `Running` | Deployment created and running |
-| `Error` | Reconciliation failed |
+| `Error` | Defined in the API, but never set by the controller (see below) |
+
+`Error` is part of the API but the controller never assigns it. A failing
+reconcile leaves the phase at its previous value, reports the reason in the
+`Ready` condition and emits a warning event. Watch the condition rather than
+the phase:
+
+```bash
+kubectl get server <name> -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}: {.message}{"\n"}{end}'
+```
+
 
 ## Deployment Strategy
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -45,6 +45,7 @@ spec:
 | `envFrom` | []EnvFromSource | - | ConfigMap/Secret sources to populate environment variables from |
 | `extraVolumes` | []Volume | - | Extra volumes added to the Server pods |
 | `extraVolumeMounts` | []VolumeMount | - | Extra volume mounts for the `openvox-server` container |
+| `readOnlyRootFilesystem` | *bool | *(inherits from Config)* | Overrides the Config's setting for this Server. One Config backs several Servers with different roles, so the CA and the compilers can differ. Unset inherits |
 | `securityContext` | [PodSecurityContextSpec](index.md#podsecuritycontextspec) | - | Override pod-level security context (runAsUser/runAsGroup/fsGroup) |
 
 ### Extra Environment and Volumes

--- a/docs/reference/signingpolicy.md
+++ b/docs/reference/signingpolicy.md
@@ -127,6 +127,7 @@ Either `value` or `valueFrom` must be set.
 
 | Field | Type | Description |
 |---|---|---|
+| `observedGeneration` | int64 | The `.metadata.generation` the status was last derived from. A value below `.metadata.generation` means the rest of this status has not caught up with the current spec yet |
 | `phase` | string | Current lifecycle phase |
 | `conditions` | []Condition | `Ready` |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,16 +43,45 @@ condition names it.
 
 **Symptoms:** Certificate never reaches `Signed` phase.
 
+A SigningPolicy is usually *not* the cause here. For an internal CA the
+operator signs its own Certificate resources over the CA API, authenticated
+with the operator signing certificate, so autosign is not involved. Policies
+govern agents, not Certificate resources.
+
 **Possible causes:**
 
-1. **CA not ready:** The CertificateAuthority must be in `Ready` phase.
-2. **No matching SigningPolicy:** No policy exists that would sign this certificate.
+1. **CA not ready.** The CertificateAuthority must report `CAReady`.
 
     ```bash
-    kubectl get signingpolicy -n <namespace>
+    kubectl get certificateauthority <name> -n <namespace> \
+      -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}{"\n"}{end}'
     ```
 
-**Solution:** Check CA status and verify a SigningPolicy with matching criteria exists.
+2. **Operator signing certificate not available yet.** Without it the operator
+   cannot sign and falls back to polling, which only succeeds if something else
+   signs the CSR.
+
+    ```bash
+    kubectl get certificateauthority <name> -n <namespace> \
+      -o jsonpath='{.status.signingSecretName}{"\n"}'
+    ```
+
+    An empty value means the `{ca}-operator-signing` Certificate is not signed
+    yet. During bootstrap this resolves on its own.
+
+3. **Certname already claimed.** Two Certificates cannot share a certname
+   against the same CA. The condition names the holder:
+
+    ```bash
+    kubectl get certificate <name> -n <namespace> \
+      -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}: {.message}{"\n"}{end}'
+    ```
+
+4. **External CA.** With `spec.external` the operator has no admin access and
+   cannot sign. The CSR must be signed on the external CA.
+
+**Agents** stuck in `--waitforcert` are the case where SigningPolicy matters -
+see [Agents cannot connect to server](#agents-cannot-connect-to-server).
 
 ### Server pods not starting
 
@@ -110,9 +139,31 @@ kubectl logs <pod-name> -n <namespace> --previous
 
 ### Agents cannot connect to server
 
-**Symptoms:** Puppet agents fail to connect to the server endpoint.
+**Symptoms:** Puppet agents fail to connect to the server endpoint, or hang in
+`puppet agent --waitforcert`.
 
-**Debugging steps:**
+An agent that reaches the server but hangs waiting for its certificate has a
+signing problem, not a connectivity one. The operator points `autosign` at its
+own binary as soon as a CertificateAuthority exists, and that binary denies
+every CSR no policy matches - so **no SigningPolicy means deny-all, not off**.
+The servers run normally and the Config reports `Running` either way.
+
+```bash
+kubectl get signingpolicy -n <namespace>
+```
+
+An empty list is the common cause on a fresh install. See
+[SigningPolicy](reference/signingpolicy.md) for the available match rules, or
+sign by hand:
+
+```bash
+kubectl exec -n <namespace> deploy/<ca-server> -- \
+  puppetserver ca list --all
+kubectl exec -n <namespace> deploy/<ca-server> -- \
+  puppetserver ca sign --certname <agent-certname>
+```
+
+**Debugging steps for connectivity:**
 
 1. Verify the Pool Service exists:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,7 +68,7 @@ condition names it.
 
 ```bash
 kubectl describe deployment <server-name> -n <namespace>
-kubectl describe pod -l app.kubernetes.io/instance=<server-name> -n <namespace>
+kubectl describe pod -l openvox.voxpupuli.org/server=<server-name> -n <namespace>
 kubectl get events -n <namespace> --sort-by='.lastTimestamp'
 ```
 
@@ -117,7 +117,7 @@ kubectl logs <pod-name> -n <namespace> --previous
 1. Verify the Pool Service exists:
 
     ```bash
-    kubectl get svc -n <namespace> -l app.kubernetes.io/name=openvox-server
+    kubectl get svc -n <namespace> -l app.kubernetes.io/name=openvox
     ```
 
 2. Check endpoints are populated:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
   - Guides:
+      - Connecting Agents: guides/connecting-agents.md
       - CA Import & External CA: guides/ca-import.md
       - Monitoring: guides/monitoring.md
       - Pausing Reconciliation: guides/pausing-reconciliation.md


### PR DESCRIPTION
A documentation review found that the docs had never been checked against the code. This works through the findings, verifying each one before changing anything -- two of the review's own claims did not survive that check and were left alone.

Work in progress; more commits will follow.

## Examples the API server rejects

`spec.code` is a list of sources, not a single one. Ten examples showed it as an object. Verified with `kubectl apply --dry-run=server`:

```
list form:   config.openvox.voxpupuli.org/... created (server dry run)
object form: Error: unknown field "spec.code.image"
```

The image tags `8.12.1` and `8.13.0` appeared at ten places and cannot exist -- `images/openvox-versions.yaml` states the tag carries the operator release version, and the published tags are `0.12.0`, `develop`, `latest`.

Three label selectors do not exist in `labels.go`: `app.kubernetes.io/instance` is never set, `app.kubernetes.io/name` is `openvox` not `openvox-server`, and the CA label has no hyphen. A selector matching nothing is worse than no command, because it reads like an answer.

## Behaviour the controller does not have

`Error` is documented as a phase for Config, Server and Database. It exists in the enum but nothing assigns it: a failed reconcile keeps the previous phase and reports the reason in a condition. Someone waiting for `Error` waits forever. Replaced with the condition to watch; the jsonpath was tested against a live object.

`serverRef` on a Pool exists neither in the CRD nor the chart -- a Server names its pools via `poolRefs`. Removed, and the direction spelled out.

## The deny-all trap

The operator sets `autosign` as soon as a CertificateAuthority exists, and `evaluatePolicies` returns false for an empty list. **Every fresh install starts in deny-all**, and nothing shows it: servers run, the Config reports `Running`, agents sit in `--waitforcert`.

Also separated two cases the troubleshooting guide conflated: a Certificate stuck in `Pending` is almost never a policy problem, because for an internal CA the operator signs its own Certificates over the CA API. Policies govern agents.

## Reference pages against the CRDs

Compared every documented field in both directions. `observedGeneration` exists on all nine status types and appeared on two pages; added to the other seven. Certificate gained `signedSpecHash` and `effectiveDNSAltNames`, Server gained `readOnlyRootFilesystem`.

The ImageSpec table still listed defaults that #549 and #576 removed and contradicted the prose beneath it.

## The missing guide

Nothing showed an agent connecting. New page covering where to point it, running one in and outside the cluster, signing by hand, revoking, and verifying. Two things it gets right that are easy to miss: `ca_server` is only needed once CA and compilers are in separate pools, and `puppet agent --test` returns **2** on success-with-changes.

It also states that `openvox-agent-<major>` is built by CI and not by the release workflow, so it has only a `develop` tag -- a test artifact, not a supported way to run agents.

## Two review claims that did not hold

The report said the docs promise a new key on renewal and that the `Renewing` phase is described wrongly. Neither is true; both pages were already correct. Applying the list blindly would have broken working documentation. What was actually missing is that renewal **reuses** the key deliberately, so it extends validity without rotating -- now documented.