### PR TITLE
fix(image): drop obsolete openvoxserver-ca rootless patches

### DIFF
--- a/images/openvox-server/Containerfile
+++ b/images/openvox-server/Containerfile
@@ -150,13 +150,6 @@ RUN printf '%s\n' \
         > /etc/sysconfig/puppetserver \
     && puppetserver gem install --no-document openvox -v "${OPENVOX_VERSION}"
 
-# Patch openvoxserver-ca to skip cadir symlink and chown (fails rootless)
-RUN find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/action/setup.rb' \
-         -exec sed -i '/Puppetserver::Ca::Utils::Config\.symlink_to_old_cadir/ s/^/# /' {} + 2>/dev/null \
-    ; find / -path '*/openvoxserver-ca-*/lib/puppetserver/ca/utils/file_system.rb' \
-         -exec sed -i 's/FileUtils\.chown/# FileUtils.chown/' {} + 2>/dev/null \
-    ; true
-
 ################################################################################
 # Stage: autosign — compile the openvox-autosign Go binary
 ################################################################################


### PR DESCRIPTION
## Summary

The openvox-server build stage carried a sed patch against the openvoxserver-ca gem that commented out the `symlink_to_old_cadir` call in `action/setup.rb` and every `FileUtils.chown` in `utils/file_system.rb`, because both raised `Errno::EPERM` in rootless containers (no `CAP_CHOWN`).

This is fixed upstream since **openvoxserver-ca 3.2.0**: OpenVoxProject/openvoxserver-ca#33 consolidates ownership changes into an `ensure_ownership` helper that is a no-op when not running as root, and `forcibly_symlink` goes through the same helper - so the cadir compatibility symlink also works rootless now (it lands in the ssl emptyDir and is harmless). The openvox-server 8.15.2 tarball ships openvoxserver-ca **3.2.1**, which includes the fix.

The patch had also been degrading silently: since 3.2.0 the chown sed was editing the inside of `ensure_ownership`, and both `find | sed` commands suppressed all errors (`2>/dev/null`, trailing `; true`), so a non-matching pattern would never have failed the build.

## Validation

- CA setup path is covered by the e2e suite (CA setup Job runs `puppetserver ca setup` rootless)
- The `ca import` path goes through the same `ensure_ownership`/`forcibly_symlink` code