### PR TITLE
ci: expand golangci-lint configuration to the common operator linter set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,31 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+  enable:
+    - errorlint
+    - gosec
+    - misspell
+    - revive
+    - unconvert
+  settings:
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+  exclusions:
+    generated: lax
+    rules:
+      # Test helpers construct fixtures with hardcoded values and do not need
+      # the same hardening as production code.
+      - path: _test\.go
+        linters:
+          - gosec
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,3 +29,9 @@ formatters:
   enable:
     - gofmt
     - goimports
+
+issues:
+  # Report everything instead of capping repeated findings (the defaults hide
+  # issues beyond 3 of the same kind, which makes CI runs non-exhaustive).
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,12 +6,55 @@ run:
 linters:
   default: standard
   enable:
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - copyloopvar
+    - dogsled
+    - durationcheck
     - errorlint
+    - gocritic
     - gosec
+    - importas
+    - intrange
+    - loggercheck
     - misspell
+    - modernize
+    - nakedret
+    - nilerr
+    - nolintlint
+    - prealloc
     - revive
     - unconvert
+    - unparam
   settings:
+    importas:
+      no-unaliased: true
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/api/apps/v1
+          alias: appsv1
+        - pkg: k8s.io/api/autoscaling/v2
+          alias: autoscalingv2
+        - pkg: k8s.io/api/batch/v1
+          alias: batchv1
+        - pkg: k8s.io/api/discovery/v1
+          alias: discoveryv1
+        - pkg: k8s.io/api/networking/v1
+          alias: networkingv1
+        - pkg: k8s.io/api/policy/v1
+          alias: policyv1
+        - pkg: k8s.io/api/rbac/v1
+          alias: rbacv1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: sigs.k8s.io/gateway-api/apis/v1
+          alias: gwapiv1
+    nolintlint:
+      require-specific: true
     revive:
       rules:
         - name: exported

--- a/api/v1alpha1/bool_default_test.go
+++ b/api/v1alpha1/bool_default_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 // TestDefaultedBooleansRoundTrip pins the behaviour of the optional boolean
@@ -27,7 +26,7 @@ func TestDefaultedBooleansRoundTrip(t *testing.T) {
 				ConfigRef:      "production",
 				CertificateRef: "production-cert",
 				CA:             true,
-				Server:         ptr.To(false),
+				Server:         new(false),
 			},
 		}
 		if err := k8sClient.Create(ctx, s); err != nil {
@@ -63,8 +62,8 @@ func TestDefaultedBooleansRoundTrip(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-config-", Namespace: "default"},
 			Spec: ConfigSpec{
 				Image:                  ImageSpec{Repository: "example.invalid/openvox-server", Tag: "latest"},
-				ReadOnlyRootFilesystem: ptr.To(false),
-				Puppet:                 PuppetSpec{Storeconfigs: ptr.To(false)},
+				ReadOnlyRootFilesystem: new(false),
+				Puppet:                 PuppetSpec{Storeconfigs: new(false)},
 			},
 		}
 		if err := k8sClient.Create(ctx, c); err != nil {
@@ -84,10 +83,10 @@ func TestDefaultedBooleansRoundTrip(t *testing.T) {
 		ca := &CertificateAuthority{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-ca-", Namespace: "default"},
 			Spec: CertificateAuthoritySpec{
-				AllowSubjectAltNames:         ptr.To(false),
-				AllowAuthorizationExtensions: ptr.To(false),
-				EnableInfraCRL:               ptr.To(false),
-				AllowAutoRenewal:             ptr.To(false),
+				AllowSubjectAltNames:         new(false),
+				AllowAuthorizationExtensions: new(false),
+				EnableInfraCRL:               new(false),
+				AllowAutoRenewal:             new(false),
 			},
 		}
 		if err := k8sClient.Create(ctx, ca); err != nil {

--- a/api/v1alpha1/certificateauthority_validation_test.go
+++ b/api/v1alpha1/certificateauthority_validation_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/ptr"
 )
 
 func validCA() *CertificateAuthority {
@@ -44,7 +43,7 @@ func TestCertificateAuthorityStorageExclusivity(t *testing.T) {
 		{
 			name: "storage without external accepted",
 			mutate: func(ca *CertificateAuthority) {
-				ca.Spec.Storage = &StorageSpec{Size: ptr.To(resource.MustParse("10Gi"))}
+				ca.Spec.Storage = &StorageSpec{Size: new(resource.MustParse("10Gi"))}
 			},
 		},
 		{
@@ -57,7 +56,7 @@ func TestCertificateAuthorityStorageExclusivity(t *testing.T) {
 			name: "external with custom storage rejected",
 			mutate: func(ca *CertificateAuthority) {
 				ca.Spec.External = external
-				ca.Spec.Storage = &StorageSpec{Size: ptr.To(resource.MustParse("10Gi"))}
+				ca.Spec.Storage = &StorageSpec{Size: new(resource.MustParse("10Gi"))}
 			},
 			wantErr: "external and storage are mutually exclusive",
 		},
@@ -65,7 +64,7 @@ func TestCertificateAuthorityStorageExclusivity(t *testing.T) {
 			name: "external with storage at the default size rejected",
 			mutate: func(ca *CertificateAuthority) {
 				ca.Spec.External = external
-				ca.Spec.Storage = &StorageSpec{Size: ptr.To(resource.MustParse("1Gi"))}
+				ca.Spec.Storage = &StorageSpec{Size: new(resource.MustParse("1Gi"))}
 			},
 			wantErr: "external and storage are mutually exclusive",
 		},
@@ -136,15 +135,15 @@ func TestCertificateAuthorityStorageSizeValidation(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("invalid quantity rejected", func(t *testing.T) {
-		raw := &unstructured.Unstructured{Object: map[string]interface{}{
+		raw := &unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": GroupVersion.String(),
 			"kind":       "CertificateAuthority",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"generateName": "test-ca-",
 				"namespace":    "default",
 			},
-			"spec": map[string]interface{}{
-				"storage": map[string]interface{}{"size": "1Gib"},
+			"spec": map[string]any{
+				"storage": map[string]any{"size": "1Gib"},
 			},
 		}}
 		err := k8sClient.Create(ctx, raw)
@@ -159,7 +158,7 @@ func TestCertificateAuthorityStorageSizeValidation(t *testing.T) {
 
 	t.Run("valid quantity accepted", func(t *testing.T) {
 		ca := validCA()
-		ca.Spec.Storage = &StorageSpec{Size: ptr.To(resource.MustParse("500Mi"))}
+		ca.Spec.Storage = &StorageSpec{Size: new(resource.MustParse("500Mi"))}
 		if err := k8sClient.Create(ctx, ca); err != nil {
 			t.Fatalf("a valid quantity must be accepted, got: %v", err)
 		}

--- a/cmd/autosign/policy.go
+++ b/cmd/autosign/policy.go
@@ -54,7 +54,7 @@ type CSRAttributeConf struct {
 
 // loadPolicyConfig reads and parses the policy YAML file.
 func loadPolicyConfig(path string) (*PolicyConfig, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("reading policy config: %w", err)
 	}

--- a/cmd/enc/classifier.go
+++ b/cmd/enc/classifier.go
@@ -189,7 +189,7 @@ func buildRequestBody(bodyType, certname string) (string, error) {
 func loadFacts(certname string) map[string]interface{} {
 	safeName := filepath.Base(certname)
 	factsPath := filepath.Join("/opt/puppetlabs/server/data/puppetserver/yaml/facts", safeName+".yaml")
-	data, err := os.ReadFile(factsPath)
+	data, err := os.ReadFile(filepath.Clean(factsPath))
 	if err != nil {
 		return map[string]interface{}{}
 	}
@@ -241,7 +241,7 @@ func buildHTTPClient(cfg *ENCConfig) (*http.Client, error) {
 
 	// Load CA certificate for server verification
 	if cfg.SSL.CAFile != "" {
-		caCert, err := os.ReadFile(cfg.SSL.CAFile)
+		caCert, err := os.ReadFile(filepath.Clean(cfg.SSL.CAFile))
 		if err != nil {
 			return nil, fmt.Errorf("reading CA cert: %w", err)
 		}
@@ -283,7 +283,7 @@ func saveCache(dir, certname, data string) error {
 func readCache(dir, certname string) (string, error) {
 	safeName := filepath.Base(certname)
 	path := filepath.Join(dir, safeName+".yaml")
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/enc/classifier.go
+++ b/cmd/enc/classifier.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,13 +78,13 @@ type notFoundError struct{ msg string }
 func (e *notFoundError) Error() string { return e.msg }
 
 func isNotFound(err error) bool {
-	_, ok := err.(*notFoundError)
-	return ok
+	var nfe *notFoundError
+	return errors.As(err, &nfe)
 }
 
 // loadENCConfig reads and parses the ENC config YAML file.
 func loadENCConfig(path string) (*ENCConfig, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("reading ENC config: %w", err)
 	}
@@ -270,12 +271,12 @@ func buildHTTPClient(cfg *ENCConfig) (*http.Client, error) {
 
 // saveCache writes the classification result to a cache file.
 func saveCache(dir, certname, data string) error {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0750); err != nil {
 		return err
 	}
 	safeName := filepath.Base(certname)
 	path := filepath.Join(dir, safeName+".yaml")
-	return os.WriteFile(path, []byte(data), 0644)
+	return os.WriteFile(path, []byte(data), 0600)
 }
 
 // readCache reads a cached classification result.

--- a/cmd/enc/classifier.go
+++ b/cmd/enc/classifier.go
@@ -67,9 +67,9 @@ type SSLConfig struct {
 
 // ENCResult represents a Puppet ENC response.
 type ENCResult struct {
-	Classes     interface{}            `yaml:"classes" json:"classes"`
-	Parameters  map[string]interface{} `yaml:"parameters,omitempty" json:"parameters,omitempty"`
-	Environment string                 `yaml:"environment,omitempty" json:"environment,omitempty"`
+	Classes     any            `yaml:"classes" json:"classes"`
+	Parameters  map[string]any `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+	Environment string         `yaml:"environment,omitempty" json:"environment,omitempty"`
 }
 
 // notFoundError indicates a 404 response.
@@ -175,7 +175,7 @@ func buildRequestBody(bodyType, certname string) (string, error) {
 		return string(data), err
 	case "facts":
 		facts := loadFacts(certname)
-		data, err := json.Marshal(map[string]interface{}{
+		data, err := json.Marshal(map[string]any{
 			"certname": certname,
 			"facts":    facts,
 		})
@@ -186,22 +186,22 @@ func buildRequestBody(bodyType, certname string) (string, error) {
 }
 
 // loadFacts reads Puppet facts for a certname from the YAML facts cache.
-func loadFacts(certname string) map[string]interface{} {
+func loadFacts(certname string) map[string]any {
 	safeName := filepath.Base(certname)
 	factsPath := filepath.Join("/opt/puppetlabs/server/data/puppetserver/yaml/facts", safeName+".yaml")
 	data, err := os.ReadFile(filepath.Clean(factsPath))
 	if err != nil {
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 
 	var factsFile struct {
-		Values map[string]interface{} `yaml:"values"`
+		Values map[string]any `yaml:"values"`
 	}
 	if err := yaml.Unmarshal(data, &factsFile); err != nil {
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 	if factsFile.Values == nil {
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 	return factsFile.Values
 }
@@ -225,7 +225,7 @@ func normalizeResponse(body []byte, format string) (string, error) {
 
 	// Ensure classes is never nil
 	if result.Classes == nil {
-		result.Classes = map[string]interface{}{}
+		result.Classes = map[string]any{}
 	}
 
 	out, err := yaml.Marshal(&result)

--- a/cmd/enc/classifier_test.go
+++ b/cmd/enc/classifier_test.go
@@ -151,8 +151,8 @@ func TestClassify_GET_JSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(ENCResult{
-			Classes:     map[string]interface{}{"nginx": nil},
-			Parameters:  map[string]interface{}{"role": "proxy"},
+			Classes:     map[string]any{"nginx": nil},
+			Parameters:  map[string]any{"role": "proxy"},
 			Environment: "staging",
 		})
 	}))
@@ -733,7 +733,7 @@ func TestBuildRequestBody_Facts(t *testing.T) {
 		t.Fatalf("buildRequestBody: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal([]byte(body), &data); err != nil {
 		t.Fatalf("parsing body: %v", err)
 	}
@@ -760,9 +760,10 @@ func TestNormalizeResponse_InvalidJSON(t *testing.T) {
 }
 
 func TestNormalizeResponse_InvalidYAML(t *testing.T) {
+	// The YAML parser is lenient, so this may or may not error; the test
+	// ensures normalizeResponse does not panic on garbage input.
 	_, err := normalizeResponse([]byte(":\n  :\n    - :\n  invalid"), "yaml")
-	// YAML parser is lenient, so this may or may not error; just ensure no panic
-	_ = err
+	t.Logf("normalizeResponse on invalid YAML returned err=%v", err)
 }
 
 func TestLoadENCConfig_InvalidYAML(t *testing.T) {

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -112,15 +112,20 @@ func main() {
 		if err := s.loadClassificationsFile(); err != nil {
 			log.Printf("WARNING: failed to load classifications file: %v", err)
 		} else {
-			log.Printf("Loaded classifications from %s", s.classificationsFile)
+			log.Printf("Loaded classifications from %s", s.classificationsFile) // #nosec G706 -- path comes from a CLI flag set by the test harness
 		}
 		go s.watchClassificationsFile()
 	}
 
 	mux := newServeMux(s)
 
-	log.Printf("openvox-mock listening on %s", listen)
-	log.Fatal(http.ListenAndServe(listen, mux))
+	log.Printf("openvox-mock listening on %s", listen) // #nosec G706 -- listen address comes from a CLI flag set by the test harness
+	srv := &http.Server{
+		Addr:              listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 func newServeMux(s *server) *http.ServeMux {
@@ -229,7 +234,7 @@ func (s *server) handleENC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	certname := r.PathValue("certname")
-	log.Printf("ENC request for certname=%s", certname)
+	log.Printf("ENC request for certname=%s", certname) // #nosec G706 -- mock server for E2E tests, logs are debug output only
 
 	s.mu.Lock()
 	s.classifications = append(s.classifications, storedClassification{

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -100,7 +100,7 @@ func main() {
 	}
 
 	if encClasses != "" {
-		for _, c := range strings.Split(encClasses, ",") {
+		for c := range strings.SplitSeq(encClasses, ",") {
 			c = strings.TrimSpace(c)
 			if c != "" {
 				s.encClasses = append(s.encClasses, c)

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -181,7 +182,7 @@ func (s *server) loadClassificationsFile() error {
 		return err
 	}
 
-	data, err := os.ReadFile(s.classificationsFile)
+	data, err := os.ReadFile(filepath.Clean(s.classificationsFile))
 	if err != nil {
 		return err
 	}

--- a/cmd/mock/main_test.go
+++ b/cmd/mock/main_test.go
@@ -599,16 +599,23 @@ func TestHECEvent_InvalidJSON(t *testing.T) {
 	}
 }
 
+// discardResponse closes the body of a fire-and-forget request.
+func discardResponse(resp *http.Response, _ error) {
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+}
+
 func TestAPIReset(t *testing.T) {
 	ts, _ := newTestServer()
 	defer ts.Close()
 
 	// Store some data
-	_, _ = http.Post(ts.URL+"/reports", "application/json", strings.NewReader(`{"host":"test"}`))
-	_, _ = http.Post(ts.URL+"/services/collector/event", "application/json", strings.NewReader(`{"event":"test"}`))
+	discardResponse(http.Post(ts.URL+"/reports", "application/json", strings.NewReader(`{"host":"test"}`)))
+	discardResponse(http.Post(ts.URL+"/services/collector/event", "application/json", strings.NewReader(`{"event":"test"}`)))
 	cmd := `{"command":"replace facts","version":5,"payload":{"certname":"node1"}}`
-	_, _ = http.Post(ts.URL+"/pdb/cmd/v1", "application/json", strings.NewReader(cmd))
-	_, _ = http.Get(ts.URL + "/node/test-node")
+	discardResponse(http.Post(ts.URL+"/pdb/cmd/v1", "application/json", strings.NewReader(cmd)))
+	discardResponse(http.Get(ts.URL + "/node/test-node"))
 
 	// Reset
 	req, _ := http.NewRequest("DELETE", ts.URL+"/api/reset", nil)
@@ -677,8 +684,11 @@ func TestReloadClassificationsIfChanged(t *testing.T) {
 
 func TestReloadClassificationsIfChanged_MissingFile(t *testing.T) {
 	s := &server{classificationsFile: "/nonexistent/file.yaml"}
-	// Should not panic, just return
+	// Should not panic, just return without loading anything
 	s.reloadClassificationsIfChanged()
+	if s.classificationsData != nil {
+		t.Error("expected no classifications to be loaded from a missing file")
+	}
 }
 
 func TestLoadClassificationsFile_StatError(t *testing.T) {

--- a/cmd/report/processor.go
+++ b/cmd/report/processor.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -55,7 +56,7 @@ type HeaderConfig struct {
 
 // loadReportConfig reads and parses the report config YAML file.
 func loadReportConfig(path string) (*ReportConfig, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("reading report config: %w", err)
 	}

--- a/cmd/report/processor.go
+++ b/cmd/report/processor.go
@@ -145,7 +145,7 @@ func buildHTTPClient(endpoint EndpointConfig) (*http.Client, error) {
 
 	// Load CA certificate for server verification
 	if endpoint.SSL.CAFile != "" {
-		caCert, err := os.ReadFile(endpoint.SSL.CAFile)
+		caCert, err := os.ReadFile(filepath.Clean(endpoint.SSL.CAFile))
 		if err != nil {
 			return nil, fmt.Errorf("reading CA cert: %w", err)
 		}

--- a/internal/controller/ca_config_uniqueness_test.go
+++ b/internal/controller/ca_config_uniqueness_test.go
@@ -27,7 +27,7 @@ func TestFindConfigForCA_Deterministic(t *testing.T) {
 	)
 	r := newCertificateAuthorityReconciler(c)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		cfg, err := r.findConfigForCA(testCtx(), ca)
 		if err != nil {
 			t.Fatalf("lookup %d: %v", i, err)

--- a/internal/controller/certificate_controller.go
+++ b/internal/controller/certificate_controller.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,7 +83,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	cert := &openvoxv1alpha1.Certificate{}
 	if err := r.Get(ctx, req.NamespacedName, cert); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			forgetCertificateMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
@@ -158,7 +158,7 @@ func (r *CertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Resolve CertificateAuthority
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: cert.Namespace}, ca); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("waiting for CertificateAuthority", "authorityRef", cert.Spec.AuthorityRef)
 			return ctrl.Result{}, nil
 		}
@@ -401,7 +401,7 @@ func (r *CertificateReconciler) adoptTLSSecret(ctx context.Context, cert *openvo
 func (r *CertificateReconciler) extractNotAfter(ctx context.Context, secretName, namespace string) *metav1.Time {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			log.FromContext(ctx).Error(err, "failed to get TLS Secret", "name", secretName, "namespace", namespace)
 		}
 		return nil
@@ -462,10 +462,7 @@ func (r *CertificateReconciler) scheduleRenewalCheck(ctx context.Context, cert *
 	r.emitExpiryWarnings(ctx, cert, timeUntilExpiry)
 
 	// Schedule next check: half the time until renewal, capped at 12h
-	requeueAfter := timeUntilRenewal / 2
-	if requeueAfter > maxRenewalCheckInterval {
-		requeueAfter = maxRenewalCheckInterval
-	}
+	requeueAfter := min(timeUntilRenewal/2, maxRenewalCheckInterval)
 
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
@@ -544,7 +541,7 @@ func (r *CertificateReconciler) handleCertificateCleanup(ctx context.Context, ce
 	// Resolve CertificateAuthority
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: cert.Namespace}, ca); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("CertificateAuthority not found, skipping cleanup", "authorityRef", cert.Spec.AuthorityRef)
 			return nil
 		}

--- a/internal/controller/certificate_controller_test.go
+++ b/internal/controller/certificate_controller_test.go
@@ -1,11 +1,12 @@
 package controller
 
 import (
+	"slices"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clocktesting "k8s.io/utils/clock/testing"
@@ -444,13 +445,7 @@ func TestCertReconcile_FinalizerAdded(t *testing.T) {
 		t.Fatalf("failed to get Certificate: %v", err)
 	}
 
-	found := false
-	for _, f := range updated.Finalizers {
-		if f == certificateFinalizer {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(updated.Finalizers, certificateFinalizer)
 	if !found {
 		t.Error("expected finalizer to be added to Certificate")
 	}
@@ -488,7 +483,7 @@ func TestCertReconcile_DeletionCleansUp(t *testing.T) {
 	// Object should be gone (fake client deletes once last finalizer is removed)
 	updated := &openvoxv1alpha1.Certificate{}
 	err = c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated)
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Errorf("expected Certificate to be deleted, got err: %v", err)
 	}
 }
@@ -513,7 +508,7 @@ func TestCertReconcile_DeletionCANotFound(t *testing.T) {
 	// Object should be gone (CA missing -> cleanup skipped -> finalizer removed)
 	updated := &openvoxv1alpha1.Certificate{}
 	err = c.Get(testCtx(), types.NamespacedName{Name: "my-cert", Namespace: testNamespace}, updated)
-	if !errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Errorf("expected Certificate to be deleted, got err: %v", err)
 	}
 }

--- a/internal/controller/certificate_derived_test.go
+++ b/internal/controller/certificate_derived_test.go
@@ -20,7 +20,7 @@ func TestEffectiveDNSAltNames_AddsTheRouteHostname(t *testing.T) {
 	server.Spec.CertificateRef = "web-cert"
 	server.Spec.PoolRefs = []string{"puppet"}
 
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw"))
 	pool.Spec.Route.InjectDNSAltName = true
 
 	r := newCertificateReconciler(setupTestClient(cert, server, pool))
@@ -43,7 +43,7 @@ func TestEffectiveDNSAltNames_LeavesTheSpecAlone(t *testing.T) {
 	server := newServer("web")
 	server.Spec.CertificateRef = "web-cert"
 	server.Spec.PoolRefs = []string{"puppet"}
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw"))
 	pool.Spec.Route.InjectDNSAltName = true
 
 	c := setupTestClient(cert, server, pool)
@@ -69,7 +69,7 @@ func TestEffectiveDNSAltNames_IsIdempotent(t *testing.T) {
 	server := newServer("web")
 	server.Spec.CertificateRef = "web-cert"
 	server.Spec.PoolRefs = []string{"puppet"}
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw"))
 	pool.Spec.Route.InjectDNSAltName = true
 
 	r := newCertificateReconciler(setupTestClient(cert, server, pool))
@@ -96,7 +96,7 @@ func TestEffectiveDNSAltNames_IgnoresPoolsWithoutInjection(t *testing.T) {
 	server := newServer("web")
 	server.Spec.CertificateRef = "web-cert"
 	server.Spec.PoolRefs = []string{"puppet"}
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw")) // InjectDNSAltName stays false
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw")) // InjectDNSAltName stays false
 
 	r := newCertificateReconciler(setupTestClient(cert, server, pool))
 	names, err := r.effectiveDNSAltNames(testCtx(), cert)
@@ -121,7 +121,7 @@ func TestEffectiveDNSAltNames_IgnoresUnrelatedServers(t *testing.T) {
 	notJoined.Spec.CertificateRef = "web-cert"
 	notJoined.Spec.PoolRefs = nil
 
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw"))
 	pool.Spec.Route.InjectDNSAltName = true
 
 	r := newCertificateReconciler(setupTestClient(cert, otherServer, notJoined, pool))
@@ -142,7 +142,7 @@ func TestEffectiveDNSAltNames_IgnoresTerminatingPool(t *testing.T) {
 	server.Spec.CertificateRef = "web-cert"
 	server.Spec.PoolRefs = []string{"puppet"}
 
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw"))
 	pool.Spec.Route.InjectDNSAltName = true
 	now := metav1.Now()
 	pool.DeletionTimestamp = &now
@@ -167,7 +167,7 @@ func TestEnqueueCertificatesForPool(t *testing.T) {
 	unrelated := newServer("other")
 	unrelated.Spec.CertificateRef = "other-cert"
 	unrelated.Spec.PoolRefs = []string{"different-pool"}
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw"))
 
 	c := setupTestClient(server, unrelated, pool)
 	got := certificatesForPool(c)(testCtx(), pool)

--- a/internal/controller/certificate_signing.go
+++ b/internal/controller/certificate_signing.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -251,11 +251,12 @@ func (r *CertificateReconciler) submitCSR(ctx context.Context, cert *openvoxv1al
 	if err != nil {
 		logger.Error(err, "failed to read CSR response body")
 	}
-	if resp.StatusCode == http.StatusOK {
+	switch {
+	case resp.StatusCode == http.StatusOK:
 		logger.Info("CSR submitted successfully", "certname", certname)
-	} else if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "already has a requested certificate") {
+	case resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "already has a requested certificate"):
 		logger.Info("CSR already pending", "certname", certname)
-	} else {
+	default:
 		return ctrl.Result{RequeueAfter: RequeueIntervalCRL}, fmt.Errorf("CA rejected CSR (HTTP %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -499,7 +500,7 @@ func (r *CertificateReconciler) signCertificate(ctx context.Context, cert *openv
 	}
 
 	// Clean up pending Secret
-	if err := r.Delete(ctx, pendingSecret); err != nil && !errors.IsNotFound(err) {
+	if err := r.Delete(ctx, pendingSecret); err != nil && !apierrors.IsNotFound(err) {
 		logger.Info("failed to delete pending Secret", "error", err)
 	}
 
@@ -729,7 +730,7 @@ func (r *CertificateReconciler) ensurePendingKey(ctx context.Context, cert *open
 	if err == nil && len(pendingSecret.Data["key.pem"]) > 0 {
 		return pendingSecret.Data["key.pem"], nil
 	}
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("checking pending Secret: %w", err)
 	}
 
@@ -755,7 +756,7 @@ func (r *CertificateReconciler) ensurePendingKey(ctx context.Context, cert *open
 	if err := controllerutil.SetControllerReference(cert, secret, r.Scheme); err != nil {
 		return nil, fmt.Errorf("setting owner reference on pending Secret %s: %w", pendingSecretName, err)
 	}
-	if err := r.Create(ctx, secret); err != nil && !errors.IsAlreadyExists(err) {
+	if err := r.Create(ctx, secret); err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("creating pending Secret: %w", err)
 	}
 	return keyPEM, nil

--- a/internal/controller/certificate_spec_drift_test.go
+++ b/internal/controller/certificate_spec_drift_test.go
@@ -13,8 +13,8 @@ import (
 
 // signedCert builds a Certificate that is already signed, with the spec hash
 // and expiry a freshly issued certificate would have.
-func signedCert(name string, notAfter time.Time) *openvoxv1alpha1.Certificate {
-	cert := newCertificate(name, "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
+func signedCert(notAfter time.Time) *openvoxv1alpha1.Certificate {
+	cert := newCertificate("web", "production-ca", openvoxv1alpha1.CertificatePhaseSigned)
 	cert.Spec.DNSAltNames = []string{"puppet.example.com"}
 	cert.Status.SignedSpecHash = specHash(cert)
 	t := metav1.NewTime(notAfter)
@@ -23,7 +23,7 @@ func signedCert(name string, notAfter time.Time) *openvoxv1alpha1.Certificate {
 }
 
 func TestSigningSpecHash(t *testing.T) {
-	base := signedCert("web", time.Now().Add(365*24*time.Hour))
+	base := signedCert(time.Now().Add(365 * 24 * time.Hour))
 
 	t.Run("stable across equal specs", func(t *testing.T) {
 		if specHash(base.DeepCopy()) != specHash(base) {
@@ -82,7 +82,7 @@ func TestRenewalDue_DerivedFromObservedState(t *testing.T) {
 	r := &CertificateReconciler{Clock: testclock.NewFakePassiveClock(now)}
 
 	t.Run("not due outside the window", func(t *testing.T) {
-		cert := signedCert("web", now.Add(200*24*time.Hour))
+		cert := signedCert(now.Add(200 * 24 * time.Hour))
 		cert.Spec.RenewBefore = "60d"
 		if r.renewalDue(cert) {
 			t.Error("renewal should not be due 200 days before expiry with renewBefore 60d")
@@ -90,7 +90,7 @@ func TestRenewalDue_DerivedFromObservedState(t *testing.T) {
 	})
 
 	t.Run("due inside the window", func(t *testing.T) {
-		cert := signedCert("web", now.Add(30*24*time.Hour))
+		cert := signedCert(now.Add(30 * 24 * time.Hour))
 		cert.Spec.RenewBefore = "60d"
 		if !r.renewalDue(cert) {
 			t.Error("renewal should be due 30 days before expiry with renewBefore 60d")
@@ -98,7 +98,7 @@ func TestRenewalDue_DerivedFromObservedState(t *testing.T) {
 	})
 
 	t.Run("suppressed by the cooldown annotation", func(t *testing.T) {
-		cert := signedCert("web", now.Add(30*24*time.Hour))
+		cert := signedCert(now.Add(30 * 24 * time.Hour))
 		cert.Spec.RenewBefore = "60d"
 		cert.Annotations = map[string]string{
 			AnnotationLastRenewalTime: now.Add(-1 * time.Minute).Format(time.RFC3339),
@@ -109,7 +109,7 @@ func TestRenewalDue_DerivedFromObservedState(t *testing.T) {
 	})
 
 	t.Run("phase is irrelevant", func(t *testing.T) {
-		cert := signedCert("web", now.Add(30*24*time.Hour))
+		cert := signedCert(now.Add(30 * 24 * time.Hour))
 		cert.Spec.RenewBefore = "60d"
 		cert.Status.Phase = ""
 		if !r.renewalDue(cert) {
@@ -124,7 +124,7 @@ func TestRenewalDue_DerivedFromObservedState(t *testing.T) {
 func TestReconcile_ResignsOnSpecDrift(t *testing.T) {
 	ca := newCertificateAuthority("production-ca")
 	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseReady
-	cert := signedCert("web", time.Now().Add(365*24*time.Hour))
+	cert := signedCert(time.Now().Add(365 * 24 * time.Hour))
 
 	c := setupTestClient(ca, cert)
 	r := newCertificateReconciler(c)
@@ -167,7 +167,7 @@ func TestReconcile_ResignsOnSpecDrift(t *testing.T) {
 func TestReconcile_AdoptsMissingHashWithoutResigning(t *testing.T) {
 	ca := newCertificateAuthority("production-ca")
 	ca.Status.Phase = openvoxv1alpha1.CertificateAuthorityPhaseReady
-	cert := signedCert("web", time.Now().Add(365*24*time.Hour))
+	cert := signedCert(time.Now().Add(365 * 24 * time.Hour))
 	cert.Status.SignedSpecHash = "" // pre-upgrade state
 
 	c := setupTestClient(ca, cert)

--- a/internal/controller/certificateauthority_controller.go
+++ b/internal/controller/certificateauthority_controller.go
@@ -8,7 +8,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,7 +66,7 @@ func (r *CertificateAuthorityReconciler) Reconcile(ctx context.Context, req ctrl
 
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, req.NamespacedName, ca); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			forgetCertificateAuthorityMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
@@ -376,7 +376,7 @@ func (r *CertificateAuthorityReconciler) reconcileExternalCA(ctx context.Context
 		caSecretName = ext.CASecretRef
 		secret := &corev1.Secret{}
 		if err := r.Get(ctx, types.NamespacedName{Name: ext.CASecretRef, Namespace: ca.Namespace}, secret); err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				logger.Info("waiting for CA Secret referenced by external CA", "secret", ext.CASecretRef)
 				return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 			}
@@ -433,7 +433,7 @@ func (r *CertificateAuthorityReconciler) reconcileExternalCA(ctx context.Context
 func (r *CertificateAuthorityReconciler) adoptSecret(ctx context.Context, ca *openvoxv1alpha1.CertificateAuthority, secretName string) error {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: ca.Namespace}, secret); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("getting Secret %s: %w", secretName, err)
@@ -455,7 +455,7 @@ func (r *CertificateAuthorityReconciler) adoptSecret(ctx context.Context, ca *op
 func (r *CertificateAuthorityReconciler) extractCANotAfter(ctx context.Context, secretName, namespace string) *metav1.Time {
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			log.FromContext(ctx).Error(err, "failed to get CA Secret", "name", secretName, "namespace", namespace)
 		}
 		return nil

--- a/internal/controller/certificateauthority_controller_test.go
+++ b/internal/controller/certificateauthority_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -11,14 +12,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
 
-// caPrereqs returns a Config with authorityRef pointing to the given CA name.
-func caPrereqs(caName string) *openvoxv1alpha1.Config {
-	return newConfig("production", withAuthorityRef(caName))
+// caPrereqs returns a Config with authorityRef pointing to the test CA.
+func caPrereqs() *openvoxv1alpha1.Config {
+	return newConfig("production", withAuthorityRef("test-ca"))
 }
 
 func TestCAReconcile_NotFound(t *testing.T) {
@@ -80,7 +80,7 @@ func TestCAReconcile_NoConfig_EmitsEvent(t *testing.T) {
 func TestCAReconcile_PVCCreation(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	c := setupTestClient(ca, cfg)
 	r := newCertificateAuthorityReconciler(c)
 
@@ -106,8 +106,8 @@ func TestCAReconcile_PVCCreation(t *testing.T) {
 func TestCAReconcile_PVCCustomStorageClass(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	ca.Spec.Storage = &openvoxv1alpha1.StorageSpec{StorageClass: "fast-ssd", Size: ptr.To(resource.MustParse("10Gi"))}
-	cfg := caPrereqs("test-ca")
+	ca.Spec.Storage = &openvoxv1alpha1.StorageSpec{StorageClass: "fast-ssd", Size: new(resource.MustParse("10Gi"))}
+	cfg := caPrereqs()
 	c := setupTestClient(ca, cfg)
 	r := newCertificateAuthorityReconciler(c)
 
@@ -133,7 +133,7 @@ func TestCAReconcile_PVCCustomStorageClass(t *testing.T) {
 func TestCAReconcile_RBACCreation(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	c := setupTestClient(ca, cfg)
 	r := newCertificateAuthorityReconciler(c)
 
@@ -166,7 +166,7 @@ func TestCAReconcile_RBACCreation(t *testing.T) {
 func TestCAReconcile_RBACResourceNames(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	cert := newCertificate("my-cert", "test-ca", openvoxv1alpha1.CertificatePhasePending)
 	c := setupTestClient(ca, cfg, cert)
 	r := newCertificateAuthorityReconciler(c)
@@ -202,7 +202,7 @@ func TestCAReconcile_RBACResourceNames(t *testing.T) {
 func TestCAReconcile_JobCreation(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	c := setupTestClient(ca, cfg)
 	r := newCertificateAuthorityReconciler(c)
 
@@ -253,7 +253,7 @@ func TestCAReconcile_JobCreation(t *testing.T) {
 func TestCAReconcile_PhasePending(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = "" // reset
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	c := setupTestClient(ca, cfg)
 	r := newCertificateAuthorityReconciler(c)
 
@@ -274,7 +274,7 @@ func TestCAReconcile_PhasePending(t *testing.T) {
 func TestCAReconcile_PhaseReady(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": []byte("ca-cert"),
 	})
@@ -316,7 +316,7 @@ func TestCAReconcile_PhaseReady(t *testing.T) {
 func TestCAReconcile_NotAfterRequeue(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	// CA secret exists but with non-parseable cert data, so NotAfter will be nil
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": []byte("not-a-valid-cert"),
@@ -489,7 +489,7 @@ func TestCAReconcile_ExternalCA_CASecretMissingKey(t *testing.T) {
 func TestCAReconcile_ServiceCreation(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	c := setupTestClient(ca, cfg)
 	r := newCertificateAuthorityReconciler(c)
 
@@ -540,7 +540,7 @@ func TestCAReconcile_ServiceCreation(t *testing.T) {
 func TestCAReconcile_JobIncludesServiceFQDN(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	server := newServer("ca-server", withCA(true), withServerRole(true))
 	server.Spec.ConfigRef = "production"
 	server.Spec.CertificateRef = "ca-cert"
@@ -593,7 +593,7 @@ func TestCAReconcile_JobIncludesServiceFQDN(t *testing.T) {
 func TestCAReconcile_StatusServiceName(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": []byte("ca-cert"),
 	})
@@ -657,7 +657,7 @@ func TestCAReconcile_ExternalCA_SkipsPVCAndJob(t *testing.T) {
 func TestCAReconcile_StatusSigningSecretName(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": []byte("ca-cert"),
 	})
@@ -686,7 +686,7 @@ func TestCAReconcile_StatusSigningSecretName(t *testing.T) {
 func TestCAReconcile_StatusSigningSecretName_NoCert(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": []byte("ca-cert"),
 	})
@@ -711,7 +711,7 @@ func TestCAReconcile_StatusSigningSecretName_NoCert(t *testing.T) {
 func TestCAReconcile_OperatorSigningCertCreated(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	certPEM, _ := generateTestCert(t)
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": certPEM,
@@ -755,7 +755,7 @@ func TestCAReconcile_OperatorSigningCertActivated(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
 	ca.Status.SigningSecretName = "old-init-job-tls"
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 
 	certPEM, keyPEM := generateTestCert(t)
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
@@ -808,7 +808,7 @@ func TestCAReconcile_OperatorSigningDoesNotOverwriteInitJobCert(t *testing.T) {
 	// When operator-signing cert is not yet active, the Init-Job cert should still be used
 	ca := newCertificateAuthority("test-ca")
 	ca.Status.Phase = ""
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
 		"ca_crt.pem": []byte("ca-cert"),
 	})
@@ -883,7 +883,7 @@ func TestEnsureCARole_CreateAndUpdate(t *testing.T) {
 	}
 
 	// Update with additional resource names
-	updatedNames := append(resourceNames, "extra-cert-tls")
+	updatedNames := slices.Concat(resourceNames, []string{"extra-cert-tls"})
 	if err := r.ensureCARole(testCtx(), "test-ca-ca-setup", testNamespace, labels, updatedNames, ca); err != nil {
 		t.Fatalf("ensureCARole update: %v", err)
 	}

--- a/internal/controller/certificateauthority_job.go
+++ b/internal/controller/certificateauthority_job.go
@@ -9,7 +9,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -195,8 +195,8 @@ func (r *CertificateAuthorityReconciler) buildCASetupJob(ctx context.Context, ca
 								{Name: "tmp", MountPath: "/tmp"},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: boolPtr(false),
-								ReadOnlyRootFilesystem:   boolPtr(true),
+								AllowPrivilegeEscalation: new(false),
+								ReadOnlyRootFilesystem:   new(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -497,7 +497,7 @@ func (r *CertificateAuthorityReconciler) reconcileJob(ctx context.Context, ca *o
 
 	existingJob := &batchv1.Job{}
 	err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: ca.Namespace}, existingJob)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		logger.Info("creating CA setup job", "name", jobName)
 		if err := controllerutil.SetControllerReference(ca, desiredJob, r.Scheme); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/certificateauthority_job_test.go
+++ b/internal/controller/certificateauthority_job_test.go
@@ -249,7 +249,7 @@ func TestResolveCAJobResources(t *testing.T) {
 
 func TestReconcileJob_CreatesNew(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	c := setupTestClient(ca, cfg)
 	r := newCertificateAuthorityReconciler(c)
 
@@ -284,7 +284,7 @@ func TestReconcileJob_CreatesNew(t *testing.T) {
 
 func TestReconcileJob_Succeeded(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 
 	// Pre-create the expected secret
 	caSecret := newSecret("test-ca-ca", map[string][]byte{
@@ -324,7 +324,7 @@ func TestReconcileJob_Succeeded(t *testing.T) {
 
 func TestReconcileJob_Failed(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 
 	existingJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -361,7 +361,7 @@ func TestReconcileJob_Failed(t *testing.T) {
 
 func TestReconcileJob_Running(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 
 	existingJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -393,7 +393,7 @@ func TestReconcileJob_Running(t *testing.T) {
 
 func TestReconcileJob_ImageChanged(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 
 	existingJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/certificateauthority_pvc.go
+++ b/internal/controller/certificateauthority_pvc.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,7 +24,7 @@ func (r *CertificateAuthorityReconciler) reconcileCAPVC(ctx context.Context, ca 
 
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: ca.Namespace}, pvc)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		storage := resolveCAStorage(ca)
 		storageSize := defaultCAStorageQuantity
 		if storage.Size != nil {

--- a/internal/controller/certificateauthority_rbac.go
+++ b/internal/controller/certificateauthority_rbac.go
@@ -6,7 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -21,7 +21,8 @@ func (r *CertificateAuthorityReconciler) reconcileCASetupRBAC(ctx context.Contex
 
 	caKeySecretName := fmt.Sprintf("%s-ca-key", ca.Name)
 	caCRLSecretName := fmt.Sprintf("%s-ca-crl", ca.Name)
-	resourceNames := []string{caSecretName, caKeySecretName, caCRLSecretName}
+	resourceNames := make([]string, 0, 3+len(certs))
+	resourceNames = append(resourceNames, caSecretName, caKeySecretName, caCRLSecretName)
 	for _, cert := range certs {
 		resourceNames = append(resourceNames, fmt.Sprintf("%s-tls", cert.Name))
 	}
@@ -46,7 +47,7 @@ func (r *CertificateAuthorityReconciler) reconcileCASetupRBAC(ctx context.Contex
 
 func (r *CertificateAuthorityReconciler) ensureCAServiceAccount(ctx context.Context, name, namespace string, labels map[string]string, owner *openvoxv1alpha1.CertificateAuthority) error {
 	sa := &corev1.ServiceAccount{}
-	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sa); errors.IsNotFound(err) {
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sa); apierrors.IsNotFound(err) {
 		sa = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -67,7 +68,7 @@ func (r *CertificateAuthorityReconciler) ensureCAServiceAccount(ctx context.Cont
 func (r *CertificateAuthorityReconciler) ensureCARole(ctx context.Context, name, namespace string, labels map[string]string, resourceNames []string, owner *openvoxv1alpha1.CertificateAuthority) error {
 	role := &rbacv1.Role{}
 	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, role)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		role = &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -115,7 +116,7 @@ func (r *CertificateAuthorityReconciler) ensureCARole(ctx context.Context, name,
 func (r *CertificateAuthorityReconciler) ensureCARoleBinding(ctx context.Context, name, namespace string, labels map[string]string, owner *openvoxv1alpha1.CertificateAuthority) error {
 	rb := &rbacv1.RoleBinding{}
 	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, rb)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		rb = &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/internal/controller/certificateauthority_service.go
+++ b/internal/controller/certificateauthority_service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -28,7 +28,7 @@ func (r *CertificateAuthorityReconciler) reconcileCAService(ctx context.Context,
 
 	svc := &corev1.Service{}
 	err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: ca.Namespace}, svc)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		logger.Info("creating CA Service", "name", svcName)
 		svc = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/certificateauthority_setup_backoff_test.go
+++ b/internal/controller/certificateauthority_setup_backoff_test.go
@@ -44,11 +44,11 @@ func failedSetupJob(message string) *batchv1.Job {
 }
 
 // reloadCA re-reads the CertificateAuthority, the way each reconcile does.
-func reloadCA(t *testing.T, c client.Client, name string) *openvoxv1alpha1.CertificateAuthority {
+func reloadCA(t *testing.T, c client.Client) *openvoxv1alpha1.CertificateAuthority {
 	t.Helper()
 	ca := &openvoxv1alpha1.CertificateAuthority{}
-	if err := c.Get(testCtx(), types.NamespacedName{Name: name, Namespace: testNamespace}, ca); err != nil {
-		t.Fatalf("reading CertificateAuthority %s: %v", name, err)
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "test-ca", Namespace: testNamespace}, ca); err != nil {
+		t.Fatalf("reading CertificateAuthority: %v", err)
 	}
 	return ca
 }
@@ -57,7 +57,7 @@ func reloadCA(t *testing.T, c client.Client, name string) *openvoxv1alpha1.Certi
 // a Job that cannot succeed used to be deleted and recreated roughly every 15
 // seconds forever.
 func TestSetupJob_StopsRecreatingAfterRepeatedFailures(t *testing.T) {
-	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs("test-ca"))
+	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs())
 	r := newCertificateAuthorityReconciler(c)
 
 	for attempt := 1; attempt <= maxSetupAttempts; attempt++ {
@@ -67,7 +67,7 @@ func TestSetupJob_StopsRecreatingAfterRepeatedFailures(t *testing.T) {
 			t.Fatalf("seeding the failed job for attempt %d: %v", attempt, err)
 		}
 
-		ca := reloadCA(t, c, "test-ca")
+		ca := reloadCA(t, c)
 		result, err := r.reconcileJob(testCtx(), ca, setupJobName, job.DeepCopy(), "test-ca-ca")
 		if err != nil {
 			t.Fatalf("reconcileJob attempt %d: %v", attempt, err)
@@ -99,10 +99,10 @@ func TestSetupJob_StopsRecreatingAfterRepeatedFailures(t *testing.T) {
 // TestSetupJob_ReportsFailureInCondition covers the second half of the problem:
 // the CA sat in Initializing with no indication of why.
 func TestSetupJob_ReportsFailureInCondition(t *testing.T) {
-	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs("test-ca"))
+	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs())
 	r := newCertificateAuthorityReconciler(c)
 
-	ca := reloadCA(t, c, "test-ca")
+	ca := reloadCA(t, c)
 	ca.Annotations = map[string]string{AnnotationSetupAttempts: "4"}
 	if err := c.Update(testCtx(), ca); err != nil {
 		t.Fatalf("seeding the attempt counter: %v", err)
@@ -113,11 +113,11 @@ func TestSetupJob_ReportsFailureInCondition(t *testing.T) {
 		t.Fatalf("seeding the failed job: %v", err)
 	}
 
-	if _, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
+	if _, err := r.reconcileJob(testCtx(), reloadCA(t, c), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
 		t.Fatalf("reconcileJob: %v", err)
 	}
 
-	got := reloadCA(t, c, "test-ca")
+	got := reloadCA(t, c)
 	if got.Status.Phase != openvoxv1alpha1.CertificateAuthorityPhaseError {
 		t.Errorf("expected phase %q, got %q", openvoxv1alpha1.CertificateAuthorityPhaseError, got.Status.Phase)
 	}
@@ -137,12 +137,12 @@ func TestSetupJob_ReportsFailureInCondition(t *testing.T) {
 // TestSetupJob_CounterDoesNotGrowOnceTerminal keeps repeated reconciles from
 // inflating the counter and re-emitting the event.
 func TestSetupJob_CounterDoesNotGrowOnceTerminal(t *testing.T) {
-	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs("test-ca"))
+	c := setupTestClient(newCertificateAuthority("test-ca"), caPrereqs())
 	r := newCertificateAuthorityReconciler(c)
 	rec := events.NewFakeRecorder(100)
 	r.Recorder = rec
 
-	ca := reloadCA(t, c, "test-ca")
+	ca := reloadCA(t, c)
 	ca.Annotations = map[string]string{AnnotationSetupAttempts: "4"}
 	if err := c.Update(testCtx(), ca); err != nil {
 		t.Fatalf("seeding the attempt counter: %v", err)
@@ -153,13 +153,13 @@ func TestSetupJob_CounterDoesNotGrowOnceTerminal(t *testing.T) {
 		t.Fatalf("seeding the failed job: %v", err)
 	}
 
-	for i := 0; i < 3; i++ {
-		if _, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
+	for i := range 3 {
+		if _, err := r.reconcileJob(testCtx(), reloadCA(t, c), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
 			t.Fatalf("reconcileJob %d: %v", i, err)
 		}
 	}
 
-	if n := setupAttempts(reloadCA(t, c, "test-ca")); n != maxSetupAttempts {
+	if n := setupAttempts(reloadCA(t, c)); n != maxSetupAttempts {
 		t.Errorf("the counter must stop at %d, got %d", maxSetupAttempts, n)
 	}
 	failures := 0
@@ -188,14 +188,14 @@ func TestSetupJob_SuccessResetsTheBudget(t *testing.T) {
 	job := failedSetupJob("")
 	job.Status = batchv1.JobStatus{Succeeded: 1}
 
-	c := setupTestClient(ca, caPrereqs("test-ca"), caSecret, job)
+	c := setupTestClient(ca, caPrereqs(), caSecret, job)
 	r := newCertificateAuthorityReconciler(c)
 
-	if _, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
+	if _, err := r.reconcileJob(testCtx(), reloadCA(t, c), setupJobName, job.DeepCopy(), "test-ca-ca"); err != nil {
 		t.Fatalf("reconcileJob: %v", err)
 	}
 
-	if n := setupAttempts(reloadCA(t, c, "test-ca")); n != 0 {
+	if n := setupAttempts(reloadCA(t, c)); n != 0 {
 		t.Errorf("a successful job must clear the counter, got %d", n)
 	}
 }
@@ -208,20 +208,20 @@ func TestSetupJob_ImageChangeResetsTheBudget(t *testing.T) {
 
 	job := failedSetupJob("Job has reached the specified backoff limit")
 
-	c := setupTestClient(ca, caPrereqs("test-ca"), job)
+	c := setupTestClient(ca, caPrereqs(), job)
 	r := newCertificateAuthorityReconciler(c)
 
 	desired := job.DeepCopy()
 	desired.Spec.Template.Spec.Containers[0].Image = "corrected:1.2.3"
 
-	res, err := r.reconcileJob(testCtx(), reloadCA(t, c, "test-ca"), setupJobName, desired, "test-ca-ca")
+	res, err := r.reconcileJob(testCtx(), reloadCA(t, c), setupJobName, desired, "test-ca-ca")
 	if err != nil {
 		t.Fatalf("reconcileJob: %v", err)
 	}
 	if res.RequeueAfter != RequeueIntervalMedium {
 		t.Errorf("a corrected image must be retried, got RequeueAfter %v", res.RequeueAfter)
 	}
-	if n := setupAttempts(reloadCA(t, c, "test-ca")); n != 0 {
+	if n := setupAttempts(reloadCA(t, c)); n != 0 {
 		t.Errorf("a corrected image must clear the counter, got %d", n)
 	}
 	if err := c.Get(testCtx(), types.NamespacedName{Name: setupJobName, Namespace: testNamespace}, &batchv1.Job{}); !apierrors.IsNotFound(err) {

--- a/internal/controller/certificateauthority_signing.go
+++ b/internal/controller/certificateauthority_signing.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,7 +55,7 @@ func (r *CertificateAuthorityReconciler) reconcileOperatorSigningCert(ctx contex
 		}
 
 		if err := r.Create(ctx, newCert); err != nil {
-			if errors.IsAlreadyExists(err) {
+			if apierrors.IsAlreadyExists(err) {
 				// Already exists, requeue to pick it up next time
 				return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 			}

--- a/internal/controller/config_autosign.go
+++ b/internal/controller/config_autosign.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,7 +60,7 @@ func (r *ConfigReconciler) reconcileAutosignSecrets(ctx context.Context, cfg *op
 	}
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cfg.Spec.AuthorityRef, Namespace: cfg.Namespace}, ca); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("getting CertificateAuthority %s: %w", cfg.Spec.AuthorityRef, err)

--- a/internal/controller/config_controller.go
+++ b/internal/controller/config_controller.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,7 +51,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	cfg := &openvoxv1alpha1.Config{}
 	if err := r.Get(ctx, req.NamespacedName, cfg); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -291,7 +291,7 @@ func (r *ConfigReconciler) findCertificateAuthority(ctx context.Context, cfg *op
 	}
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cfg.Spec.AuthorityRef, Namespace: cfg.Namespace}, ca); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("getting CertificateAuthority %s: %w", cfg.Spec.AuthorityRef, err)

--- a/internal/controller/config_controller_test.go
+++ b/internal/controller/config_controller_test.go
@@ -82,7 +82,7 @@ func TestConfigReconcile_PuppetConfRendering(t *testing.T) {
 		{
 			name: "storeconfigs enabled",
 			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
-				Storeconfigs: boolPtr(true),
+				Storeconfigs: new(true),
 				StoreBackend: "puppetdb",
 				Reports:      "puppetdb",
 			})},
@@ -91,7 +91,7 @@ func TestConfigReconcile_PuppetConfRendering(t *testing.T) {
 		{
 			name: "storeconfigs disabled",
 			opts: []configOption{withPuppetSpec(openvoxv1alpha1.PuppetSpec{
-				Storeconfigs: boolPtr(false),
+				Storeconfigs: new(false),
 				Reports:      "puppetdb",
 			})},
 			excludes: []string{"storeconfigs = true"},
@@ -222,7 +222,7 @@ func TestConfigReconcile_PuppetConfWithCA(t *testing.T) {
 
 func TestConfigReconcile_PuppetConfWithENC(t *testing.T) {
 	nc := newNodeClassifier("my-enc", "https://enc.example.com")
-	cfg := newConfig("production", withNodeClassifierRef("my-enc"))
+	cfg := newConfig("production", withNodeClassifierRef())
 	c := setupTestClient(cfg, nc)
 	r := newConfigReconciler(c)
 
@@ -279,7 +279,7 @@ func TestConfigReconcile_AutosignCommandOverride(t *testing.T) {
 
 func TestConfigReconcile_ExternalNodesCommandOverride(t *testing.T) {
 	cfg := newConfig("production",
-		withNodeClassifierRef("my-enc"),
+		withNodeClassifierRef(),
 		withExternalNodesCommand("/usr/local/bin/custom-enc"),
 	)
 	nc := newNodeClassifier("my-enc", "https://enc.example.com")
@@ -315,7 +315,7 @@ func TestConfigReconcile_ExternalNodesCommandOverride(t *testing.T) {
 
 func TestConfigReconcile_PuppetConfWithReports(t *testing.T) {
 	cfg := newConfig("production")
-	rp := newReportProcessor("webhook-rp", "production", "https://reports.example.com")
+	rp := newReportProcessor("webhook-rp", "https://reports.example.com")
 	c := setupTestClient(cfg, rp)
 	r := newConfigReconciler(c)
 
@@ -365,8 +365,8 @@ func TestConfigReconcile_PuppetserverConf(t *testing.T) {
 			name: "http-client settings",
 			ps: openvoxv1alpha1.PuppetServerSpec{
 				HTTPClient: &openvoxv1alpha1.HTTPClientSpec{
-					ConnectTimeoutMs: int32Ptr(5000),
-					IdleTimeoutMs:    int32Ptr(30000),
+					ConnectTimeoutMs: new(int32(5000)),
+					IdleTimeoutMs:    new(int32(30000)),
 				},
 			},
 			contains: []string{
@@ -587,7 +587,7 @@ func TestConfigReconcile_ENCSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := newConfig("production", withNodeClassifierRef("my-enc"))
+			cfg := newConfig("production", withNodeClassifierRef())
 			c := setupTestClient(cfg, tt.nc)
 			r := newConfigReconciler(c)
 
@@ -612,8 +612,8 @@ func TestConfigReconcile_ENCSecret(t *testing.T) {
 
 func TestConfigReconcile_ReportWebhookSecret(t *testing.T) {
 	cfg := newConfig("production")
-	rp1 := newReportProcessor("beta-webhook", "production", "https://beta.example.com/reports")
-	rp2 := newReportProcessor("alpha-webhook", "production", "https://alpha.example.com/reports")
+	rp1 := newReportProcessor("beta-webhook", "https://beta.example.com/reports")
+	rp2 := newReportProcessor("alpha-webhook", "https://alpha.example.com/reports")
 
 	c := setupTestClient(cfg, rp1, rp2)
 	r := newConfigReconciler(c)
@@ -757,8 +757,4 @@ func TestConfigReconcile_UpdateExistingConfigMap(t *testing.T) {
 	if !strings.Contains(cm.Data["puppet.conf"], "[main]") {
 		t.Error("ConfigMap puppet.conf missing expected content")
 	}
-}
-
-func int32Ptr(v int32) *int32 {
-	return &v
 }

--- a/internal/controller/config_enc.go
+++ b/internal/controller/config_enc.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,7 +33,7 @@ func (r *ConfigReconciler) reconcileENCSecret(ctx context.Context, cfg *openvoxv
 
 	nc := &openvoxv1alpha1.NodeClassifier{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cfg.Spec.NodeClassifierRef, Namespace: cfg.Namespace}, nc); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("getting NodeClassifier %s: %w", cfg.Spec.NodeClassifierRef, err)

--- a/internal/controller/config_rendering.go
+++ b/internal/controller/config_rendering.go
@@ -52,7 +52,7 @@ func (r *ConfigReconciler) renderPuppetConf(ctx context.Context, cfg *openvoxv1a
 		if reports == "" {
 			reports = "webhook"
 		} else if !strings.Contains(reports, "webhook") {
-			reports = reports + ",webhook"
+			reports += ",webhook"
 		}
 	}
 	if reports != "" {
@@ -297,11 +297,12 @@ func (r *ConfigReconciler) renderAuthConf(cfg *openvoxv1alpha1.Config, ca *openv
 			}
 		}
 		sb.WriteString("            }\n")
-		if rule.AllowUnauthenticated {
+		switch {
+		case rule.AllowUnauthenticated:
 			sb.WriteString("            allow-unauthenticated: true\n")
-		} else if rule.Allow != "" {
+		case rule.Allow != "":
 			fmt.Fprintf(&sb, "            allow: %q\n", rule.Allow)
-		} else if rule.Deny != "" {
+		case rule.Deny != "":
 			fmt.Fprintf(&sb, "            deny: %q\n", rule.Deny)
 		}
 		sortOrder := rule.SortOrder

--- a/internal/controller/config_rendering_test.go
+++ b/internal/controller/config_rendering_test.go
@@ -35,7 +35,7 @@ func TestRenderRoutesYAML(t *testing.T) {
 		{
 			name: "wired up but backend is not puppetdb",
 			cfg: newConfig("c", withDatabaseRef("db"), withPuppetSpec(openvoxv1alpha1.PuppetSpec{
-				Storeconfigs: boolPtr(false),
+				Storeconfigs: new(false),
 				StoreBackend: "",
 				Reports:      "store",
 			})),
@@ -44,7 +44,7 @@ func TestRenderRoutesYAML(t *testing.T) {
 		{
 			name: "wired up via reports=puppetdb only",
 			cfg: newConfig("c", withDatabaseRef("db"), withPuppetSpec(openvoxv1alpha1.PuppetSpec{
-				Storeconfigs: boolPtr(false),
+				Storeconfigs: new(false),
 				Reports:      "puppetdb",
 			})),
 			want: true,
@@ -280,10 +280,10 @@ func TestRenderCAConf(t *testing.T) {
 			name: "custom values",
 			ca: &openvoxv1alpha1.CertificateAuthority{
 				Spec: openvoxv1alpha1.CertificateAuthoritySpec{
-					AllowSubjectAltNames:         boolPtr(false),
-					AllowAuthorizationExtensions: boolPtr(false),
-					EnableInfraCRL:               boolPtr(false),
-					AllowAutoRenewal:             boolPtr(false),
+					AllowSubjectAltNames:         new(false),
+					AllowAuthorizationExtensions: new(false),
+					EnableInfraCRL:               new(false),
+					AllowAutoRenewal:             new(false),
 					AutoRenewalCertTTL:           "30d",
 				},
 			},
@@ -299,10 +299,10 @@ func TestRenderCAConf(t *testing.T) {
 			name: "empty autoRenewalCertTTL uses default",
 			ca: &openvoxv1alpha1.CertificateAuthority{
 				Spec: openvoxv1alpha1.CertificateAuthoritySpec{
-					AllowSubjectAltNames:         boolPtr(true),
-					AllowAuthorizationExtensions: boolPtr(true),
-					EnableInfraCRL:               boolPtr(true),
-					AllowAutoRenewal:             boolPtr(true),
+					AllowSubjectAltNames:         new(true),
+					AllowAuthorizationExtensions: new(true),
+					EnableInfraCRL:               new(true),
+					AllowAutoRenewal:             new(true),
 					AutoRenewalCertTTL:           "",
 				},
 			},

--- a/internal/controller/config_serviceaccount.go
+++ b/internal/controller/config_serviceaccount.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -19,7 +19,7 @@ func (r *ConfigReconciler) reconcileServerServiceAccount(ctx context.Context, cf
 
 	sa := &corev1.ServiceAccount{}
 	err := r.Get(ctx, types.NamespacedName{Name: saName, Namespace: cfg.Namespace}, sa)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		sa = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      saName,

--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -63,7 +63,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	db := &openvoxv1alpha1.Database{}
 	if err := r.Get(ctx, req.NamespacedName, db); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("getting Database %s: %w", req.NamespacedName, err)
@@ -90,7 +90,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Resolve Certificate -- wait until phase is Signed
 	cert := &openvoxv1alpha1.Certificate{}
 	if err := r.Get(ctx, types.NamespacedName{Name: db.Spec.CertificateRef, Namespace: db.Namespace}, cert); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("waiting for Certificate", "certificateRef", db.Spec.CertificateRef)
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
@@ -110,7 +110,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Resolve CertificateAuthority via Certificate's authorityRef
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: db.Namespace}, ca); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("waiting for CertificateAuthority", "authorityRef", cert.Spec.AuthorityRef)
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
@@ -120,7 +120,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Validate PG credentials Secret exists
 	pgSecret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: db.Spec.Postgres.CredentialsSecretRef, Namespace: db.Namespace}, pgSecret); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("waiting for PostgreSQL credentials Secret", "secretRef", db.Spec.Postgres.CredentialsSecretRef)
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
@@ -312,7 +312,7 @@ func (r *DatabaseReconciler) reconcileService(ctx context.Context, db *openvoxv1
 func (r *DatabaseReconciler) getReadyReplicas(ctx context.Context, db *openvoxv1alpha1.Database) (int32, error) {
 	deploy := &appsv1.Deployment{}
 	if err := r.Get(ctx, types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, deploy); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("getting Deployment %s: %w", db.Name, err)
@@ -332,11 +332,11 @@ func (r *DatabaseReconciler) reconcilePDB(ctx context.Context, db *openvoxv1alph
 				return guardErr
 			}
 			logger.Info("deleting Database PDB (disabled)", "name", pdbName)
-			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("deleting PodDisruptionBudget %s: %w", pdbName, err)
 			}
 			r.Recorder.Eventf(db, nil, corev1.EventTypeNormal, EventReasonDatabasePDBDeleted, "Reconcile", "PodDisruptionBudget %s deleted", pdbName)
-		} else if !errors.IsNotFound(err) {
+		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("getting PodDisruptionBudget %s: %w", pdbName, err)
 		}
 		return nil
@@ -386,11 +386,12 @@ func (r *DatabaseReconciler) buildPDB(db *openvoxv1alpha1.Database) (*policyv1.P
 			},
 		},
 	}
-	if db.Spec.PDB.MinAvailable != nil {
+	switch {
+	case db.Spec.PDB.MinAvailable != nil:
 		pdb.Spec.MinAvailable = db.Spec.PDB.MinAvailable
-	} else if db.Spec.PDB.MaxUnavailable != nil {
+	case db.Spec.PDB.MaxUnavailable != nil:
 		pdb.Spec.MaxUnavailable = db.Spec.PDB.MaxUnavailable
-	} else {
+	default:
 		minAvailable := intstrInt(DefaultPDBMinAvailable)
 		pdb.Spec.MinAvailable = &minAvailable
 	}
@@ -412,11 +413,11 @@ func (r *DatabaseReconciler) reconcileNetworkPolicy(ctx context.Context, db *ope
 				return guardErr
 			}
 			logger.Info("deleting Database NetworkPolicy (disabled)", "name", npName)
-			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("deleting NetworkPolicy %s: %w", npName, err)
 			}
 			r.Recorder.Eventf(db, nil, corev1.EventTypeNormal, EventReasonDatabaseNetworkPolicyDeleted, "Reconcile", "NetworkPolicy %s deleted", npName)
-		} else if !errors.IsNotFound(err) {
+		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("getting NetworkPolicy %s: %w", npName, err)
 		}
 		return nil

--- a/internal/controller/database_deployment.go
+++ b/internal/controller/database_deployment.go
@@ -6,7 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -68,7 +68,7 @@ func (r *DatabaseReconciler) reconcileDeployment(ctx context.Context, db *openvo
 
 	deploy := &appsv1.Deployment{}
 	err = r.Get(ctx, types.NamespacedName{Name: deployName, Namespace: db.Namespace}, deploy)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		logger.Info("creating Database Deployment", "name", deployName, "replicas", replicas)
 
 		deploy = &appsv1.Deployment{
@@ -239,8 +239,8 @@ chmod 640 /ssl/private_keys/%s.pem`, certname, certname, certname)
 	}
 
 	containerSecurityContext := &corev1.SecurityContext{
-		AllowPrivilegeEscalation: boolPtr(false),
-		ReadOnlyRootFilesystem:   boolPtr(true),
+		AllowPrivilegeEscalation: new(false),
+		ReadOnlyRootFilesystem:   new(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -112,7 +112,7 @@ func parseCertNotAfter(ctx context.Context, certPEM []byte) *metav1.Time {
 func isSecretReady(ctx context.Context, reader client.Reader, name, namespace, requiredKey string) bool {
 	secret := &corev1.Secret{}
 	if err := reader.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			log.FromContext(ctx).Error(err, "failed to get Secret", "name", name, "namespace", namespace)
 		}
 		return false

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -212,25 +212,6 @@ func TestResolveCodeMounts(t *testing.T) {
 	}
 }
 
-func TestInt64Ptr(t *testing.T) {
-	val := int64Ptr(42)
-	if val == nil || *val != 42 {
-		t.Errorf("int64Ptr(42) = %v, want pointer to 42", val)
-	}
-}
-
-func TestBoolPtr(t *testing.T) {
-	val := boolPtr(true)
-	if val == nil || !*val {
-		t.Errorf("boolPtr(true) = %v, want pointer to true", val)
-	}
-
-	val = boolPtr(false)
-	if val == nil || *val {
-		t.Errorf("boolPtr(false) = %v, want pointer to false", val)
-	}
-}
-
 func TestUpdateStatusWithRetry(t *testing.T) {
 	cfg := &openvoxv1alpha1.Config{
 		ObjectMeta: metav1.ObjectMeta{
@@ -273,7 +254,7 @@ func TestUpdateStatusWithRetry_ConflictRetry(t *testing.T) {
 		WithInterceptorFuncs(interceptor.Funcs{
 			SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 				if calls.Add(1) == 1 {
-					return errors.NewConflict(schema.GroupResource{Group: "openvox.voxpupuli.org", Resource: "configs"}, obj.GetName(), fmt.Errorf("conflict"))
+					return apierrors.NewConflict(schema.GroupResource{Group: "openvox.voxpupuli.org", Resource: "configs"}, obj.GetName(), fmt.Errorf("conflict"))
 				}
 				return client.SubResource(subResourceName).Update(ctx, obj, opts...)
 			},

--- a/internal/controller/image_pull_settings_test.go
+++ b/internal/controller/image_pull_settings_test.go
@@ -240,7 +240,7 @@ func TestSSLBootstrapped_TrueOnceSigned(t *testing.T) {
 // TestPullSecrets_ReachTheCASetupJob covers the third workload.
 func TestPullSecrets_ReachTheCASetupJob(t *testing.T) {
 	ca := newCertificateAuthority("test-ca")
-	cfg := caPrereqs("test-ca")
+	cfg := caPrereqs()
 	cfg.Spec.Image.PullSecrets = []corev1.LocalObjectReference{{Name: "registry-creds"}}
 
 	r := newCertificateAuthorityReconciler(setupTestClient(ca, cfg))

--- a/internal/controller/labels.go
+++ b/internal/controller/labels.go
@@ -1,7 +1,5 @@
 package controller
 
-import corev1 "k8s.io/api/core/v1"
-
 const (
 	// Label keys used across all resources.
 	LabelConfig               = "openvox.voxpupuli.org/config"
@@ -59,11 +57,4 @@ func databaseLabels(dbName string) map[string]string {
 		"app.kubernetes.io/managed-by": "openvox-operator",
 		LabelDatabase:                  dbName,
 	}
-}
-
-func int64Ptr(i int64) *int64 { return &i }
-func boolPtr(b bool) *bool    { return &b }
-
-func fsGroupChangePolicyPtr(p corev1.PodFSGroupChangePolicy) *corev1.PodFSGroupChangePolicy {
-	return &p
 }

--- a/internal/controller/observed_generation_test.go
+++ b/internal/controller/observed_generation_test.go
@@ -125,7 +125,7 @@ func TestCondition_LastTransitionTimeIsStable(t *testing.T) {
 	}
 	first := readTransitionTime("the first reconcile")
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
 			t.Fatalf("reconcile %d: %v", i+2, err)
 		}

--- a/internal/controller/ownership_test.go
+++ b/internal/controller/ownership_test.go
@@ -78,7 +78,7 @@ func TestReconcilePDB_NoEventWhenUnchanged(t *testing.T) {
 	}
 	drain(rec)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := r.reconcilePDB(testCtx(), server); err != nil {
 			t.Fatalf("reconcile %d: %v", i+2, err)
 		}
@@ -165,7 +165,7 @@ func TestPoolRouteHostname_IsDerivedNotWritten(t *testing.T) {
 	server.Spec.CertificateRef = "web-cert"
 	server.Spec.PoolRefs = []string{"puppet"}
 
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "gw"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "gw"))
 	pool.Spec.Route.InjectDNSAltName = true
 
 	c := setupTestClient(ca, cert, server, pool)

--- a/internal/controller/pause_test.go
+++ b/internal/controller/pause_test.go
@@ -198,7 +198,7 @@ func TestPause_DoesNotWriteStatusRepeatedly(t *testing.T) {
 		t.Fatalf("reading Config: %v", err)
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, err := r.Reconcile(testCtx(), testRequest("production")); err != nil {
 			t.Fatalf("reconcile %d: %v", i+2, err)
 		}

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -432,7 +432,7 @@ func (r *PoolReconciler) reconcileTLSRoute(ctx context.Context, pool *openvoxv1a
 
 	port := gwapiv1.PortNumber(8140)
 	if pool.Spec.Service.Port > 0 {
-		port = gwapiv1.PortNumber(pool.Spec.Service.Port)
+		port = pool.Spec.Service.Port
 	}
 
 	parentRef := gwapiv1.ParentReference{

--- a/internal/controller/pool_controller.go
+++ b/internal/controller/pool_controller.go
@@ -3,10 +3,11 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -57,7 +58,7 @@ func (r *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	pool := &openvoxv1alpha1.Pool{}
 	if err := r.Get(ctx, req.NamespacedName, pool); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("getting Pool %s: %w", req.NamespacedName, err)
@@ -242,7 +243,7 @@ func (r *PoolReconciler) deleteOwnedTLSRoute(ctx context.Context, pool *openvoxv
 
 	existing := &gwapiv1.TLSRoute{}
 	if err := r.Get(ctx, types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}, existing); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("getting TLSRoute %s: %w", pool.Name, err)
@@ -252,7 +253,7 @@ func (r *PoolReconciler) deleteOwnedTLSRoute(ctx context.Context, pool *openvoxv
 	}
 
 	logger.Info("deleting orphaned TLSRoute", "name", pool.Name)
-	if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+	if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("deleting orphaned TLSRoute: %w", err)
 	}
 	r.Recorder.Eventf(pool, nil, corev1.EventTypeNormal, EventReasonTLSRouteDeleted, "Reconcile", "TLSRoute %s deleted", pool.Name)
@@ -358,9 +359,7 @@ func (r *PoolReconciler) reconcileService(ctx context.Context, pool *openvoxv1al
 		"app.kubernetes.io/managed-by": "openvox-operator",
 		poolLabel(pool.Name):           "true",
 	}
-	for k, v := range pool.Spec.Service.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, pool.Spec.Service.Labels)
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: pool.Namespace},

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -148,7 +148,7 @@ func TestPoolReconcile_EndpointCount(t *testing.T) {
 }
 
 func TestPoolReconcile_TLSRouteCreation(t *testing.T) {
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "my-gateway"))
 	c := setupTestClient(pool)
 	r := newPoolReconciler(c, true)
 
@@ -187,7 +187,7 @@ func TestPoolReconcile_TLSRouteDisabled(t *testing.T) {
 
 func TestPoolReconcile_TLSRouteHostnameConflict(t *testing.T) {
 	// Create pool-a first and reconcile it
-	pool1 := newPool("puppet-a", withRoute(true, "puppet.example.com", "gw"))
+	pool1 := newPool("puppet-a", withRoute("puppet.example.com", "gw"))
 	c := setupTestClient(pool1)
 	r := newPoolReconciler(c, true)
 
@@ -196,7 +196,7 @@ func TestPoolReconcile_TLSRouteHostnameConflict(t *testing.T) {
 	}
 
 	// Now add pool-b with the same hostname
-	pool2 := newPool("puppet-b", withRoute(true, "puppet.example.com", "gw"))
+	pool2 := newPool("puppet-b", withRoute("puppet.example.com", "gw"))
 	if err := c.Create(testCtx(), pool2); err != nil {
 		t.Fatalf("failed to create pool-b: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestPoolReconcile_UpdateExistingService(t *testing.T) {
 }
 
 func TestPoolReconcile_TLSRouteDirectUpdate(t *testing.T) {
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "my-gateway"))
 	c := setupTestClient(pool)
 	r := newPoolReconciler(c, true)
 
@@ -266,7 +266,7 @@ func TestPoolReconcile_TLSRouteDirectUpdate(t *testing.T) {
 }
 
 func TestPoolReconcile_TLSRouteWithSectionName(t *testing.T) {
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"))
+	pool := newPool("puppet", withRoute("puppet.example.com", "my-gateway"))
 	pool.Spec.Route.GatewayRef.SectionName = "https"
 	c := setupTestClient(pool)
 	r := newPoolReconciler(c, true)
@@ -285,7 +285,7 @@ func TestPoolReconcile_TLSRouteWithSectionName(t *testing.T) {
 }
 
 func TestPoolReconcile_TLSRouteCustomPort(t *testing.T) {
-	pool := newPool("puppet", withRoute(true, "puppet.example.com", "my-gateway"), withServicePort(9140))
+	pool := newPool("puppet", withRoute("puppet.example.com", "my-gateway"), withServicePort(9140))
 	c := setupTestClient(pool)
 	r := newPoolReconciler(c, true)
 

--- a/internal/controller/pool_controller_test.go
+++ b/internal/controller/pool_controller_test.go
@@ -297,7 +297,7 @@ func TestPoolReconcile_TLSRouteCustomPort(t *testing.T) {
 	if err := c.Get(testCtx(), types.NamespacedName{Name: "puppet", Namespace: testNamespace}, route); err != nil {
 		t.Fatalf("TLSRoute not created: %v", err)
 	}
-	if route.Spec.Rules[0].BackendRefs[0].Port == nil || int32(*route.Spec.Rules[0].BackendRefs[0].Port) != 9140 {
+	if route.Spec.Rules[0].BackendRefs[0].Port == nil || *route.Spec.Rules[0].BackendRefs[0].Port != 9140 {
 		t.Errorf("expected port 9140 on backend ref")
 	}
 }

--- a/internal/controller/pool_hostname_conflict_test.go
+++ b/internal/controller/pool_hostname_conflict_test.go
@@ -25,8 +25,8 @@ const conflictHostname = "puppet.example.com"
 // controller-runtime retry it with exponential backoff forever, which produced
 // nothing but a growing backlog of identical events.
 func TestPoolConflict_ReportedAsConditionNotRetried(t *testing.T) {
-	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
-	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+	winner := newPool("pool-a", withRoute(conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(conflictHostname, "gw"))
 
 	c := setupTestClient(winner, loser)
 	r := newPoolReconciler(c, true)
@@ -60,9 +60,9 @@ func TestPoolConflict_ReportedAsConditionNotRetried(t *testing.T) {
 // the same list, so both must reach the same verdict, otherwise they take turns
 // creating and deleting the TLSRoute.
 func TestPoolConflict_OlderPoolKeepsTheHostname(t *testing.T) {
-	older := newPool("zzz-first", withRoute(true, conflictHostname, "gw"))
+	older := newPool("zzz-first", withRoute(conflictHostname, "gw"))
 	older.CreationTimestamp = metav1.NewTime(time.Unix(1_700_000_000, 0))
-	younger := newPool("aaa-second", withRoute(true, conflictHostname, "gw"))
+	younger := newPool("aaa-second", withRoute(conflictHostname, "gw"))
 	younger.CreationTimestamp = metav1.NewTime(time.Unix(1_700_000_100, 0))
 
 	c := setupTestClient(older, younger)
@@ -99,7 +99,7 @@ func TestPoolConflict_OlderPoolKeepsTheHostname(t *testing.T) {
 // TLSRoutes for one hostname: a Pool that held the route before an older
 // claimant enabled its own must release it.
 func TestPoolConflict_LoserGivesUpItsRoute(t *testing.T) {
-	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(conflictHostname, "gw"))
 
 	c := setupTestClient(loser)
 	r := newPoolReconciler(c, true)
@@ -112,7 +112,7 @@ func TestPoolConflict_LoserGivesUpItsRoute(t *testing.T) {
 	}
 
 	// pool-a takes the hostname on the tie-break.
-	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	winner := newPool("pool-a", withRoute(conflictHostname, "gw"))
 	if err := c.Create(testCtx(), winner); err != nil {
 		t.Fatalf("creating pool-a: %v", err)
 	}
@@ -130,10 +130,10 @@ func TestPoolConflict_LoserGivesUpItsRoute(t *testing.T) {
 // from holding a hostname hostage.
 func TestPoolConflict_TerminatingPoolReleasesTheHostname(t *testing.T) {
 	now := metav1.Now()
-	leaving := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
+	leaving := newPool("pool-a", withRoute(conflictHostname, "gw"))
 	leaving.DeletionTimestamp = &now
 	leaving.Finalizers = []string{"example.com/keep-around"}
-	successor := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+	successor := newPool("pool-b", withRoute(conflictHostname, "gw"))
 
 	c := setupTestClient(leaving, successor)
 	r := newPoolReconciler(c, true)
@@ -150,15 +150,15 @@ func TestPoolConflict_TerminatingPoolReleasesTheHostname(t *testing.T) {
 // TestPoolConflict_EventFiresOncePerTransition guards against the event noise
 // the old backoff loop produced.
 func TestPoolConflict_EventFiresOncePerTransition(t *testing.T) {
-	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
-	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+	winner := newPool("pool-a", withRoute(conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(conflictHostname, "gw"))
 
 	c := setupTestClient(winner, loser)
 	r := newPoolReconciler(c, true)
 	rec := events.NewFakeRecorder(100)
 	r.Recorder = rec
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, err := r.Reconcile(testCtx(), testRequest("pool-b")); err != nil {
 			t.Fatalf("reconcile %d: %v", i, err)
 		}
@@ -189,8 +189,8 @@ func countEvents(rec *events.FakeRecorder, reason string) int {
 // hostname is free the Pool must pick it up, which is what the sibling watch is
 // there to trigger.
 func TestPoolConflict_ResolvedWhenTheWinnerGivesUp(t *testing.T) {
-	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
-	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+	winner := newPool("pool-a", withRoute(conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(conflictHostname, "gw"))
 
 	c := setupTestClient(winner, loser)
 	r := newPoolReconciler(c, true)
@@ -223,9 +223,9 @@ func TestPoolConflict_ResolvedWhenTheWinnerGivesUp(t *testing.T) {
 // TestPoolsSharingHostname checks the watch that makes the resolution
 // above happen without polling.
 func TestPoolsSharingHostname(t *testing.T) {
-	changed := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
-	sibling := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
-	unrelated := newPool("pool-c", withRoute(true, "other.example.com", "gw"))
+	changed := newPool("pool-a", withRoute(conflictHostname, "gw"))
+	sibling := newPool("pool-b", withRoute(conflictHostname, "gw"))
+	unrelated := newPool("pool-c", withRoute("other.example.com", "gw"))
 	noRoute := newPool("pool-d")
 
 	c := setupTestClient(changed, sibling, unrelated, noRoute)
@@ -242,8 +242,8 @@ func TestPoolsSharingHostname(t *testing.T) {
 // flight comes back with a nil Spec.Route. Reporting the conflict must not
 // reach into it.
 func TestPoolConflict_SurvivesRouteRemovedMidReconcile(t *testing.T) {
-	winner := newPool("pool-a", withRoute(true, conflictHostname, "gw"))
-	loser := newPool("pool-b", withRoute(true, conflictHostname, "gw"))
+	winner := newPool("pool-a", withRoute(conflictHostname, "gw"))
+	loser := newPool("pool-b", withRoute(conflictHostname, "gw"))
 
 	gets := 0
 	c := fake.NewClientBuilder().

--- a/internal/controller/reportprocessor_controller.go
+++ b/internal/controller/reportprocessor_controller.go
@@ -3,10 +3,11 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +45,7 @@ func (r *ReportProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	rp := &openvoxv1alpha1.ReportProcessor{}
 	if err := r.Get(ctx, req.NamespacedName, rp); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("getting ReportProcessor %s: %w", req.NamespacedName, err)
@@ -100,7 +101,7 @@ func (r *ReportProcessorReconciler) observe(ctx context.Context, rp *openvoxv1al
 
 	cfg := &openvoxv1alpha1.Config{}
 	if err := r.Get(ctx, types.NamespacedName{Name: rp.Spec.ConfigRef, Namespace: rp.Namespace}, cfg); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return openvoxv1alpha1.ReportProcessorPhaseError, "ConfigNotFound",
 				fmt.Sprintf("Config %s does not exist", rp.Spec.ConfigRef)
 		}
@@ -110,7 +111,7 @@ func (r *ReportProcessorReconciler) observe(ctx context.Context, rp *openvoxv1al
 	secretName := fmt.Sprintf("%s-report-webhook", cfg.Name)
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: rp.Namespace}, secret); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return openvoxv1alpha1.ReportProcessorPhaseError, "NotRendered",
 				fmt.Sprintf("Secret %s has not been rendered yet", secretName)
 		}
@@ -122,11 +123,9 @@ func (r *ReportProcessorReconciler) observe(ctx context.Context, rp *openvoxv1al
 		return openvoxv1alpha1.ReportProcessorPhaseError, "RenderedConfigUnreadable",
 			fmt.Sprintf("Secret %s does not contain a readable report-webhook.yaml: %v", secretName, err)
 	}
-	for _, name := range rendered {
-		if name == rp.Name {
-			return openvoxv1alpha1.ReportProcessorPhaseActive, "Rendered",
-				fmt.Sprintf("Endpoint is present in Secret %s", secretName)
-		}
+	if slices.Contains(rendered, rp.Name) {
+		return openvoxv1alpha1.ReportProcessorPhaseActive, "Rendered",
+			fmt.Sprintf("Endpoint is present in Secret %s", secretName)
 	}
 
 	return openvoxv1alpha1.ReportProcessorPhaseError, "NotRendered",

--- a/internal/controller/reportprocessor_controller_status_test.go
+++ b/internal/controller/reportprocessor_controller_status_test.go
@@ -23,7 +23,7 @@ func webhookSecret(cfgName string, endpointNames ...string) *corev1.Secret {
 }
 
 func TestReportProcessorReconcile_Status(t *testing.T) {
-	rp := newReportProcessor("test-rp", "production", "https://puppetdb.example.invalid")
+	rp := newReportProcessor("test-rp", "https://puppetdb.example.invalid")
 	cfg := newConfig("production")
 	key := types.NamespacedName{Name: "test-rp", Namespace: testNamespace}
 

--- a/internal/controller/reportprocessor_controller_test.go
+++ b/internal/controller/reportprocessor_controller_test.go
@@ -18,7 +18,7 @@ func TestReportProcessorReconcile_NotFound(t *testing.T) {
 }
 
 func TestReportProcessorReconcile_BasicReconcile(t *testing.T) {
-	rp := newReportProcessor("test-rp", "production", "https://reports.example.com")
+	rp := newReportProcessor("test-rp", "https://reports.example.com")
 	c := setupTestClient(rp)
 	r := newReportProcessorReconciler(c)
 

--- a/internal/controller/securitycontext.go
+++ b/internal/controller/securitycontext.go
@@ -15,13 +15,15 @@ import (
 // root. Callers pass their workload-specific uid/gid/fsGroup constants; users can
 // override individual fields via the CRD (e.g. on OpenShift or PSA-restricted
 // namespaces that assign their own UID/GID ranges).
+//
+//nolint:unparam // every workload currently runs as uid 1001; the uid stays a parameter alongside group and fsGroup so per-workload constants remain possible
 func buildPodSecurityContext(defaultUser, defaultGroup, defaultFSGroup int64, override *openvoxv1alpha1.PodSecurityContextSpec) *corev1.PodSecurityContext {
 	psc := &corev1.PodSecurityContext{
-		RunAsUser:           int64Ptr(defaultUser),
-		RunAsGroup:          int64Ptr(defaultGroup),
-		RunAsNonRoot:        boolPtr(true),
-		FSGroup:             int64Ptr(defaultFSGroup),
-		FSGroupChangePolicy: fsGroupChangePolicyPtr(corev1.FSGroupChangeOnRootMismatch),
+		RunAsUser:           new(defaultUser),
+		RunAsGroup:          new(defaultGroup),
+		RunAsNonRoot:        new(true),
+		FSGroup:             new(defaultFSGroup),
+		FSGroupChangePolicy: new(corev1.FSGroupChangeOnRootMismatch),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -534,6 +535,11 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func intstrInt(val int) intstr.IntOrString {
+	if val > math.MaxInt32 {
+		val = math.MaxInt32
+	} else if val < math.MinInt32 {
+		val = math.MinInt32
+	}
 	return intstr.FromInt32(int32(val))
 }
 

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,7 +67,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	server := &openvoxv1alpha1.Server{}
 	if err := r.Get(ctx, req.NamespacedName, server); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// The Server carries no finalizer, so this is the only point at
 			// which its gauges can be retired.
 			forgetServerMetrics(req.Name, req.Namespace)
@@ -97,7 +97,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Resolve Config
 	cfg := &openvoxv1alpha1.Config{}
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.ConfigRef, Namespace: server.Namespace}, cfg); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("waiting for Config", "configRef", server.Spec.ConfigRef)
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
@@ -107,7 +107,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Resolve Certificate -- wait until phase is Signed
 	cert := &openvoxv1alpha1.Certificate{}
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Spec.CertificateRef, Namespace: server.Namespace}, cert); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("waiting for Certificate", "certificateRef", server.Spec.CertificateRef)
 			r.reportSSLBootstrapped(ctx, server, metav1.ConditionFalse, "CertificateNotFound",
 				fmt.Sprintf("Certificate %s does not exist", server.Spec.CertificateRef))
@@ -136,7 +136,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Resolve CertificateAuthority (needed for CA PVC name when ca: true)
 	ca := &openvoxv1alpha1.CertificateAuthority{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cert.Spec.AuthorityRef, Namespace: server.Namespace}, ca); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("waiting for CertificateAuthority", "authorityRef", cert.Spec.AuthorityRef)
 			return ctrl.Result{RequeueAfter: RequeueIntervalShort}, nil
 		}
@@ -252,11 +252,11 @@ func (r *ServerReconciler) reconcilePDB(ctx context.Context, server *openvoxv1al
 				return guardErr
 			}
 			logger.Info("deleting PDB (disabled)", "name", pdbName)
-			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("deleting PodDisruptionBudget %s: %w", pdbName, err)
 			}
 			r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonPDBDeleted, "Reconcile", "PodDisruptionBudget %s deleted", pdbName)
-		} else if !errors.IsNotFound(err) {
+		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("getting PodDisruptionBudget %s: %w", pdbName, err)
 		}
 		return nil
@@ -309,11 +309,12 @@ func (r *ServerReconciler) buildPDB(server *openvoxv1alpha1.Server) (*policyv1.P
 			},
 		},
 	}
-	if server.Spec.PDB.MinAvailable != nil {
+	switch {
+	case server.Spec.PDB.MinAvailable != nil:
 		pdb.Spec.MinAvailable = server.Spec.PDB.MinAvailable
-	} else if server.Spec.PDB.MaxUnavailable != nil {
+	case server.Spec.PDB.MaxUnavailable != nil:
 		pdb.Spec.MaxUnavailable = server.Spec.PDB.MaxUnavailable
-	} else {
+	default:
 		// Default: minAvailable: 1
 		minAvailable := intstrInt(DefaultPDBMinAvailable)
 		pdb.Spec.MinAvailable = &minAvailable
@@ -337,11 +338,11 @@ func (r *ServerReconciler) reconcileHPA(ctx context.Context, server *openvoxv1al
 				return guardErr
 			}
 			logger.Info("deleting HPA (disabled)", "name", hpaName)
-			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("deleting HorizontalPodAutoscaler %s: %w", hpaName, err)
 			}
 			r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonHPADeleted, "Reconcile", "HorizontalPodAutoscaler %s deleted", hpaName)
-		} else if !errors.IsNotFound(err) {
+		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("getting HorizontalPodAutoscaler %s: %w", hpaName, err)
 		}
 		return nil
@@ -437,11 +438,11 @@ func (r *ServerReconciler) reconcileNetworkPolicy(ctx context.Context, server *o
 				return guardErr
 			}
 			logger.Info("deleting NetworkPolicy (disabled)", "name", npName)
-			if err := r.Delete(ctx, existing); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("deleting NetworkPolicy %s: %w", npName, err)
 			}
 			r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, EventReasonNetworkPolicyDeleted, "Reconcile", "NetworkPolicy %s deleted", npName)
-		} else if !errors.IsNotFound(err) {
+		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("getting NetworkPolicy %s: %w", npName, err)
 		}
 		return nil
@@ -552,7 +553,7 @@ func intstrInt(val int) intstr.IntOrString {
 func (r *ServerReconciler) getReadyReplicas(ctx context.Context, server *openvoxv1alpha1.Server) (int32, error) {
 	deploy := &appsv1.Deployment{}
 	if err := r.Get(ctx, types.NamespacedName{Name: server.Name, Namespace: server.Namespace}, deploy); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("getting Deployment %s: %w", server.Name, err)

--- a/internal/controller/server_deployment.go
+++ b/internal/controller/server_deployment.go
@@ -7,7 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -120,7 +120,7 @@ func (r *ServerReconciler) reconcileDeployment(ctx context.Context, server *open
 	// policy changes, so a SigningPolicy edit applies without a manual restart.
 	deploy := &appsv1.Deployment{}
 	err = r.Get(ctx, types.NamespacedName{Name: deployName, Namespace: server.Namespace}, deploy)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		logger.Info("creating Server Deployment", "name", deployName, "role", role, "replicas", replicas)
 
 		deploy = &appsv1.Deployment{
@@ -433,7 +433,7 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName: reportSecretName,
-						Optional:   boolPtr(true),
+						Optional:   new(true),
 					},
 				},
 			},
@@ -445,9 +445,8 @@ func (r *ServerReconciler) buildPodSpec(server *openvoxv1alpha1.Server, cfg *ope
 	volumes = append(volumes, server.Spec.ExtraVolumes...)
 	volumeMounts = append(volumeMounts, server.Spec.ExtraVolumeMounts...)
 
-	env := []corev1.EnvVar{
-		{Name: "JAVA_ARGS", Value: javaArgs},
-	}
+	env := make([]corev1.EnvVar, 0, 1+len(server.Spec.ExtraEnv))
+	env = append(env, corev1.EnvVar{Name: "JAVA_ARGS", Value: javaArgs})
 	env = append(env, server.Spec.ExtraEnv...)
 
 	container := corev1.Container{
@@ -515,8 +514,8 @@ chmod 640 /ssl/private_keys/puppet.pem`
 	}
 
 	containerSecurityContext := &corev1.SecurityContext{
-		AllowPrivilegeEscalation: boolPtr(false),
-		ReadOnlyRootFilesystem:   boolPtr(resolveReadOnlyRootFilesystem(server, cfg)),
+		AllowPrivilegeEscalation: new(false),
+		ReadOnlyRootFilesystem:   new(resolveReadOnlyRootFilesystem(server, cfg)),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},

--- a/internal/controller/server_deployment_test.go
+++ b/internal/controller/server_deployment_test.go
@@ -220,7 +220,7 @@ func TestBuildPodSpec_AutosignCommandSkipsPolicyMount(t *testing.T) {
 
 func TestBuildPodSpec_ExternalNodesCommandSkipsENCMount(t *testing.T) {
 	cfg := newConfig("production",
-		withNodeClassifierRef("my-enc"),
+		withNodeClassifierRef(),
 		withExternalNodesCommand("/usr/local/bin/custom-enc"),
 	)
 	server := newServer("test-server", withServerRole(true))
@@ -465,7 +465,7 @@ func TestBuildPodSpec_SecurityContextOverride(t *testing.T) {
 }
 
 func TestBuildPodSpec_ENCVolumes(t *testing.T) {
-	cfg := newConfig("production", withNodeClassifierRef("my-enc"))
+	cfg := newConfig("production", withNodeClassifierRef())
 	server := newServer("test-server", withServerRole(true))
 
 	podSpec := testBuildPodSpec(server, cfg)

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -86,7 +86,7 @@ func newConfig(name string, opts ...configOption) *openvoxv1alpha1.Config {
 			Namespace: testNamespace,
 		},
 		Spec: openvoxv1alpha1.ConfigSpec{
-			ReadOnlyRootFilesystem: boolPtr(true),
+			ReadOnlyRootFilesystem: new(true),
 			Image: openvoxv1alpha1.ImageSpec{
 				Repository: "ghcr.io/slauger/openvox-server-8",
 				Tag:        "latest",
@@ -96,7 +96,7 @@ func newConfig(name string, opts ...configOption) *openvoxv1alpha1.Config {
 				EnvironmentTimeout: "unlimited",
 				EnvironmentPath:    "/etc/puppetlabs/code/environments",
 				HieraConfig:        "$confdir/hiera.yaml",
-				Storeconfigs:       boolPtr(true),
+				Storeconfigs:       new(true),
 				StoreBackend:       "puppetdb",
 				Reports:            "puppetdb",
 			},
@@ -114,15 +114,15 @@ func withAuthorityRef(ref string) configOption {
 	}
 }
 
-func withNodeClassifierRef(ref string) configOption {
+func withNodeClassifierRef() configOption {
 	return func(c *openvoxv1alpha1.Config) {
-		c.Spec.NodeClassifierRef = ref
+		c.Spec.NodeClassifierRef = "my-enc"
 	}
 }
 
 func withReadOnlyRootFS(v bool) configOption {
 	return func(c *openvoxv1alpha1.Config) {
-		c.Spec.ReadOnlyRootFilesystem = boolPtr(v)
+		c.Spec.ReadOnlyRootFilesystem = new(v)
 	}
 }
 
@@ -201,7 +201,7 @@ func newServer(name string, opts ...serverOption) *openvoxv1alpha1.Server {
 		Spec: openvoxv1alpha1.ServerSpec{
 			ConfigRef:      "production",
 			CertificateRef: "production-cert",
-			Server:         boolPtr(true),
+			Server:         new(true),
 			CA:             false,
 			Replicas:       &replicas,
 		},
@@ -216,14 +216,14 @@ func withCA(ca bool) serverOption {
 	return func(s *openvoxv1alpha1.Server) {
 		s.Spec.CA = ca
 		if ca && !serverRoleEnabled(s) {
-			s.Spec.Server = boolPtr(false)
+			s.Spec.Server = new(false)
 		}
 	}
 }
 
 func withServerRole(server bool) serverOption {
 	return func(s *openvoxv1alpha1.Server) {
-		s.Spec.Server = boolPtr(server)
+		s.Spec.Server = new(server)
 	}
 }
 
@@ -320,10 +320,10 @@ func withServiceAnnotations(a map[string]string) poolOption {
 	}
 }
 
-func withRoute(enabled bool, hostname, gwName string) poolOption {
+func withRoute(hostname, gwName string) poolOption {
 	return func(p *openvoxv1alpha1.Pool) {
 		p.Spec.Route = &openvoxv1alpha1.PoolRouteSpec{
-			Enabled:  enabled,
+			Enabled:  true,
 			Hostname: hostname,
 			GatewayRef: openvoxv1alpha1.GatewayReference{
 				Name: gwName,
@@ -395,10 +395,10 @@ func newCertificateAuthority(name string, opts ...caOption) *openvoxv1alpha1.Cer
 		},
 		Spec: openvoxv1alpha1.CertificateAuthoritySpec{
 			TTL:                          "5y",
-			AllowSubjectAltNames:         boolPtr(true),
-			AllowAuthorizationExtensions: boolPtr(true),
-			EnableInfraCRL:               boolPtr(true),
-			AllowAutoRenewal:             boolPtr(true),
+			AllowSubjectAltNames:         new(true),
+			AllowAuthorizationExtensions: new(true),
+			EnableInfraCRL:               new(true),
+			AllowAutoRenewal:             new(true),
 			AutoRenewalCertTTL:           "90d",
 		},
 	}
@@ -449,14 +449,14 @@ func newNodeClassifier(name, url string) *openvoxv1alpha1.NodeClassifier {
 	}
 }
 
-func newReportProcessor(name, configRef, url string) *openvoxv1alpha1.ReportProcessor {
+func newReportProcessor(name, url string) *openvoxv1alpha1.ReportProcessor {
 	return &openvoxv1alpha1.ReportProcessor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
 		},
 		Spec: openvoxv1alpha1.ReportProcessorSpec{
-			ConfigRef:      configRef,
+			ConfigRef:      "production",
 			URL:            url,
 			TimeoutSeconds: 30,
 		},
@@ -495,7 +495,7 @@ func newEndpointSlice(name, serviceName string, readyCount int) *discoveryv1.End
 		AddressType: discoveryv1.AddressTypeIPv4,
 	}
 	ready := true
-	for i := 0; i < readyCount; i++ {
+	for range readyCount {
 		eps.Endpoints = append(eps.Endpoints, discoveryv1.Endpoint{
 			Conditions: discoveryv1.EndpointConditions{
 				Ready: &ready,

--- a/internal/webhook/certificateauthority_delete_test.go
+++ b/internal/webhook/certificateauthority_delete_test.go
@@ -7,7 +7,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -64,7 +63,7 @@ func TestValidateStorageTransition(t *testing.T) {
 			Spec:       openvoxv1alpha1.CertificateAuthoritySpec{Storage: &openvoxv1alpha1.StorageSpec{StorageClass: class}},
 		}
 		if size != "" {
-			ca.Spec.Storage.Size = ptr.To(resource.MustParse(size))
+			ca.Spec.Storage.Size = new(resource.MustParse(size))
 		}
 		return ca
 	}

--- a/internal/webhook/certificateauthority_webhook_test.go
+++ b/internal/webhook/certificateauthority_webhook_test.go
@@ -6,7 +6,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	openvoxv1alpha1 "github.com/slauger/openvox-operator/api/v1alpha1"
 )
@@ -39,7 +38,7 @@ func TestCertificateAuthorityValidator(t *testing.T) {
 				TTL:                "5y",
 				AutoRenewalCertTTL: "90d",
 				CRLRefreshInterval: "5m",
-				Storage:            &openvoxv1alpha1.StorageSpec{Size: ptr.To(resource.MustParse("1Gi"))},
+				Storage:            &openvoxv1alpha1.StorageSpec{Size: new(resource.MustParse("1Gi"))},
 			},
 		}
 		_, err := v.ValidateCreate(context.Background(), ca)

--- a/internal/webhook/helpers.go
+++ b/internal/webhook/helpers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +35,7 @@ func validateCodeList(code []openvoxv1alpha1.CodeSpec, path *field.Path) field.E
 func refExists[T client.Object](ctx context.Context, c client.Reader, ns, name string, obj T) error {
 	key := types.NamespacedName{Namespace: ns, Name: name}
 	if err := c.Get(ctx, key, obj); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("referenced %T %q not found", obj, name)
 		}
 		return fmt.Errorf("looking up %T %q: %w", obj, name, err)


### PR DESCRIPTION
## Summary

- Add a `.golangci.yml` (v2 format, matching the pinned golangci-lint v2.13.2 in CI); previously CI ran with the bare `standard` preset and no formatter enforcement
- Enable the linter set common to cluster-api, cert-manager, CloudNativePG, external-secrets and the kubebuilder scaffolding: `bodyclose`, `copyloopvar`, `dogsled`, `durationcheck`, `errorlint`, `gocritic`, `gosec`, `importas`, `intrange`, `loggercheck`, `misspell`, `modernize`, `nakedret`, `nilerr`, `nolintlint`, `prealloc`, `revive`, `unconvert`, `unparam` plus `asciicheck`/`bidichk`
- Enforce `gofmt` and `goimports` formatting in CI
- `importas` (with `no-unaliased`) pins the usual k8s import aliases; this unifies the previous split between plain and `apierrors` imports of `k8s.io/apimachinery/pkg/api/errors` (the plain form shadowed the stdlib `errors` name)
- Disable the default issue caps (`max-same-issues: 3`, `max-issues-per-linter: 50`) so lint runs report exhaustively
- Fix all findings across the codebase: filepath.Clean on variable file reads, tighter ENC cache permissions, `errors.As` instead of a type assertion, ReadHeaderTimeout for the mock server, int32 clamping, if-else chains to switches, closed response bodies, preallocated slices, removed single-value test-helper parameters and the now-obsolete local ptr helpers (`new(expr)`)

## Test plan

- `golangci-lint run ./...` reports 0 issues locally with the pinned v2.13.2
- `go build ./...`, `go vet ./...` and the full test suite (incl. envtest) pass locally
- CI `go / lint` job picks up the new config